### PR TITLE
Improve timeline: structured temporal analysis + interrupt handling

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -93,7 +93,7 @@ _sf_handle_interrupt() {
             log "Committing partial work before exit..."
             (
                 cd "$PROJECT_DIR"
-                git add working/evaluations/ working/logs/ working/scores/ working/costs/ scenes/ 2>/dev/null || true
+                git add working/evaluations/ working/logs/ working/scores/ working/costs/ working/timeline/ scenes/ reference/ 2>/dev/null || true
                 git commit -m "Interrupted: partial work saved" 2>/dev/null || true
                 git push 2>/dev/null || true
             )

--- a/scripts/storyforge-timeline
+++ b/scripts/storyforge-timeline
@@ -480,12 +480,18 @@ ${id}|<day>"
 
     begin_healing_zone "timeline phase 2 assignment"
 
+    # Run claude in background so we can track its PID for interrupt handling
     claude -p "$timeline_prompt" \
         --model "$SONNET_MODEL" \
         --dangerously-skip-permissions \
         --output-format stream-json \
         --verbose \
-        > "$tl_log" 2>&1 || true
+        > "$tl_log" 2>&1 &
+    local claude_pid=$!
+    register_child_pid $claude_pid
+
+    wait "$claude_pid" 2>/dev/null || true
+    unregister_child_pid "$claude_pid" 2>/dev/null || true
 
     end_healing_zone
 


### PR DESCRIPTION
## Summary

- **Phase 1 rewrite**: Replace unfocused "extract all temporal indicators" with three focused questions per scene: DELTA (time gap classification), EVIDENCE (single strongest quote), ANCHOR (absolute time reference). Each call receives previous scene context.
- **Phase 2 update**: Sonnet prompt consumes structured deltas instead of raw indicator lists — builds cumulative day count with anchors as pins.
- **Interrupt fix**: Phase 2 claude process now runs in background with tracked PID so Ctrl+C can kill it. Added reference/ and working/timeline/ to interrupt handler's partial-work commit.

### Test results (Night Watch, scenes 1-10)

Phase 1 output quality:
- `waking-maren`: DELTA=days_later, EVIDENCE="Third night", ANCHOR="on a Thursday in November"
- `waking-hank`: DELTA=same_day (correct — same night, different POV)
- `missing-persons`: DELTA=next_day, ANCHOR="Friday morning"
- `pewter-town`: DELTA=next_day, ANCHOR="Saturday morning"

Friday→Saturday anchor chain validates cumulative day count.

## Test plan

- [x] Tested on Night Watch scenes 1-10 with --force
- [x] Structured output gives Sonnet actionable deltas vs raw noise
- [x] Interrupt handling verified (kill works on Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)