### PR TITLE
Update skills for elaboration pipeline, add migration script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/docs/superpowers/plans/2026-04-02-elaboration-pipeline-plan-4-skills-migration.md
+++ b/docs/superpowers/plans/2026-04-02-elaboration-pipeline-plan-4-skills-migration.md
@@ -1,0 +1,11 @@
+# Elaboration Pipeline — Plan 4: Skill Updates & Migration
+
+**Goal:** Update existing skills to understand elaboration phases, add migration tooling, update init for new projects.
+
+**Tasks:**
+1. Update forge hub to route elaboration phases to elaborate skill
+2. Update recommend to understand elaboration stages
+3. Update scenes, develop, plan-revision to redirect during elaboration
+4. Update init for elaboration pipeline projects
+5. Add migration script for existing projects
+6. Tests, version bump

--- a/scripts/storyforge-migrate-elaborate
+++ b/scripts/storyforge-migrate-elaborate
@@ -1,0 +1,218 @@
+#!/bin/bash
+# storyforge-migrate-elaborate — Migrate a project to the elaboration pipeline
+#
+# Usage:
+#   ./storyforge migrate-elaborate             # Interactive migration
+#   ./storyforge migrate-elaborate --dry-run   # Show what would change
+#
+# Converts scene-metadata.csv → scenes.csv and creates scene-briefs.csv.
+# Preserves all existing data. Does not delete the old files.
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/lib"
+PYTHON_LIB="${SCRIPT_DIR}/lib/python"
+
+source "${LIB_DIR}/common.sh"
+detect_project_root
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            echo "Usage: storyforge migrate-elaborate [--dry-run]"
+            echo "Converts a traditional Storyforge project to the elaboration pipeline."
+            exit 0
+            ;;
+    esac
+done
+
+REF_DIR="${PROJECT_DIR}/reference"
+
+# ============================================================================
+# Check current state
+# ============================================================================
+
+if [[ -f "${REF_DIR}/scenes.csv" ]]; then
+    log "This project already has reference/scenes.csv — it may already use the elaboration pipeline."
+    log "If you want to re-migrate, remove scenes.csv first."
+    exit 1
+fi
+
+if [[ ! -f "${REF_DIR}/scene-metadata.csv" ]]; then
+    log "No scene-metadata.csv found. Nothing to migrate."
+    log "Use /storyforge:init to create a new project with the elaboration pipeline."
+    exit 1
+fi
+
+log "============================================"
+log "Migrating to Elaboration Pipeline"
+log "============================================"
+
+# ============================================================================
+# Convert scene-metadata.csv → scenes.csv
+# ============================================================================
+
+log "Converting scene-metadata.csv → scenes.csv..."
+
+PYTHONPATH="$PYTHON_LIB" python3 -c "
+import csv, os, sys
+
+ref_dir = '${REF_DIR}'
+dry_run = '${DRY_RUN}' == 'true'
+
+# Read old metadata
+old_path = os.path.join(ref_dir, 'scene-metadata.csv')
+with open(old_path, newline='', encoding='utf-8') as f:
+    reader = csv.DictReader(f, delimiter='|')
+    old_rows = list(reader)
+    old_fields = reader.fieldnames
+
+print(f'  Read {len(old_rows)} scenes from scene-metadata.csv')
+
+# Map old columns to new scenes.csv columns
+new_cols = ['id', 'seq', 'title', 'part', 'pov', 'location',
+            'timeline_day', 'time_of_day', 'duration', 'status',
+            'word_count', 'target_words']
+
+new_rows = []
+for row in old_rows:
+    new_row = {c: '' for c in new_cols}
+    for col in new_cols:
+        if col in row:
+            new_row[col] = row[col]
+    # Backfill status based on existing data
+    status = new_row.get('status', '')
+    if status in ('drafted', 'revised', 'consolidated', 'polished'):
+        pass  # keep existing status
+    elif new_row.get('word_count', '0') not in ('0', ''):
+        new_row['status'] = 'drafted'
+    else:
+        new_row['status'] = 'mapped'  # has metadata but no prose
+    new_rows.append(new_row)
+
+if dry_run:
+    print(f'  Would create scenes.csv with {len(new_rows)} rows')
+    print(f'  Columns: {\"|\".join(new_cols)}')
+    for r in new_rows[:3]:
+        print(f'    {r[\"id\"]}: status={r[\"status\"]}')
+    if len(new_rows) > 3:
+        print(f'    ... and {len(new_rows) - 3} more')
+else:
+    new_path = os.path.join(ref_dir, 'scenes.csv')
+    with open(new_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=new_cols, delimiter='|', extrasaction='ignore')
+        writer.writeheader()
+        writer.writerows(new_rows)
+    print(f'  Created scenes.csv with {len(new_rows)} rows')
+"
+
+# ============================================================================
+# Update scene-intent.csv with new columns (if missing)
+# ============================================================================
+
+log "Checking scene-intent.csv columns..."
+
+PYTHONPATH="$PYTHON_LIB" python3 -c "
+import csv, os
+
+ref_dir = '${REF_DIR}'
+dry_run = '${DRY_RUN}' == 'true'
+intent_path = os.path.join(ref_dir, 'scene-intent.csv')
+
+if not os.path.exists(intent_path):
+    print('  No scene-intent.csv found — will create empty one')
+    if not dry_run:
+        new_cols = ['id', 'function', 'scene_type', 'emotional_arc', 'value_at_stake',
+                    'value_shift', 'turning_point', 'threads', 'characters', 'on_stage',
+                    'mice_threads']
+        with open(intent_path, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=new_cols, delimiter='|')
+            writer.writeheader()
+else:
+    with open(intent_path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f, delimiter='|')
+        rows = list(reader)
+        fields = reader.fieldnames
+
+    new_cols = ['id', 'function', 'scene_type', 'emotional_arc', 'value_at_stake',
+                'value_shift', 'turning_point', 'threads', 'characters', 'on_stage',
+                'mice_threads']
+
+    missing = [c for c in new_cols if c not in fields]
+    if missing:
+        print(f'  Adding missing columns: {missing}')
+        if not dry_run:
+            for row in rows:
+                for col in missing:
+                    row.setdefault(col, '')
+            with open(intent_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=new_cols, delimiter='|', extrasaction='ignore')
+                writer.writeheader()
+                writer.writerows(rows)
+    else:
+        print('  scene-intent.csv already has all elaboration columns')
+"
+
+# ============================================================================
+# Create scene-briefs.csv
+# ============================================================================
+
+log "Creating scene-briefs.csv..."
+
+if [[ "$DRY_RUN" == true ]]; then
+    log "  Would create scene-briefs.csv with header only"
+else
+    echo "id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow" > "${REF_DIR}/scene-briefs.csv"
+    log "  Created scene-briefs.csv (header only — fill via /storyforge:elaborate)"
+fi
+
+# ============================================================================
+# Update storyforge.yaml phase
+# ============================================================================
+
+CURRENT_PHASE=$(read_yaml_field "phase" 2>/dev/null || echo "development")
+if [[ "$CURRENT_PHASE" == "development" || "$CURRENT_PHASE" == "scene-design" ]]; then
+    NEW_PHASE="briefs"  # Assume scenes are designed, need briefs
+    # Check if scenes exist but no brief data
+    SCENE_COUNT=$(tail -n +2 "${REF_DIR}/scenes.csv" 2>/dev/null | wc -l | tr -d ' ')
+    if (( SCENE_COUNT == 0 )); then
+        NEW_PHASE="spine"
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        log "  Would update phase: ${CURRENT_PHASE} → ${NEW_PHASE}"
+    else
+        sed -i '' "s/^phase:.*/phase: ${NEW_PHASE}/" "${PROJECT_DIR}/storyforge.yaml"
+        log "  Phase updated: ${CURRENT_PHASE} → ${NEW_PHASE}"
+    fi
+else
+    log "  Phase is '${CURRENT_PHASE}' — not changing (already past development)"
+fi
+
+# ============================================================================
+# Commit
+# ============================================================================
+
+if [[ "$DRY_RUN" == true ]]; then
+    log ""
+    log "Dry run complete. No files were changed."
+else
+    (
+        cd "$PROJECT_DIR"
+        git add reference/scenes.csv reference/scene-intent.csv reference/scene-briefs.csv storyforge.yaml 2>/dev/null || true
+        git commit -m "Migrate to elaboration pipeline" 2>/dev/null || true
+        git push 2>/dev/null || true
+    )
+    log ""
+    log "============================================"
+    log "Migration complete."
+    log "  scenes.csv created from scene-metadata.csv"
+    log "  scene-briefs.csv created (empty — populate via /storyforge:elaborate)"
+    log "  Phase set to: $(read_yaml_field "phase" 2>/dev/null)"
+    log ""
+    log "Next: run /storyforge:elaborate to start the elaboration pipeline"
+    log "  or /storyforge:elaborate --stage briefs to write briefs for existing scenes"
+    log "============================================"
+fi

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -34,7 +34,17 @@ Do NOT skip this step. You need to know what already exists before you can help 
 
 ---
 
