### PR TITLE
Score: deficit-first prompts to fix score inflation

### DIFF
--- a/scripts/prompts/scoring/calibration-system.md
+++ b/scripts/prompts/scoring/calibration-system.md
@@ -1,0 +1,14 @@
+You are a demanding but fair manuscript editor. Your job is to find what isn't working, not to validate what is. A score of 7 means "competent but with real room for improvement." A score of 9 means "I struggled to find meaningful deficits." A score of 10 means "this is the best execution of this principle I've seen in this manuscript."
+
+Scoring guidelines:
+- The median scene in a solid manuscript should score 6-7, not 8-9.
+- If you are scoring most scenes 8+, you are not looking hard enough.
+- "The prose is competent" is not a strength. Quote what specifically makes a passage work.
+- "This could be tighter" is not a deficit. Quote the specific passage and say what's wrong.
+- Every deficit and strength must reference actual text from the scene. No generalizations.
+
+Deficit classification bands:
+- Structural deficits (scene misunderstands or ignores the principle) → 1-4
+- Execution deficits (scene attempts the principle but stumbles) → 5-7
+- Surface deficits only (minor polish issues in otherwise strong execution) → 8-9
+- No genuine deficits, with notable strengths → 10

--- a/scripts/prompts/scoring/character-craft-scene.md
+++ b/scripts/prompts/scoring/character-craft-scene.md
@@ -1,4 +1,4 @@
-You are scoring a scene against scene-level Character Craft principles. Score each principle 1-10 based on the rubric.
+You are scoring a scene against scene-level Character Craft principles using deficit-first evaluation.
 
 ## Rubric
 
@@ -19,12 +19,25 @@ You are scoring a scene against scene-level Character Craft principles. Score ea
 
 ## Instructions
 
-- Score each principle as an integer from 1 to 10 using the rubric's score bands.
-- For egri_premise: assess whether the scene's conflict arises from the character's defining traits rather than external coincidence.
-- For testing_characters: assess whether characters behave as specific individuals with distinctive responses, not as generic plot functions.
-- Anchor every score in observable textual evidence, not subjective impression.
-- Weighted principles marked as high-priority deserve extra scrutiny -- flag specific passages that support or undermine them.
-- Output ONLY the two CSV blocks below. No prose, no explanation, no commentary before, between, or after the blocks.
+For EACH principle below, complete ALL four steps IN ORDER before moving to the next principle. Do not skip steps or batch principles together.
+
+**Step 1: Find deficits.**
+Quote 2-5 specific passages (exact text from the scene) where the scene falls short of this principle. For each quote, state in one sentence what the deficit is and why it matters. If the scene has fewer than 2 genuine deficits, say so — but be honest.
+- For egri_premise: look for conflict that arises from external coincidence rather than the character's defining traits.
+- For testing_characters: look for characters behaving as generic plot functions rather than specific individuals with distinctive responses.
+
+**Step 2: Find strengths.**
+Quote 1-3 specific passages where the scene executes this principle well. For each, state in one sentence what makes it work.
+
+**Step 3: Weigh the evidence.**
+In 1-2 sentences, classify the deficits as structural (1-4), execution (5-7), or surface (8-9). No genuine deficits with notable strengths = 10.
+
+**Step 4: Score.**
+Assign a single integer 1-10 consistent with the evidence band from Step 3.
+
+Complete all four steps for: egri_premise, testing_characters.
+
+After completing the full analysis for all principles, output ONLY the two CSV blocks below. The rationale for each principle should be the Step 3 assessment (structural/execution/surface classification + justification).
 
 ## Output Format
 
@@ -34,4 +47,4 @@ id|egri_premise|testing_characters
 
 RATIONALE:
 id|egri_premise|testing_characters
-{{SCENE_ID}}|<one sentence>|<one sentence>
+{{SCENE_ID}}|<assessment>|<assessment>

