### PR TITLE
Add elaboration stages: script, prompts, and skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/docs/superpowers/plans/2026-04-02-elaboration-pipeline-plan-2-stages.md
+++ b/docs/superpowers/plans/2026-04-02-elaboration-pipeline-plan-2-stages.md
@@ -1,0 +1,46 @@
+# Elaboration Pipeline — Plan 2: Stages
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the elaboration pipeline stages — the scripts and skills that take a project from seed through validated briefs. Four stages (spine, architecture, scene map, briefs), each producing structured CSV data and reference materials, with validation gates between stages.
+
+**Architecture:** New bash script `scripts/storyforge-elaborate` handles autonomous execution (API mode). New skill `skills/elaborate/SKILL.md` handles interactive sessions. Python prompt builders in `scripts/lib/python/storyforge/prompts_elaborate.py` construct stage-specific prompts. Each stage creates a branch, does the work, runs validation, and opens a PR.
+
+**Tech Stack:** Python 3, bash, pipe-delimited CSV, Anthropic Messages API
+
+**Spec:** `docs/superpowers/specs/2026-04-01-elaboration-pipeline-design.md`
+
+---
+
+## File Structure
+
+### New files
+- `scripts/storyforge-elaborate` — bash CLI for autonomous elaboration
+- `scripts/lib/python/storyforge/prompts_elaborate.py` — prompt builders per stage
+- `skills/elaborate/SKILL.md` — interactive elaboration skill
+
+### Modified files
+- `scripts/lib/python/storyforge/elaborate.py` — add response parsing helpers
+- `templates/storyforge.yaml` — already updated in Plan 1
+
+---
+
+## Task 1: Prompt builders for each stage
+
+Create `scripts/lib/python/storyforge/prompts_elaborate.py` with four functions that build the Claude prompt for each stage. Each reads the current project state and produces a prompt that tells Claude exactly what to produce and in what format.
+
+**Key design:** Prompts instruct Claude to output structured CSV rows (pipe-delimited) wrapped in code fences, plus markdown for reference docs. A parser extracts both.
+
+## Task 2: Response parsing
+
+Add to `elaborate.py`: functions to parse Claude's response into CSV updates and markdown files. Claude outputs CSV rows in fenced blocks and markdown content in separate fenced blocks.
+
+## Task 3: The `storyforge-elaborate` script
+
+Bash script following the established patterns (source common.sh, detect_project_root, create_branch, create_draft_pr, invoke_anthropic_api, commit, run_review_phase). Accepts `--stage spine|architecture|map|briefs`, `--dry-run`, `--interactive`.
+
+## Task 4: The `elaborate` skill
+
+Interactive skill for Claude Code sessions. Routes based on project phase and author intent. Delegates to the script for autonomous work or handles stages interactively.
+
+## Task 5: Tests, version bump, commit