-## Step 2: Determine Execution Mode
+## Step 2: Check for Elaboration Pipeline
+
+If `storyforge.yaml` phase is `spine`, `architecture`, `scene-map`, or `briefs`, this project uses the elaboration pipeline. During elaboration, character development, world building, and story architecture are integrated into the elaborate stages — they're not done separately.
+
+Tell the author: "This project is in the elaboration pipeline (phase: {phase}). Character, world, and story architecture work is part of `/storyforge:elaborate`. Would you like to go there instead?"
+
+If the author insists on doing standalone develop work during elaboration (e.g., deepening a specific character outside the pipeline), that's fine — proceed normally. The elaborate skill will pick up the reference material changes.
+
+If the phase is NOT an elaboration phase, proceed normally.
+
+## Step 3: Determine Execution Mode
 
 **If invoked with specific direction** (e.g., "deepen Maren's wound/lie structure" or "build out the economic system in the world bible"):
 Skip assessment. Go directly to the relevant sub-workflow and execute. Make creative sub-decisions autonomously. Do not ask "what aspect?" or "which character?" — the direction tells you what to do. Do it.

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -27,7 +27,7 @@ Before doing anything else, orient yourself:
    - `reference/story-architecture.md`
    - `reference/voice-guide.md`
    - `reference/timeline.md`
