### PR TITLE
Fix missing scoring and enrichment PR labels

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1185,6 +1185,8 @@ ensure_all_labels() {
     ensure_label "evaluation"     "d93f0b" "Multi-agent evaluation panel"           "$project_dir"
     ensure_label "revision"       "c5def5" "Revision pass execution"               "$project_dir"
     ensure_label "assembly"       "bfdadc" "Manuscript assembly and production"     "$project_dir"
+    ensure_label "scoring"        "fbca04" "Principled craft scoring"               "$project_dir"
+    ensure_label "enrichment"     "d4c5f9" "Metadata enrichment"                    "$project_dir"
 }
 
 # Create a draft PR for the current branch.


### PR DESCRIPTION
## Summary

Closes #25

Added `scoring` and `enrichment` labels to `ensure_all_labels` in `common.sh`. These were the only two work-type labels used by `create_draft_pr` callers but not pre-created, causing silent PR creation failures.

## Test plan
- [x] `bash -n` syntax check passes
- [ ] Run `storyforge-score --dry-run` on a project — should no longer warn about failed PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)