--- a/scripts/lib/python/storyforge/prompts_elaborate.py
+++ b/scripts/lib/python/storyforge/prompts_elaborate.py
@@ -1,0 +1,500 @@
+"""Prompt builders for elaboration pipeline stages.
+
+Each function reads current project state and produces a Claude prompt
+for one elaboration stage. Prompts instruct Claude to output structured
+data (pipe-delimited CSV rows in fenced code blocks) plus markdown
+content for reference documents.
+"""
+
+import os
+from .prompts import read_yaml_field
+
+
+def _read_file(path: str) -> str:
+    """Read a file's contents, or return empty string if missing."""
+    if not os.path.isfile(path):
+        return ''
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+def _read_csv_contents(path: str) -> str:
+    """Read CSV contents for inclusion in prompts."""
+    content = _read_file(path)
+    return content.strip() if content else '(empty)'
+
+
+def _project_context(project_dir: str) -> str:
+    """Build the common project context block for all stage prompts."""
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    title = read_yaml_field(yaml_path, 'project.title') or 'Untitled'
+    genre = read_yaml_field(yaml_path, 'project.genre') or ''
+    subgenre = read_yaml_field(yaml_path, 'project.subgenre') or ''
+    logline = read_yaml_field(yaml_path, 'project.logline') or ''
+    target = read_yaml_field(yaml_path, 'project.target_words') or ''
+
+    genre_str = genre
+    if subgenre:
+        genre_str = f"{genre} / {subgenre}"
+
+    return f"""## Project
+
+**Title:** {title}
+**Genre:** {genre_str}
+**Logline:** {logline}
+**Target word count:** {target}"""
+
+
+def _existing_refs(project_dir: str) -> str:
+    """Include any existing reference materials."""
+    sections = []
+    ref_dir = os.path.join(project_dir, 'reference')
+
+    for name, label in [
+        ('story-architecture.md', 'Story Architecture'),
+        ('character-bible.md', 'Character Bible'),
+        ('world-bible.md', 'World Bible'),
+        ('voice-guide.md', 'Voice Guide'),
+        ('continuity-tracker.md', 'Continuity Tracker'),
+        ('key-decisions.md', 'Key Decisions'),
+    ]:
+        content = _read_file(os.path.join(ref_dir, name))
+        if content.strip():
+            sections.append(f"### {label}\n\n{content.strip()}")
+
+    return '\n\n'.join(sections) if sections else '(no reference materials yet)'
+
+
+def _craft_principles(project_dir: str, plugin_dir: str) -> str:
+    """Load craft engine excerpt for prompts."""
+    # Try plugin references first, then project
+    for base in [plugin_dir, project_dir]:
+        path = os.path.join(base, 'references', 'craft-engine.md')
+        content = _read_file(path)
+        if content:
+            # Extract sections 2-5 (Scene Craft through Rules)
+            lines = content.split('\n')
+            capture = False
+            captured = []
+            for line in lines:
+                if line.startswith('## 2'):
+                    capture = True
+                if line.startswith('## 6') or line.startswith('## 7'):
+                    capture = False
+                if capture:
+                    captured.append(line)
+            if captured:
+                return '\n'.join(captured)
+            return content[:3000]  # fallback: first 3000 chars
+    return ''
+
+
+# ============================================================================
+# Stage 1: Spine
+# ============================================================================
+
+def build_spine_prompt(project_dir: str, plugin_dir: str, seed: str = '') -> str:
+    """Build the prompt for the spine stage.
+
+    Args:
+        project_dir: Path to the book project.
+        plugin_dir: Path to the Storyforge plugin root.
+        seed: Author-provided seed text (logline, concepts, constraints).
+              If empty, reads from storyforge.yaml logline.
+    """
+    context = _project_context(project_dir)
+    refs = _existing_refs(project_dir)
+
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    if not seed:
+        seed = read_yaml_field(yaml_path, 'project.logline') or ''
+
+    return f"""You are building the spine of a novel — the 5-10 irreducible story events that must happen.
+
+{context}
+
+## Author's Seed
+
+{seed if seed else '(Use the logline above as the seed.)'}
+
+## Existing Reference Materials
+
+{refs}
+
+## Instructions
+
+Produce the following deliverables:
+
+### 1. Story Architecture
+
+Write a complete story architecture document with:
+- **Premise**: One sentence — character + conflict + stakes
+- **Theme**: The question the story explores (phrased as a question, not a statement)
+- **External conflict**: The tangible, visible struggle
+- **Internal conflict**: The protagonist's inner battle (Lie vs. Need)
+- **Thematic conflict**: How the theme manifests in character clash
+- **Ending**: How all three conflict levels resolve
+
+Output this in a fenced block labeled `story-architecture`:
+
+```story-architecture
+(your story architecture markdown here)
+```
+
+### 2. Character Bible Seeds
+
+Write seed entries for the protagonist and antagonist force. Each character needs:
+- Name and role
+- Want (conscious, concrete goal)
+- Need (unconscious requirement, usually opposite of Want)
+- Wound (formative damage that shaped worldview)
+- Lie (false belief resulting from wound)
+- Flaw/strength duality
+
+Output in a fenced block labeled `character-bible`:
+
+```character-bible
+(your character bible markdown here)
+```
+
+### 3. Spine Scenes
+
+Identify 5-10 irreducible story events. For each, provide a row in pipe-delimited CSV format.
+
+Output in a fenced block labeled `scenes-csv`:
+
+```scenes-csv
+id|seq|title|status
+(one row per spine event — id is a descriptive slug, seq is reading order, status is always "spine")
+```
+
+And the intent for each scene:
+
+```intent-csv
+id|function
+(one row per spine event — function is WHY this scene must exist, stated as a testable claim)
+```
+
+### Rules
+
+- Every spine event must connect causally to the next (but/therefore, not and-then)
+- The protagonist's wound/lie must produce a want that drives the external conflict
+- The ending must resolve all three conflict levels
+- Scene functions must be testable — "Establish the world" is vague; "Reveal that the mine has been salted through a surveying error" is testable
+- If the author provided character concepts or world details in the seed, honor them
+"""
+
+
+# ============================================================================
+# Stage 2: Architecture
+# ============================================================================
+
+def build_architecture_prompt(project_dir: str, plugin_dir: str) -> str:
+    """Build the prompt for the architecture stage."""
+    context = _project_context(project_dir)
+    refs = _existing_refs(project_dir)
+    ref_dir = os.path.join(project_dir, 'reference')
+    scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
+    intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
+
+    return f"""You are building the architecture of a novel — expanding the spine into a full structural plan.
+
+{context}
+
+## Current Spine
+
+### scenes.csv
+```
+{scenes}
+```
+
+### scene-intent.csv
+```
+{intent}
+```
+
+## Reference Materials
+
+{refs}
+
+## Instructions
+
+Expand the spine (5-10 events) into 15-25 scenes. For each scene:
+
+1. Keep all existing spine scenes (you may adjust titles and functions)
+2. Add supporting scenes: character development, subplot introduction, transitions, world-building
+3. Assign every scene to a part/act
+4. Assign POV characters
+5. Classify each as action or sequel (Swain's scene/sequel pattern)
+6. Define the value at stake and its polarity shift (McKee)
+7. Identify the turning point type (action or revelation — vary these)
+8. Assign story threads
+
+### Output Format
+
+Update the scenes CSV with new columns filled:
+
+```scenes-csv
+id|seq|title|part|pov|status
+(all scenes — existing spine scenes updated, new scenes added, status is "architecture")
+```
+
+Update the intent CSV with new columns:
+
+```intent-csv
+id|function|scene_type|emotional_arc|value_at_stake|value_shift|turning_point|threads
+(all scenes)
+```
+
+If you need to deepen the character bible with supporting characters, output:
+
+```character-bible
+(additional character entries in the same format as existing)
+```
+
+If the world needs a bible, output:
+
+```world-bible
+(world bible markdown)
+```
+
+### Rules
+
+- No flat polarity stretches: 3+ consecutive scenes with no value shift (+/+) is a red flag
+- Vary scene types: no 4+ consecutive action or sequel scenes
+- Vary turning point types: no 4+ consecutive action or revelation turning points
+- Every thread introduced must have a planned resolution
+- Parts should hit roughly: first act ~25%, midpoint ~50%, climax ~75-85%
+- Character arcs need structural progression: lie reinforced → challenged → confronted → truth/refusal
+"""
+
+
+# ============================================================================
+# Stage 3: Scene Map
+# ============================================================================
+
+def build_map_prompt(project_dir: str, plugin_dir: str) -> str:
+    """Build the prompt for the scene map stage."""
+    context = _project_context(project_dir)
+    refs = _existing_refs(project_dir)
+    ref_dir = os.path.join(project_dir, 'reference')
+    scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
+    intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
+
+    return f"""You are mapping a novel — expanding the architecture into a complete scene-by-scene plan with locations, timeline, characters, and thread tracking.
+
+{context}
+
+## Current Architecture
+
+### scenes.csv
+```
+{scenes}
+```
+
+### scene-intent.csv
+```
+{intent}
+```
+
+## Reference Materials
+
+{refs}
+
+## Instructions
+
+Expand the architecture into the full scene count (40-60 scenes). For each scene:
+
+1. Keep all existing scenes (adjust as needed)
+2. Fill in gaps: transitions, subplot scenes, breathing room
+3. Assign locations, timeline days, time of day, duration
+4. List all characters present (on_stage) and referenced (characters)
+5. Track MICE thread opens (+) and closes (-) in FILO order
+
+### Output Format
+
+```scenes-csv
+id|seq|title|part|pov|location|timeline_day|time_of_day|duration|status
+(all scenes — status is "mapped" for new/updated scenes)
+```
+
+```intent-csv
+id|function|scene_type|emotional_arc|value_at_stake|value_shift|turning_point|threads|characters|on_stage|mice_threads
+(all scenes)
+```
+
+### Rules
+
+- Timeline must be consistent: no backward jumps without explicit justification
+- Every character referenced must exist in the character bible
+- MICE threads must nest in FILO order (first opened = last closed)
+- No thread dormant for more than 8-10 scenes without acknowledgment
+- Every scene must have at least one on-stage character
+- Location names must be consistent (same place = same name)
+- Total target_words should sum to within 10% of the manuscript target ({read_yaml_field(os.path.join(project_dir, 'storyforge.yaml'), 'project.target_words') or 'not set'})
+"""
+
+
+# ============================================================================
+# Stage 4: Briefs
+# ============================================================================
+
+def build_briefs_prompt(project_dir: str, plugin_dir: str,
+                        scene_ids: list[str] | None = None) -> str:
+    """Build the prompt for the briefs stage.
+
+    Args:
+        project_dir: Path to the book project.
+        plugin_dir: Path to the Storyforge plugin root.
+        scene_ids: If provided, only build briefs for these scenes.
+                   If None, builds for all mapped scenes without briefs.
+    """
+    context = _project_context(project_dir)
+    refs = _existing_refs(project_dir)
+    ref_dir = os.path.join(project_dir, 'reference')
+    scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
+    intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
+    briefs = _read_csv_contents(os.path.join(ref_dir, 'scene-briefs.csv'))
+    craft = _craft_principles(project_dir, plugin_dir)
+
+    scope_note = ""
+    if scene_ids:
+        scope_note = f"\n**Scope:** Only write briefs for these scenes: {', '.join(scene_ids)}\n"
+
+    return f"""You are writing the drafting contracts for a novel — the scene-level briefs that define exactly what happens in each scene, in enough detail that scenes can be drafted independently and still cohere.
+
+{context}
+{scope_note}
+
+## Current State
+
+### scenes.csv
+```
+{scenes}
+```
+
+### scene-intent.csv
+```
+{intent}
+```
+
+### scene-briefs.csv (existing)
+```
+{briefs}
+```
+
+## Reference Materials
+
+{refs}
+
+## Craft Principles
+
+{craft if craft else '(craft engine not available)'}
+
+## Instructions
+
+For each scene that needs a brief, define the complete drafting contract:
+
+- **goal**: The POV character's concrete objective entering the scene (Swain)
+- **conflict**: What specifically opposes the goal
+- **outcome**: How the scene ends — yes / no / yes-but / no-and (Weiland)
+- **crisis**: The dilemma — best bad choice or irreconcilable goods (Story Grid)
+- **decision**: What the character actively chooses
+- **knowledge_in**: Semicolon-separated facts the POV character knows entering. Use EXACT wording that matches prior scenes' knowledge_out.
+- **knowledge_out**: Semicolon-separated facts the POV character knows leaving. These become available for later scenes' knowledge_in.
+- **key_actions**: Semicolon-separated concrete things that happen
+- **key_dialogue**: Specific lines or exchanges that must appear in the prose
+- **emotions**: Semicolon-separated emotional beats in sequence
+- **motifs**: Semicolon-separated recurring images/symbols deployed
+- **continuity_deps**: Semicolon-separated scene IDs this scene depends on (for parallel drafting)
+- **has_overflow**: false (unless you indicate a scene needs extended brief)
+
+### Output Format
+
+```briefs-csv
+id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow
+(one row per scene being briefed)
+```
+
+Also update scenes.csv status to "briefed" for all briefed scenes:
+
+```scenes-csv-update
+id|status
+(one row per scene, status = briefed)
+```
+
+### Rules
+
+- knowledge_in must use EXACT wording from prior scenes' knowledge_out — validation will check this
+- continuity_deps should list the minimum set of scenes whose knowledge_out this scene needs
+- Every scene must have goal/conflict/outcome filled
+- Key dialogue should sound like the character, not the author
+- Scenes with no continuity_deps can be drafted in parallel — maximize these
+- The crisis must be a genuine dilemma (two bad choices or two good choices that conflict), not "do the obvious thing or don't"
+"""
+
+
+# ============================================================================
+# Response parsing
+# ============================================================================
+
+def parse_stage_response(response: str) -> dict[str, str]:
+    """Parse a stage response into labeled content blocks.
+
+    Claude outputs fenced blocks like:
+        ```scenes-csv
+        id|seq|...
+        ```
+        ```story-architecture
+        # Story Architecture
+        ...
+        ```
+
+    Returns a dict mapping label -> content, e.g.:
+        {'scenes-csv': 'id|seq|...', 'story-architecture': '# Story...'}
+    """
+    blocks: dict[str, str] = {}
+    lines = response.split('\n')
+    current_label = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith('```') and current_label is None:
+            # Opening fence
+            label = line[3:].strip()
+            if label:
+                current_label = label
+                current_lines = []
+        elif line.startswith('```') and current_label is not None:
+            # Closing fence
+            blocks[current_label] = '\n'.join(current_lines).strip()
+            current_label = None
+            current_lines = []
+        elif current_label is not None:
+            current_lines.append(line)
+
+    return blocks
+
+
+def csv_block_to_rows(csv_text: str) -> list[dict[str, str]]:
+    """Parse a pipe-delimited CSV block into a list of dicts.
+
+    Args:
+        csv_text: The raw CSV text (header + data rows, pipe-delimited).
+
+    Returns:
+        List of dicts keyed by header column names.
+    """
+    lines = [l.strip() for l in csv_text.strip().split('\n') if l.strip()]
+    if not lines:
+        return []
+
+    header = [h.strip() for h in lines[0].split('|')]
+    rows = []
+    for line in lines[1:]:
+        values = line.split('|')
+        row = {}
+        for i, col in enumerate(header):
+            row[col] = values[i].strip() if i < len(values) else ''
+        rows.append(row)
+    return rows

