### PR TITLE
Commit ledger in SessionEnd hook

### DIFF
--- a/hooks/session-end
+++ b/hooks/session-end
@@ -113,4 +113,11 @@ while IFS='|' read -r model input output cache_read cache_create; do
 
 done <<< "$USAGE_DATA"
 
+# --- Commit the ledger update ---
+(
+    cd "$CWD"
+    git add "working/costs/ledger.csv" 2>/dev/null || true
+    git commit -m "Score: interactive session cost (${SESSION_ID})" 2>/dev/null || true
+)
+
 exit 0


### PR DESCRIPTION
## Summary

The SessionEnd hook appends interactive session costs to the ledger but left it as an uncommitted change. Now it stages and commits the file immediately after writing.

No push — fits within the hook timeout and the commit gets pushed on the next script run.

## Test plan
- [ ] End a Claude Code session in a storyforge project, verify ledger.csv is committed (not just modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)