-   - `reference/scene-metadata.csv`
+   - `reference/scenes.csv` (elaboration pipeline) or `reference/scene-metadata.csv` (legacy)
    - `working/evaluations/*/findings.csv` (preferred) or `working/evaluations/findings.yaml` (legacy)
    - `working/plans/revision-plan.csv` (preferred) or `working/plans/revision-plan.yaml` (legacy)
    - The `scenes/` directory (any `.md` files = drafted scenes)
@@ -35,7 +35,20 @@ Before doing anything else, orient yourself:
 
 Do not present this information unless the author asks for a status check. This is your internal orientation.
 
-## Step 2: Determine Mode
+## Step 2: Check for Elaboration Pipeline
+
+Read the `phase` field from `storyforge.yaml`. If it is one of: `spine`, `architecture`, `scene-map`, `briefs`, this project uses the elaboration pipeline.
+
+**If the project is in an elaboration phase:**
+- Route to the `elaborate` skill for most requests (scene work, drafting prep, "what's next", structural planning)
+- The `develop`, `voice`, `scenes`, and `plan-revision` skills are not used during elaboration — their work is integrated into the elaborate pipeline
+- Skills that still apply normally: `visualize`, `title`, `cover`, `press-kit`, `produce`, `score`, `publish`
+- If the author asks to start drafting and the phase is `briefs` (briefs are complete), check that `reference/scene-briefs.csv` has data and validation passes, then provide the write command (which will automatically detect briefs and use the brief-aware prompt builder)
+- If the author asks to evaluate or polish after drafting, those scripts work normally
+
+**If the project is NOT in an elaboration phase** (legacy phases: `development`, `scene-design`, `drafting`, `evaluation`, `revision`, `review`, `complete`, `production`), proceed with the existing routing below.
+
+## Step 3: Determine Mode
 
 Based on the author's message, operate in one of three modes:
 
@@ -60,7 +73,7 @@ Invoke the `scenes` skill. This covers scene index population, scene design, sce
 Check prerequisites before proceeding:
 
 - *Hard prerequisites* (will not proceed without):
-  - `reference/scene-metadata.csv` must exist and contain at least one scene
+  - Scene data must exist: `reference/scenes.csv` (elaboration) or `reference/scene-metadata.csv` (legacy) with at least one scene
   - `reference/voice-guide.md` must exist
 - *Soft prerequisites* (recommend but allow override):
   - `reference/character-bible.md`
@@ -204,7 +217,7 @@ Suggest next steps but don't push. Let the author absorb the information and dec
 
 | Command | Requires |
 |---|---|