--- a/scripts/prompts/scoring/prose-craft.md
+++ b/scripts/prompts/scoring/prose-craft.md
@@ -1,4 +1,4 @@
-You are scoring a scene against Prose Craft principles. Score each principle 1-10 based on the rubric.
+You are scoring a scene against Prose Craft principles using deficit-first evaluation.
 
 ## Rubric
 
@@ -19,10 +19,23 @@ You are scoring a scene against Prose Craft principles. Score each principle 1-1
 
 ## Instructions
 
-- Score each principle as an integer from 1 to 10 using the rubric's score bands.
-- Anchor every score in observable textual evidence, not subjective impression.
-- Weighted principles marked as high-priority deserve extra scrutiny -- flag specific passages that support or undermine them.
-- Output ONLY the two CSV blocks below. No prose, no explanation, no commentary before, between, or after the blocks.
+For EACH principle below, complete ALL four steps IN ORDER before moving to the next principle. Do not skip steps or batch principles together.
+
+**Step 1: Find deficits.**
+Quote 2-5 specific passages (exact text from the scene) where the scene falls short of this principle. For each quote, state in one sentence what the deficit is and why it matters. If the scene has fewer than 2 genuine deficits on this principle, say so — but be honest. Even strong scenes have places where a word could be cut or a rhythm could be sharper. "No deficits" should be rare and defensible.
+
+**Step 2: Find strengths.**
+Quote 1-3 specific passages where the scene executes this principle well. For each, state in one sentence what makes it work.
+
+**Step 3: Weigh the evidence.**
+In 1-2 sentences, classify the deficits as structural (1-4), execution (5-7), or surface (8-9). No genuine deficits with notable strengths = 10.
+
+**Step 4: Score.**
+Assign a single integer 1-10 consistent with the evidence band from Step 3.
+
+Complete all four steps for: economy_clarity, sentence_as_thought, writers_toolbox, precision_language, persuasive_structure, fictive_dream, scene_vs_summary, sound_rhythm_pov, permission_honesty.
+
+After completing the full analysis for all principles, output ONLY the two CSV blocks below. The rationale for each principle should be the Step 3 assessment (structural/execution/surface classification + justification).
 
 ## Output Format
 
@@ -32,4 +45,4 @@ id|economy_clarity|sentence_as_thought|writers_toolbox|precision_language|persua
 
 RATIONALE:
 id|economy_clarity|sentence_as_thought|writers_toolbox|precision_language|persuasive_structure|fictive_dream|scene_vs_summary|sound_rhythm_pov|permission_honesty
-{{SCENE_ID}}|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>
+{{SCENE_ID}}|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>

--- a/scripts/prompts/scoring/quick.md
+++ b/scripts/prompts/scoring/quick.md
@@ -1,4 +1,4 @@
-You are scoring a scene against ALL 25 scene-level craft principles in a single pass. Score each principle 1-10 based on the rubric. This is a fast-pass evaluation -- be decisive and anchor each score in your strongest single observation.
+You are scoring a scene against ALL 25 scene-level craft principles using deficit-first evaluation. For each principle, build the case from evidence before assigning a number.
 
 ## Rubric
 
@@ -25,12 +25,19 @@ You are scoring a scene against ALL 25 scene-level craft principles in a single 
 
 ## Instructions
 
-- Score each principle as an integer from 1 to 10 using the rubric's score bands.
-- This is a single-pass evaluation of all 25 scene-level principles. Be decisive -- one strong observation per principle.
-- For Rules to Break: 10 = followed masterfully OR broken with clear artistic purpose. 1 = violated accidentally in ways that undermine the prose.
-- Anchor every score in observable textual evidence, not subjective impression.
-- Weighted principles marked as high-priority deserve extra scrutiny.
-- Output ONLY the two CSV blocks below. No prose, no explanation, no commentary before, between, or after the blocks.
+For EACH of the 25 principles, complete this process before moving to the next:
+
+1. **Deficits**: Quote 1-2 specific passages where the scene falls short. State what's wrong. If no genuine deficit exists, say so.
+2. **Assessment**: One word — structural (1-4), execution (5-7), or surface (8-9). No deficits = 10.
+3. **Score**: Integer 1-10 consistent with the assessment band.
+
+This is a fast-pass evaluation — limit yourself to the strongest single deficit and assessment per principle. But the score MUST match the band.
+
+For Rules to Break: 10 = followed masterfully OR broken with clear artistic purpose. 1 = violated accidentally in ways that undermine the prose.
+
+Weighted principles marked as high-priority deserve extra scrutiny.
+
+After completing the analysis for all 25 principles, output ONLY the two CSV blocks below. The rationale column should contain the assessment classification and key deficit.
 
 ## Output Format
 