--- a/scripts/storyforge-elaborate
+++ b/scripts/storyforge-elaborate
@@ -1,0 +1,478 @@
+#!/bin/bash
+# storyforge-elaborate — Run an elaboration stage (spine/architecture/map/briefs)
+#
+# Usage:
+#   ./storyforge elaborate --stage spine              # Build the spine
+#   ./storyforge elaborate --stage architecture       # Expand to architecture
+#   ./storyforge elaborate --stage map                # Full scene map
+#   ./storyforge elaborate --stage briefs             # Write drafting briefs
+#   ./storyforge elaborate --stage spine --dry-run    # Print prompt, don't invoke
+#   ./storyforge elaborate --stage spine -i           # Interactive mode
+#
+# Each stage creates a branch, does the work, runs validation, and opens a PR.
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/lib"
+PYTHON_LIB="${SCRIPT_DIR}/lib/python"
+
+source "${LIB_DIR}/common.sh"
+detect_project_root
+
+LOG_DIR="${PROJECT_DIR}/working/logs"
+mkdir -p "$LOG_DIR"
+
+# ============================================================================
+# Arguments
+# ============================================================================
+
+STAGE=""
+DRY_RUN=false
+INTERACTIVE=false
+COACHING_LEVEL=""
+SEED=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --stage STAGE [OPTIONS]
+
+Stages:
+  spine          Build the 5-10 irreducible story events
+  architecture   Expand spine to 15-25 scenes with structure
+  map            Full scene map with locations, timeline, characters
+  briefs         Write drafting contracts for each scene
+
+Options:
+  --stage STAGE    Required. Which elaboration stage to run.
+  --seed TEXT      Seed text for spine stage (overrides logline).
+  --dry-run        Print the prompt without invoking Claude.
+  --interactive    Run interactively via claude -p.
+  --coaching LEVEL Override coaching level (full/coach/strict).
+  -h, --help       Show this help.
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --stage)     STAGE="${2:?ERROR: --stage requires a value}"; shift 2 ;;
+        --seed)      SEED="${2:?ERROR: --seed requires a value}"; shift 2 ;;
+        --dry-run)   DRY_RUN=true; shift ;;
+        --interactive|-i) INTERACTIVE=true; shift ;;
+        --coaching)  COACHING_LEVEL="${2:?ERROR: --coaching requires a value}"; shift 2 ;;
+        -h|--help)   usage ;;
+        -*)          echo "ERROR: Unknown option: $1" >&2; usage ;;
+        *)           shift ;;
+    esac
+done
+
+if [[ -z "$STAGE" ]]; then
+    echo "ERROR: --stage is required" >&2
+    usage
+fi
+
+case "$STAGE" in
+    spine|architecture|map|briefs) ;;
+    *) echo "ERROR: Unknown stage: $STAGE (expected: spine|architecture|map|briefs)" >&2; exit 1 ;;
+esac
+
+# API key required for non-interactive, non-dry-run
+if [[ "$DRY_RUN" != true && "$INTERACTIVE" != true && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    log "ERROR: ANTHROPIC_API_KEY not set. Required for autonomous mode."
+    log "  Set it with: export ANTHROPIC_API_KEY=your-key"
+    log "  Or use --interactive to run via claude -p."
+    exit 1
+fi
+
+# Coaching
+if [[ -n "$COACHING_LEVEL" ]]; then
+    STORYFORGE_COACHING="$COACHING_LEVEL"
+    export STORYFORGE_COACHING
+fi
+
+# ============================================================================
+# Project info
+# ============================================================================
+
+PROJECT_TITLE=$(read_yaml_field "project.title" 2>/dev/null || echo "Untitled")
+PLUGIN_DIR="${SCRIPT_DIR}/.."
+
+log "============================================"
+log "Storyforge Elaborate: ${STAGE}"
+log "Project: ${PROJECT_TITLE}"
+log "============================================"
+
+# ============================================================================
+# Build prompt
+# ============================================================================
+
+log "Building ${STAGE} prompt..."
+
+PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys
+from storyforge.prompts_elaborate import (
+    build_spine_prompt, build_architecture_prompt,
+    build_map_prompt, build_briefs_prompt,
+)
+stage = '${STAGE}'
+project_dir = '${PROJECT_DIR}'
+plugin_dir = '${PLUGIN_DIR}'
+seed = '''${SEED}'''
+
+if stage == 'spine':
+    print(build_spine_prompt(project_dir, plugin_dir, seed))
+elif stage == 'architecture':
+    print(build_architecture_prompt(project_dir, plugin_dir))
+elif stage == 'map':
+    print(build_map_prompt(project_dir, plugin_dir))
+elif stage == 'briefs':
+    print(build_briefs_prompt(project_dir, plugin_dir))
+")
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "===== DRY RUN: elaborate ${STAGE} ====="
+    echo "$PROMPT"
+    echo "===== END DRY RUN ====="
+    exit 0
+fi
+
+# ============================================================================
+# Branch and PR
+# ============================================================================
+
+create_branch "elaborate-${STAGE}" "$PROJECT_DIR"
+ensure_branch_pushed "$PROJECT_DIR"
+
+PR_BODY="## Elaboration: ${STAGE}
+
+**Project:** ${PROJECT_TITLE}
+**Stage:** ${STAGE}
+
+### Tasks
+- [ ] Run ${STAGE} stage
+- [ ] Validate
+- [ ] Review"
+
+create_draft_pr "Elaborate: ${PROJECT_TITLE} — ${STAGE}" "$PR_BODY" "$PROJECT_DIR" "elaboration"
+
+# ============================================================================
+# Invoke Claude
+# ============================================================================
+
+STAGE_LOG="${LOG_DIR}/elaborate-${STAGE}.log"
+STAGE_MODEL=$(select_model "drafting")  # Opus for creative work
+
+_SF_INVOCATION_START=$(date +%s)
+export _SF_INVOCATION_START
+
+if [[ "$INTERACTIVE" == true ]]; then
+    log "Invoking interactive claude for ${STAGE}..."
+
+    claude -p "$PROMPT" \
+        --model "$STAGE_MODEL" \
+        --dangerously-skip-permissions \
+        --output-format stream-json \
+        --verbose \
+        > "$STAGE_LOG" 2>&1 &
+    CLAUDE_PID=$!
+    register_child_pid $CLAUDE_PID
+
+    set +e
+    wait "$CLAUDE_PID" 2>/dev/null
+    CLAUDE_RC=$?
+    set -e
+    unregister_child_pid "$CLAUDE_PID" 2>/dev/null || true
+else
+    log "Invoking API for ${STAGE} (model: ${STAGE_MODEL})..."
+
+    begin_healing_zone "elaborate ${STAGE}"
+    invoke_anthropic_api "$PROMPT" "$STAGE_MODEL" "$STAGE_LOG" 16384
+    CLAUDE_RC=$?
+    end_healing_zone
+fi
+
+if [[ "$_SF_SHUTTING_DOWN" == true ]]; then
+    log "Interrupted during ${STAGE} — partial work may be committed"
+    exit 130
+fi
+
+if [[ $CLAUDE_RC -ne 0 ]]; then
+    log "ERROR: Claude invocation failed (exit code ${CLAUDE_RC})"
+    log "See: ${STAGE_LOG}"
+    exit 1
+fi
+
+# Log cost
+log_api_usage "$STAGE_LOG" "elaborate-${STAGE}" "${STAGE}" "$STAGE_MODEL" 2>/dev/null || true
+
+# ============================================================================
+# Parse response and apply updates
+# ============================================================================
+
+log "Parsing ${STAGE} response..."
+
+RESPONSE=$(extract_api_response "$STAGE_LOG" 2>/dev/null)
+if [[ -z "$RESPONSE" ]]; then
+    RESPONSE=$(extract_claude_response "$STAGE_LOG" 2>/dev/null)
+fi
+
+if [[ -z "$RESPONSE" ]]; then
+    log "ERROR: Could not extract response from ${STAGE_LOG}"
+    exit 1
+fi
+
+REF_DIR="${PROJECT_DIR}/reference"
+
+PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os
+from storyforge.prompts_elaborate import parse_stage_response, csv_block_to_rows
+from storyforge.elaborate import _read_csv, _write_csv, _read_csv_as_map, _FILE_MAP
+
+response = open('${STAGE_LOG}', encoding='utf-8').read()
+
+# Try API JSON format first
+try:
+    import json
+    data = json.loads(response)
+    text = ''
+    for item in data.get('content', []):
+        if item.get('type') == 'text':
+            text += item.get('text', '')
+    if text:
+        response = text
+except (json.JSONDecodeError, KeyError):
+    pass
+
+# Try stream-json format
+if not response.strip().startswith('{'):
+    # Already text, use as-is
+    pass
+else:
+    # Try extracting from stream-json
+    lines = response.strip().split('\n')
+    texts = []
+    for line in lines:
+        try:
+            obj = json.loads(line)
+            if obj.get('type') == 'content_block_delta':
+                texts.append(obj.get('delta', {}).get('text', ''))
+        except json.JSONDecodeError:
+            pass
+    if texts:
+        response = ''.join(texts)
+
+blocks = parse_stage_response(response)
+
+ref_dir = '${REF_DIR}'
+written = []
+
+# Apply CSV blocks
+for label, content in blocks.items():
+    if label == 'scenes-csv':
+        rows = csv_block_to_rows(content)
+        if rows:
+            path = os.path.join(ref_dir, 'scenes.csv')
+            existing = _read_csv_as_map(path)
+            for row in rows:
+                sid = row.get('id', '')
+                if not sid:
+                    continue
+                if sid in existing:
+                    existing[sid].update({k: v for k, v in row.items() if v})
+                else:
+                    new = {c: '' for c in _FILE_MAP['scenes.csv']}
+                    new.update(row)
+                    existing[sid] = new
+            ordered = sorted(existing.values(), key=lambda r: int(r.get('seq', 0)))
+            _write_csv(path, ordered, _FILE_MAP['scenes.csv'])
+            written.append(f'scenes.csv ({len(rows)} rows)')
+
+    elif label == 'intent-csv':
+        rows = csv_block_to_rows(content)
+        if rows:
+            path = os.path.join(ref_dir, 'scene-intent.csv')
+            existing = _read_csv_as_map(path)
+            for row in rows:
+                sid = row.get('id', '')
+                if not sid:
+                    continue
+                if sid in existing:
+                    existing[sid].update({k: v for k, v in row.items() if v})
+                else:
+                    new = {c: '' for c in _FILE_MAP['scene-intent.csv']}
+                    new.update(row)
+                    existing[sid] = new
+            ordered = sorted(existing.values(),
+                             key=lambda r: r.get('id', ''))
+            _write_csv(path, ordered, _FILE_MAP['scene-intent.csv'])
+            written.append(f'scene-intent.csv ({len(rows)} rows)')
+
+    elif label == 'briefs-csv':
+        rows = csv_block_to_rows(content)
+        if rows:
+            path = os.path.join(ref_dir, 'scene-briefs.csv')
+            existing = _read_csv_as_map(path)
+            for row in rows:
+                sid = row.get('id', '')
+                if not sid:
+                    continue
+                if sid in existing:
+                    existing[sid].update({k: v for k, v in row.items() if v})
+                else:
+                    new = {c: '' for c in _FILE_MAP['scene-briefs.csv']}
+                    new.update(row)
+                    existing[sid] = new
+            ordered = sorted(existing.values(),
+                             key=lambda r: r.get('id', ''))
+            _write_csv(path, ordered, _FILE_MAP['scene-briefs.csv'])
+            written.append(f'scene-briefs.csv ({len(rows)} rows)')
+
+    elif label == 'scenes-csv-update':
+        # Partial update (just status changes)
+        rows = csv_block_to_rows(content)
+        if rows:
+            path = os.path.join(ref_dir, 'scenes.csv')
+            existing = _read_csv_as_map(path)
+            for row in rows:
+                sid = row.get('id', '')
+                if sid in existing:
+                    existing[sid].update({k: v for k, v in row.items() if v and k != 'id'})
+            ordered = sorted(existing.values(), key=lambda r: int(r.get('seq', 0)))
+            _write_csv(path, ordered, _FILE_MAP['scenes.csv'])
+            written.append(f'scenes.csv status updates ({len(rows)} rows)')
+
+    elif label in ('story-architecture', 'character-bible', 'world-bible', 'voice-guide'):
+        filename = label + '.md'
+        path = os.path.join(ref_dir, filename)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(content + '\n')
+        written.append(filename)
+
+if written:
+    print('Updated: ' + ', '.join(written))
+else:
+    print('WARNING: No structured output blocks found in response')
+" 2>&1 | while IFS= read -r line; do log "  $line"; done
+
+# ============================================================================
+# Validate
+# ============================================================================
+
+log "Running validation..."
+
+VALIDATE_RESULT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import json
+from storyforge.elaborate import validate_structure
+report = validate_structure('${REF_DIR}')
+print(json.dumps(report))
+")
+
+VALIDATE_PASSED=$(echo "$VALIDATE_RESULT" | python3 -c "import sys, json; r=json.load(sys.stdin); print(r['passed'])")
+VALIDATE_FAILURES=$(echo "$VALIDATE_RESULT" | python3 -c "import sys, json; r=json.load(sys.stdin); print(len(r['failures']))")
+
+if [[ "$VALIDATE_PASSED" == "True" ]]; then
+    log "Validation passed"
+else
+    log "Validation found ${VALIDATE_FAILURES} issue(s):"
+    echo "$VALIDATE_RESULT" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+for f in r['failures']:
+    sev = f.get('severity', 'blocking')
+    scene = f.get('scene_id', '')
+    prefix = f'  [{sev}]'
+    if scene:
+        prefix += f' {scene}:'
+    print(f\"{prefix} {f['message']}\")
+" | while IFS= read -r line; do log "$line"; done
+fi
+
+# Save validation report
+VALIDATE_FILE="${PROJECT_DIR}/working/validation/validate-$(date '+%Y%m%d-%H%M%S').md"
+mkdir -p "$(dirname "$VALIDATE_FILE")"
+echo "$VALIDATE_RESULT" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+print(f'# Validation Report: ${STAGE}')
+print(f'')
+print(f'**Passed:** {r[\"passed\"]}')
+print(f'**Checks:** {len(r[\"checks\"])}')
+print(f'**Failures:** {len(r[\"failures\"])}')
+print()
+if r['failures']:
+    print('## Failures')
+    print()
+    for f in r['failures']:
+        sev = f.get('severity', 'blocking')
+        scene = f.get('scene_id', '')
+        msg = f['message']
+        if scene:
+            print(f'- **[{sev}]** {scene}: {msg}')
+        else:
+            print(f'- **[{sev}]** {msg}')
+" > "$VALIDATE_FILE"
+
+# ============================================================================
+# Commit and update PR
+# ============================================================================
+
+log "Committing ${STAGE} results..."
+
+(
+    cd "$PROJECT_DIR"
+    git add -A
+    git commit -m "Elaborate: ${STAGE} stage" 2>/dev/null || true
+    git push 2>/dev/null || true
+)
+
+update_pr_task "Run ${STAGE} stage" "$PROJECT_DIR" 2>/dev/null || true
+update_pr_task "Validate" "$PROJECT_DIR" 2>/dev/null || true
+
+# ============================================================================
+# Update phase in storyforge.yaml
+# ============================================================================
+
+# Map stage to next phase
+case "$STAGE" in
+    spine)        NEXT_PHASE="architecture" ;;
+    architecture) NEXT_PHASE="scene-map" ;;
+    map)          NEXT_PHASE="briefs" ;;
+    briefs)       NEXT_PHASE="drafting" ;;
+esac
+
+# Only advance phase if validation passed
+if [[ "$VALIDATE_PASSED" == "True" ]]; then
+    CURRENT_PHASE=$(read_yaml_field "phase" 2>/dev/null || echo "")
+    if [[ "$CURRENT_PHASE" == "$STAGE" || "$CURRENT_PHASE" == "spine" || "$CURRENT_PHASE" == "development" ]]; then
+        sed -i '' "s/^phase:.*/phase: ${NEXT_PHASE}/" "${PROJECT_DIR}/storyforge.yaml"
+        (
+            cd "$PROJECT_DIR"
+            git add storyforge.yaml
+            git commit -m "Elaborate: advance phase to ${NEXT_PHASE}" 2>/dev/null || true
+            git push 2>/dev/null || true
+        )
+        log "Phase advanced to: ${NEXT_PHASE}"
+    fi
+fi
+
+# ============================================================================
+# Review phase
+# ============================================================================
+
+run_review_phase "elaboration" "$PROJECT_DIR"
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+log ""
+log "============================================"
+log "Elaboration ${STAGE} complete."
+if [[ "$VALIDATE_PASSED" == "True" ]]; then
+    log "Validation: PASSED"
+else
+    log "Validation: ${VALIDATE_FAILURES} issue(s) — review before advancing"
+fi
+log "============================================"
+
+print_cost_summary "elaborate-${STAGE}" 2>/dev/null || true