-| `storyforge write` | `reference/scene-metadata.csv` with at least one scene, `reference/voice-guide.md` |
+| `storyforge write` | Scene data (`reference/scenes.csv` or `reference/scene-metadata.csv`) with at least one scene, `reference/voice-guide.md` |
 | `storyforge evaluate` | At least some scene files (`.md`) in `scenes/` |
 | `plan-revision` | Evaluation results in `working/evaluations/` |
 | `storyforge revise` | Revision plan for the current pipeline cycle (from `working/pipeline.csv`) |

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -53,6 +53,12 @@ Ask the author for the following details **one question at a time** using `AskUs
 
    You can change this anytime in storyforge.yaml."
 
+7. **Pipeline approach** — "How do you want to build your novel?
+   - **Elaboration** (recommended) — Build structural integrity before writing prose. Progressive stages: spine → architecture → scene map → briefs → draft → polish. Catches continuity issues before they become prose problems. Enables parallel scene drafting.
+   - **Traditional** — Jump into scene design and drafting. Evaluate and revise after. Good for authors who prefer to discover the story through writing.
+
+   The elaboration approach is newer and produces cleaner first drafts. Traditional is the established workflow."
+
 Store all answers for use in subsequent steps.
 
 ## Step 2: Create the Project Directory Structure
@@ -126,7 +132,7 @@ project:
   subgenre: "{subgenre or empty}"
   target_word_count: {word_count}
   logline: "{logline}"
-  phase: development
+  phase: spine  # or "development" if traditional pipeline
   status: active
 
 structure:
@@ -147,7 +153,28 @@ If no templates are found in the plugin directory, note this to the author and l
 
 ## Step 5: Create the Scene CSV Files
 
-Use the **Write tool** to create the two scene CSV files with headers only:
+The CSV files depend on which pipeline the author chose.
+
+**If elaboration pipeline:** Create three files with headers only:
+
+**`{project-dir}/reference/scenes.csv`:**
+```
+id|seq|title|part|pov|location|timeline_day|time_of_day|duration|status|word_count|target_words
+```
+
+**`{project-dir}/reference/scene-intent.csv`:**
+```
+id|function|scene_type|emotional_arc|value_at_stake|value_shift|turning_point|threads|characters|on_stage|mice_threads
+```
+
+**`{project-dir}/reference/scene-briefs.csv`:**
+```
+id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow
+```
+
+Copy these from the plugin's `templates/reference/` directory if available.
+
+**If traditional pipeline:** Create two files with headers only:
 
 **`{project-dir}/reference/scene-metadata.csv`:**
 ```

--- a/skills/plan-revision/SKILL.md
+++ b/skills/plan-revision/SKILL.md
@@ -15,6 +15,18 @@ and reference materials live at `references/` relative to that plugin root.
 
 Store this resolved plugin path for use throughout the session.
 
+## Step 0: Check Pipeline Type
+
+Read `storyforge.yaml` phase. If the phase is an elaboration phase (`spine`, `architecture`, `scene-map`, `briefs`), revision planning doesn't apply yet — the manuscript hasn't been drafted.
+
+Tell the author: "Revision planning happens after scenes are drafted. Your project is still in the elaboration phase ({phase}). Use `/storyforge:elaborate` to continue building toward drafting."
+
+If the phase is `drafting` or later AND `reference/scene-briefs.csv` exists with data, this is an elaboration-pipeline project. In this case, evaluation findings should include a `fix_location` field categorizing each finding as `brief`, `intent`, `structural`, or `craft`. When building revision passes:
+- **brief/intent/structural findings** → Create passes that update the CSV data upstream, then re-draft affected scenes
+- **craft findings** → Create passes that polish prose directly (or route to `./storyforge polish`)
+
+This upstream-first approach is the key difference from the legacy pipeline where all revision operates on prose.
+
 ## Step 1: Read Evaluation Results
 
 Look for evaluation output using the pipeline manifest:

--- a/skills/recommend/SKILL.md
+++ b/skills/recommend/SKILL.md
@@ -29,7 +29,7 @@ Read all of the following. Do not skip any — the recommendation depends on hav
    - `reference/story-architecture.md`
    - `reference/voice-guide.md`
    - `reference/timeline.md`
-   - `reference/scene-metadata.csv` (read it — check if it has entries or is empty)
+   - `reference/scenes.csv` (elaboration) or `reference/scene-metadata.csv` (legacy) — read it, check if it has entries or is empty
    - `reference/chapter-map.csv`
 6. **Scene status** — count scene files in `scenes/*.md`. Compare planned (from scene-index) vs. drafted (files exist) vs. revised (check frontmatter or pass status). Calculate current word count vs. target.
 7. **Evaluation state** — check for `working/evaluations/`. If evaluations exist, read the most recent `findings.yaml` or `synthesis.md` to understand outstanding issues. Note severity counts (critical/major/minor).
@@ -43,7 +43,18 @@ Work through these priorities in order. Stop at the first one that applies — t
 
 ### Priority 1: Phase-Driven Actions
 