@@ -40,4 +47,4 @@ id|enter_late_leave_early|every_scene_must_turn|scene_emotion_vs_character|psych
 
 RATIONALE:
 id|enter_late_leave_early|every_scene_must_turn|scene_emotion_vs_character|psychic_distance_scene|show_vs_tell_scenes|thread_management|pacing_variety|economy_clarity|sentence_as_thought|writers_toolbox|precision_language|persuasive_structure|fictive_dream|scene_vs_summary|sound_rhythm_pov|permission_honesty|egri_premise|testing_characters|show_dont_tell|avoid_adverbs|avoid_passive|write_what_you_know|no_weather_dreams|avoid_said_bookisms|kill_darlings
-{{SCENE_ID}}|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>
+{{SCENE_ID}}|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>

--- a/scripts/prompts/scoring/rules.md
+++ b/scripts/prompts/scoring/rules.md
@@ -1,4 +1,4 @@
-You are scoring a scene against the Rules to Break. These are conventional writing rules that skilled authors may follow or break intentionally.
+You are scoring a scene against the Rules to Break using deficit-first evaluation. These are conventional writing rules that skilled authors may follow or break intentionally.
 
 **Scoring logic:** A score of 10 means the rule was either followed masterfully OR broken with clear artistic purpose that strengthens the prose. A score of 1 means the rule was violated in ways that undermine the prose -- the breaking is accidental, habitual, or harmful. The question is not "was the rule followed?" but "is the result effective?"
 
@@ -21,12 +21,23 @@ You are scoring a scene against the Rules to Break. These are conventional writi
 
 ## Instructions
 
-- Score each rule as an integer from 1 to 10 using the rubric's score bands.
-- High scores mean the rule is followed skillfully OR broken intentionally with demonstrable artistic effect.
-- Low scores mean the rule is violated accidentally or habitually in ways that weaken the prose.
-- Anchor every score in observable textual evidence, not subjective impression.
-- Weighted principles marked as high-priority deserve extra scrutiny -- flag specific passages that support or undermine them.
-- Output ONLY the two CSV blocks below. No prose, no explanation, no commentary before, between, or after the blocks.
+For EACH rule below, complete ALL four steps IN ORDER before moving to the next rule. Do not skip steps or batch rules together.
+
+**Step 1: Find deficits.**
+Quote 2-5 specific passages where the rule is violated accidentally or habitually in ways that weaken the prose. For each quote, state in one sentence what's wrong and why it matters. If the scene has fewer than 2 genuine deficits, say so — but be honest. Intentional, effective rule-breaking is NOT a deficit.
+
+**Step 2: Find strengths.**
+Quote 1-3 specific passages where the rule is followed skillfully OR broken intentionally with demonstrable artistic effect. For each, state what makes it work.
+
+**Step 3: Weigh the evidence.**
+In 1-2 sentences, classify the deficits as structural (1-4), execution (5-7), or surface (8-9). No genuine deficits with notable strengths = 10.
+
+**Step 4: Score.**
+Assign a single integer 1-10 consistent with the evidence band from Step 3.
+
+Complete all four steps for: show_dont_tell, avoid_adverbs, avoid_passive, write_what_you_know, no_weather_dreams, avoid_said_bookisms, kill_darlings.
+
+After completing the full analysis for all rules, output ONLY the two CSV blocks below. The rationale for each rule should be the Step 3 assessment (structural/execution/surface classification + justification).
 
 ## Output Format
 