--- a/skills/elaborate/SKILL.md
+++ b/skills/elaborate/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: elaborate
+description: Progressive elaboration pipeline — build a novel from seed through validated briefs. Use when the author wants to start a new novel using the elaboration approach, advance to the next stage, or work on spine/architecture/scene map/briefs.
+---
+
+# Storyforge Elaborate
+
+You are guiding an author through the elaboration pipeline — a progressive deepening process that builds structural integrity before any prose is written. Each stage adds detail to a unified scene data model, with validation gates between stages.
+
+## Locating the Storyforge Plugin
+
+The Storyforge plugin root is two levels up from this skill file's directory (this skill's directory -> `skills/` -> plugin root).
+
+Store this resolved plugin path for use throughout the session.
+
+## Step 1: Read Project State
+
+Read the following files to understand where the project stands:
+
+1. `storyforge.yaml` — check the `phase` field to determine current stage
+2. `reference/scenes.csv` — check if it exists and how many rows (0 = no spine yet)
+3. `reference/scene-intent.csv` — check column depth (function only = spine; has value_shift = architecture; has characters = mapped)
+4. `reference/scene-briefs.csv` — check if it exists and has non-empty rows
+5. `reference/story-architecture.md` — does it exist?
+6. `reference/character-bible.md` — does it exist?
+
+## Step 2: Determine Current Stage
+
+Based on the project state, identify where the author is:
+
+| Phase in YAML | scenes.csv rows | Intent depth | Briefs | Current stage |
+|---------------|----------------|--------------|--------|---------------|
+| spine | 0 | — | — | Needs spine |
+| spine | 5-10 | function only | — | Spine done, ready for architecture |
+| architecture | 15-25 | has value_shift, threads | — | Architecture done, ready for map |
+| scene-map | 40-60 | has characters, on_stage | — | Map done, ready for briefs |
+| briefs | 40-60 | full | has goal/conflict/outcome | Briefs done, ready for drafting |
+| drafting+ | — | — | — | Past elaboration — redirect to forge |
+
+## Step 3: Determine Mode
+
+Based on the author's request:
+
+- **"Start a new novel"** / **"Let's begin"** → Start at spine. Ask for the seed (logline, genre, characters, themes, constraints). Whatever they give you is the seed.
+- **"What's next?"** / **"Keep going"** → Advance to the next stage based on current state.
+- **"Work on the spine/architecture/map/briefs"** → Go to that specific stage.
+- **"Validate"** → Run validation on the current state.
+- **Status question** → Report current stage, scene count, validation state.
+
+## Step 4: Execute the Stage
+
+### Coaching Level Behavior
+
+Read the coaching level from `storyforge.yaml` (`project.coaching_level`) or environment.
+
+**Full mode (default):**
+- You do the creative work. Propose the spine, build the architecture, map scenes, write briefs.
+- Present results for author review at each stage boundary.
+- If the author says "keep going" or "looks good," advance to the next stage.
+
+**Coach mode:**
+- Present options and ask questions at each stage.
+- For spine: "Here are three possible spines — which direction resonates?"
+- For architecture: "I see two ways to structure Act 2 — which feels right?"
+- Author makes all creative decisions; you structure and organize them.
+
+**Strict mode:**
+- Ask structural questions only. Don't propose creative content.
+- "What are the 5-10 events that must happen in this story?"
+- "Who is the POV character for this scene and why?"
+- You handle all CSV formatting, validation, and file management.
+- **Validate is your key offering** — run it after the author fills in each stage.
+
+### Running Each Stage
+
+For each stage, offer two options:
+
+> **Option A: Run it here**
+> I'll work through the stage in this conversation. We can discuss and iterate.
+>
+> **Option B: Run it autonomously**
+> Copy this command and run it in a separate terminal:
+> ```bash
+> cd [project_dir] && [plugin_path]/scripts/storyforge-elaborate --stage [stage]
+> ```
+> This creates a branch, runs the stage, validates, and opens a PR.
+
+Wait for the author's choice. If they choose Option A, work through the stage interactively:
+
+1. Build the stage's output (CSV rows + reference materials)
+2. Present a summary to the author
+3. Apply the updates to the CSV files and reference docs
+4. Run validation
+5. Report results
+6. Commit and push
+
+If they choose Option B, provide the full command and end.
+
+### Spine Stage (Interactive)
+
+1. Gather the seed from the author (or read from logline)
+2. Propose the story architecture: premise, theme, three-level conflict, ending
+3. Propose protagonist with wound/lie/need/want
+4. Propose 5-10 spine events as a numbered list
+5. Once approved, write to:
+   - `reference/story-architecture.md`
+   - `reference/character-bible.md`
+   - `reference/scenes.csv` (id, seq, title, status=spine)
+   - `reference/scene-intent.csv` (id, function)
+6. Commit: `git add -A && git commit -m "Elaborate: spine" && git push`
+
+### Architecture Stage (Interactive)
+
+1. Read the spine scenes and story architecture
+2. Expand to 15-25 scenes: add supporting scenes, transitions, subplot introductions
+3. Assign parts, POV, scene types (action/sequel), value shifts, turning points, threads
+4. Deepen character bible with supporting characters
+5. Create world bible if needed
+6. Write updates to all CSV files and reference docs
+7. Run validation — fix any issues before committing
+8. Commit: `git add -A && git commit -m "Elaborate: architecture" && git push`
+
+### Scene Map Stage (Interactive)
+
+1. Read architecture scenes and reference materials
+2. Expand to 40-60 scenes: fill gaps, add transitions
+3. Assign locations, timeline, characters, MICE threads
+4. Initialize continuity tracker
+5. Write updates
+6. Run validation — MICE nesting, timeline, character references
+7. Commit: `git add -A && git commit -m "Elaborate: scene map" && git push`
+
+### Briefs Stage (Interactive)
+
+1. Read full scene map and all reference materials
+2. For each scene, define: goal, conflict, outcome, crisis, decision, knowledge_in, knowledge_out, key_actions, key_dialogue, emotions, motifs, continuity_deps
+3. **Knowledge wording must be exact** — knowledge_out from scene N becomes knowledge_in for later scenes, matched literally
+4. Maximize scenes with no continuity_deps (these can be drafted in parallel)
+5. Write updates
+6. Run validation — knowledge flow, completeness, DAG check
+7. Commit: `git add -A && git commit -m "Elaborate: briefs" && git push`
+
+## Step 5: Validate and Report
+
+After any stage completes, run validation:
+
+```bash
+cd [project_dir] && [plugin_path]/scripts/storyforge-validate
+```
+
+Or use the Python helpers directly:
+
+```python
+from storyforge.elaborate import validate_structure
+report = validate_structure('reference/')
+```
+
+Report results to the author. Blocking failures must be fixed before advancing. Advisory findings are noted for author judgment.
+
+## Step 6: Commit After Every Deliverable
+
+Every stage output gets committed immediately:
+
+```bash
+git add -A && git commit -m "Elaborate: [stage name]" && git push
+```
+
+Do not batch multiple stages into one commit.


### PR DESCRIPTION
## Summary

- `scripts/storyforge-elaborate` — autonomous elaboration script accepting `--stage spine|architecture|map|briefs`. Creates branch, invokes Claude with stage-specific prompts, parses structured CSV/markdown output, runs validation, advances phase, opens PR.
- `scripts/lib/python/storyforge/prompts_elaborate.py` — prompt builders for each stage (spine, architecture, map, briefs) plus response parsing (fenced block extraction, CSV block to row dicts)
- `skills/elaborate/SKILL.md` — interactive elaboration skill with coaching level adaptation (full: Claude proposes; coach: Claude presents options; strict: author writes, Claude validates)
- Supports `--dry-run` (print prompt), `--interactive` (claude -p), and autonomous API mode
- Each stage validates before committing and advancing phase

## Context

Plan 2 of 4 for the elaboration pipeline. Builds on Plan 1 (three-file CSV model and validation engine, merged in #52).

## Test plan

- [x] Dry-run mode tested for spine and architecture stages — prompts include correct project context and CSV data
- [x] Response parser tested — correctly extracts labeled fenced blocks and parses CSV rows
- [x] Full test suite: 741 tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)