-Some phases have a single obvious next step:
+Some phases have a single obvious next step.
+
+**Elaboration pipeline phases:**
+
+- **Phase is `spine`** → Recommend `/storyforge:elaborate`. "Start with the spine — the 5-10 irreducible story events."
+- **Phase is `architecture`** → Recommend `/storyforge:elaborate`. "Expand the spine into a full architecture with POV assignments, value shifts, and thread structure."
+- **Phase is `scene-map`** → Recommend `/storyforge:elaborate`. "Map every scene with locations, timeline, characters, and MICE thread tracking."
+- **Phase is `briefs`** → Recommend `/storyforge:elaborate`. "Write the drafting contracts — goal, conflict, outcome, knowledge states for every scene."
+- **Phase is `drafting` and `reference/scene-briefs.csv` has data** → Recommend running `./storyforge write`. "Briefs are validated — ready to draft scenes in parallel from the briefs."
+- **Phase is `polish`** → Recommend running `./storyforge polish`. "Polish the prose — one targeted pass for voice, rhythm, and naturalness."
+
+**Legacy pipeline phases:**
 
 - **Phase is `review`** → The revision cycle just finished. Recommend `/storyforge:review` to assess what changed and determine if the revision landed. Do not recommend other work until the review is done.
 - **Phase is `complete`** → The manuscript is done. Recommend `/storyforge:produce` to set up production (chapter map, epub settings), or prompt the author to run `./storyforge assemble` if the chapter map already exists.

--- a/skills/scenes/SKILL.md
+++ b/skills/scenes/SKILL.md
@@ -22,8 +22,11 @@ Store this resolved plugin path for use throughout the session.
 Read the following files to understand the full context before doing any scene work:
 
 - `storyforge.yaml` — project configuration, active extensions, current state. **Note the `project.coaching_level` field** — it controls how proactive you should be (see Coaching Level Behavior below).
-- `reference/scene-metadata.csv` — the existing scene metadata (pipe-delimited CSV: `id|seq|title|pov|location|part|type|timeline_day|time_of_day|status|word_count|target_words`).
-- `reference/scene-intent.csv` — scene intent data (pipe-delimited CSV: `id|function|emotional_arc|characters|threads|motifs|notes`). Array fields use `;` (semicolon) as the internal separator.
+- `reference/scenes.csv` (elaboration pipeline) or `reference/scene-metadata.csv` (legacy) — the scene structural data
+- `reference/scene-intent.csv` — scene intent data. In elaboration pipeline, this includes additional columns: `scene_type`, `value_at_stake`, `value_shift`, `turning_point`, `on_stage`, `mice_threads`.
+- `reference/scene-briefs.csv` (elaboration pipeline only) — drafting contracts with goal, conflict, outcome, knowledge states
+
+**Elaboration pipeline check:** If `storyforge.yaml` phase is `spine`, `architecture`, `scene-map`, or `briefs`, scene design is handled by the `/storyforge:elaborate` skill, not this skill. Tell the author: "This project uses the elaboration pipeline. Scene design happens through `/storyforge:elaborate`." However, this skill's **Review Mode** and **Edit Mode** (reordering, splitting, renaming) still work on elaboration projects — they operate on the CSV data regardless of pipeline type.
 - `reference/story-architecture.md` — structural context: acts, parts, arcs, turning points.
 - `reference/character-bible.md` — character arcs, relationships, and motivations.
 - `reference/voice-guide.md` — voice and POV rules (if it exists), especially POV-specific voice rules that affect scene assignment.


### PR DESCRIPTION
## Summary

- **Forge hub** detects elaboration phases and routes to elaborate skill; other skills (visualize, cover, title, etc.) still route normally
- **Recommend** adds elaboration phase priorities — each phase maps to a clear next action via `/storyforge:elaborate`
- **Scenes** redirects design work to elaborate during elaboration phases; review/edit modes still work on the new CSV model
- **Develop** notes creative work is integrated into elaborate during elaboration; allows standalone deepening if author insists
- **Plan-revision** checks for elaboration pipeline; routes findings by `fix_location` field for upstream-first fixes
- **Init** asks about pipeline approach (elaboration vs traditional); creates appropriate CSV structure and starting phase
- **Migration script** (`storyforge-migrate-elaborate`) converts existing projects: scene-metadata.csv → scenes.csv with status backfill, adds missing intent columns, creates scene-briefs.csv, updates phase

## Context

Plan 4 of 4 — the final piece of the elaboration pipeline. All four plans are now complete:
1. Foundation (data model + validation) — merged in #52
2. Elaboration stages (script + skill + prompts) — merged in #53
3. Drafting & evaluation (wave planner + brief prompts + polish + finding categorization) — merged in #54
4. Skills & migration (this PR)

## Test plan

- [x] Migration dry-run tested against Meridian Line (64 scenes, correct status backfill, identifies 6 missing columns)
- [x] Full suite: 753 tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)