@@ -36,4 +47,4 @@ id|show_dont_tell|avoid_adverbs|avoid_passive|write_what_you_know|no_weather_dre
 
 RATIONALE:
 id|show_dont_tell|avoid_adverbs|avoid_passive|write_what_you_know|no_weather_dreams|avoid_said_bookisms|kill_darlings
-{{SCENE_ID}}|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>
+{{SCENE_ID}}|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>

--- a/scripts/prompts/scoring/scene-craft.md
+++ b/scripts/prompts/scoring/scene-craft.md
@@ -1,4 +1,4 @@
-You are scoring a scene against Scene Craft principles. Score each principle 1-10 based on the rubric.
+You are scoring a scene against Scene Craft principles using deficit-first evaluation.
 
 ## Rubric
 
@@ -19,10 +19,23 @@ You are scoring a scene against Scene Craft principles. Score each principle 1-1
 
 ## Instructions
 
-- Score each principle as an integer from 1 to 10 using the rubric's score bands.
-- Anchor every score in observable textual evidence, not subjective impression.
-- Weighted principles marked as high-priority deserve extra scrutiny -- flag specific passages that support or undermine them.
-- Output ONLY the two CSV blocks below. No prose, no explanation, no commentary before, between, or after the blocks.
+For EACH principle below, complete ALL four steps IN ORDER before moving to the next principle. Do not skip steps or batch principles together.
+
+**Step 1: Find deficits.**
+Quote 2-5 specific passages (exact text from the scene) where the scene falls short of this principle. For each quote, state in one sentence what the deficit is and why it matters. If the scene has fewer than 2 genuine deficits on this principle, say so — but be honest. Even strong scenes have places where a beat could land harder or a moment could be more precise. "No deficits" should be rare and defensible.
+
+**Step 2: Find strengths.**
+Quote 1-3 specific passages where the scene executes this principle well. For each, state in one sentence what makes it work.
+
+**Step 3: Weigh the evidence.**
+In 1-2 sentences, classify the deficits as structural (1-4), execution (5-7), or surface (8-9). No genuine deficits with notable strengths = 10.
+
+**Step 4: Score.**
+Assign a single integer 1-10 consistent with the evidence band from Step 3.
+
+Complete all four steps for: enter_late_leave_early, every_scene_must_turn, scene_emotion_vs_character, psychic_distance_scene, show_vs_tell_scenes, thread_management, pacing_variety.
+
+After completing the full analysis for all principles, output ONLY the two CSV blocks below. The rationale for each principle should be the Step 3 assessment (structural/execution/surface classification + justification).
 
 ## Output Format
 
@@ -32,4 +45,4 @@ id|enter_late_leave_early|every_scene_must_turn|scene_emotion_vs_character|psych
 
 RATIONALE:
 id|enter_late_leave_early|every_scene_must_turn|scene_emotion_vs_character|psychic_distance_scene|show_vs_tell_scenes|thread_management|pacing_variety
-{{SCENE_ID}}|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>|<one sentence>
+{{SCENE_ID}}|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>|<assessment>

--- a/scripts/storyforge-score
+++ b/scripts/storyforge-score
@@ -159,6 +159,13 @@ PROMPTS_DIR="${SCRIPT_DIR}/prompts/scoring"
 MODEL=$(select_model "evaluation")
 log "Scoring model: ${MODEL}"
 
+# --- Load calibration system prompt ---
+CALIBRATION_PROMPT=""
+if [[ -f "${PROMPTS_DIR}/calibration-system.md" ]]; then
+    CALIBRATION_PROMPT=$(cat "${PROMPTS_DIR}/calibration-system.md")
+    log "Loaded deficit-first calibration prompt"
+fi
+
 # --- Initialize craft weights ---
 init_craft_weights "$PROJECT_DIR" "$PLUGIN_DIR"
 WEIGHTS_FILE="${PROJECT_DIR}/working/craft-weights.csv"
@@ -436,11 +443,13 @@ invoke_and_parse() {
 
     begin_healing_zone "scoring invocation"
 
-    claude -p "$prompt" \
-        --model "$MODEL" \
-        --dangerously-skip-permissions \
-        --output-format stream-json \
-        --verbose \
+    # Build Claude command with optional system prompt
+    local claude_args=(-p "$prompt" --model "$MODEL" --dangerously-skip-permissions --output-format stream-json --verbose)
+    if [[ -n "${CALIBRATION_PROMPT:-}" ]]; then
+        claude_args+=(--append-system-prompt "$CALIBRATION_PROMPT")
+    fi
+
+    claude "${claude_args[@]}" \
         > "$log_file" 2>&1 || true
 
     end_healing_zone
@@ -740,7 +749,7 @@ deep)
                         done)
                     fi
 
-                    prompt="You are scoring a single craft principle for a scene. Score it 1-10.
+                    prompt="You are scoring a single craft principle for a scene using deficit-first evaluation.
 
 ## Rubric
 
@@ -757,8 +766,21 @@ ${scene_text}
 
 ## Instructions
 
-Score the principle '${principle}' as an integer from 1 to 10. Anchor in textual evidence.
-Output ONLY the two CSV blocks below.
+Score the principle '${principle}' using this process:
+
+**Step 1: Find deficits.**
+Quote 2-5 specific passages (exact text from the scene) where the scene falls short of this principle. For each quote, state in one sentence what the deficit is and why it matters. If the scene has fewer than 2 genuine deficits, say so — but be honest.
+
+**Step 2: Find strengths.**
+Quote 1-3 specific passages where the scene executes this principle well. For each, state what makes it work.
+
+**Step 3: Weigh the evidence.**
+In 1-2 sentences, classify the deficits as structural (1-4), execution (5-7), or surface (8-9). No genuine deficits with notable strengths = 10.
+
+**Step 4: Score.**
+Assign a single integer 1-10 consistent with the evidence band from Step 3.
+
+After completing the analysis, output ONLY the two CSV blocks below. The rationale should be the Step 3 assessment.
 
 SCORES:
 id|${principle}
@@ -766,7 +788,7 @@ ${id}|<score>
 
 RATIONALE:
 id|${principle}
-${id}|<one sentence>"
+${id}|<assessment>"
 
                     log_file="${LOG_DIR}/score-${id}-${principle}.log"
                     tmp_scores="${CYCLE_DIR}/.tmp-scores-${id}-${principle}.csv"


### PR DESCRIPTION
## Summary

Closes #14

- Replaces "score 1-10" prompts with a 4-step deficit-first process: find deficits (with quoted passages) → find strengths → weigh evidence (structural/execution/surface classification) → score within the band
- New calibration system prompt anchors expectations: median 6-7, demands quoted evidence, defines scoring bands
- All 5 prompt templates rewritten (quick, scene-craft, prose-craft, character-craft-scene, rules) plus deep mode inline prompt
- `invoke_and_parse()` now passes calibration prompt via `--append-system-prompt`
- CSV output format unchanged — rationale column now contains deficit classification + justification

### Test results (Night Watch, "Six Men" scene)

| Metric | Old | New |
|--------|-----|-----|
| Mean | 8.0 | 7.7 |
| Range | 7-9 | 6-9 |
| Biggest drops | — | persuasive_structure 8→6, show_dont_tell 9→7, kill_darlings 9→7 |
| Biggest gains | — | permission_honesty 7→9, no_weather_dreams 7→9 |

Old rationale: empty. New rationale quotes specific passages with actionable assessments.

## Test plan

- [x] All 648 existing tests pass (18 suites, 0 failures)
- [x] Dry run verifies calibration prompt loads
- [x] Live test on Night Watch scene shows lower mean, wider spread, evidence-based rationale
- [ ] Run full scoring cycle on a project and compare distribution to previous cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)