### PR TITLE
Add reverse elaboration: extract structural data from existing prose

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/docs/superpowers/plans/2026-04-02-reverse-elaboration.md
+++ b/docs/superpowers/plans/2026-04-02-reverse-elaboration.md
@@ -1,0 +1,846 @@
+# Reverse Elaboration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract structural data from existing prose into the three-file scene CSV model. Takes a manuscript (or existing scenes) and produces populated scenes.csv, scene-intent.csv, and scene-briefs.csv — accurate enough for the author to review and correct rather than build from scratch. Also supports novella-to-novel expansion analysis.
+
+**Architecture:** New script `scripts/storyforge-extract` orchestrates four extraction phases (characterize → skeleton → intent → briefs). New Python module `scripts/lib/python/storyforge/extract.py` provides prompt builders and response parsers for each phase. Reuses existing enrichment infrastructure where possible. New skill `skills/extract/SKILL.md` for interactive use.
+
+**Tech Stack:** Python 3, bash, Anthropic Messages API (batch + direct), pipe-delimited CSV
+
+**Spec:** `docs/superpowers/specs/2026-04-01-elaboration-pipeline-design.md` (Migration section)
+
+---
+
+## File Structure
+
+### New files
+- `scripts/lib/python/storyforge/extract.py` — prompt builders, response parsers, and extraction logic for all phases
+- `scripts/storyforge-extract` — bash CLI orchestrating the multi-phase extraction
+- `skills/extract/SKILL.md` — interactive extraction skill
+- `tests/test-extract.sh` — tests for extraction helpers
+
+### Modified files
+- `scripts/lib/python/storyforge/elaborate.py` — add expansion analysis function
+
+---
+
+## Task 1: Extraction prompt builders and parsers — `extract.py`
+
+Create the Python module with prompt builders for each phase and parsers for extracting structured data from Claude's responses.
+
+**Files:**
+- Create: `scripts/lib/python/storyforge/extract.py`
+
+- [ ] **Step 1: Create `extract.py` with Phase 0 (characterize) prompt and parser**
+
+```python
+"""Reverse elaboration — extract structural data from existing prose.
+
+Four extraction phases:
+  Phase 0: Characterize (full manuscript → manuscript profile)
+  Phase 1: Skeleton (per scene → scenes.csv fields)
+  Phase 2: Intent (per scene, parallel → scene-intent.csv fields)
+  Phase 3: Briefs (per scene, knowledge chain sequential → scene-briefs.csv fields)
+"""
+
+import json
+import os
+import re
+from typing import Any
+
+from .prompts import read_yaml_field
+
+
+def _read_file(path: str) -> str:
+    if not os.path.isfile(path):
+        return ''
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+def _read_all_scenes(project_dir: str) -> dict[str, str]:
+    """Read all scene files, returning {scene_id: prose_text}."""
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    if not os.path.isdir(scenes_dir):
+        return {}
+    result = {}
+    for fname in sorted(os.listdir(scenes_dir)):
+        if fname.endswith('.md'):
+            scene_id = fname[:-3]
+            with open(os.path.join(scenes_dir, fname), encoding='utf-8') as f:
+                result[scene_id] = f.read()
+    return result
+
+
+def _read_manuscript(project_dir: str) -> str:
+    """Read the full manuscript by concatenating all scene files in seq order,
+    or reading assembled chapters if available."""
+    # Try assembled chapters first
+    chapters_dir = os.path.join(project_dir, 'manuscript', 'output', 'web', 'chapters')
+    if os.path.isdir(chapters_dir):
+        parts = []
+        for fname in sorted(os.listdir(chapters_dir)):
+            if fname.endswith('.html'):
+                with open(os.path.join(chapters_dir, fname), encoding='utf-8') as f:
+                    # Strip HTML tags for analysis
+                    text = re.sub(r'<[^>]+>', ' ', f.read())
+                    text = re.sub(r'\s+', ' ', text).strip()
+                    parts.append(text)
+        if parts:
+            return '\n\n---\n\n'.join(parts)
+
+    # Fall back to concatenating scene files in seq order
+    scenes = _read_all_scenes(project_dir)
+    if not scenes:
+        return ''
+
+    # Try to order by seq from scenes.csv or scene-metadata.csv
+    ref_dir = os.path.join(project_dir, 'reference')
+    seq_order = {}
+    for csv_name in ['scenes.csv', 'scene-metadata.csv']:
+        csv_path = os.path.join(ref_dir, csv_name)
+        if os.path.isfile(csv_path):
+            with open(csv_path, encoding='utf-8') as f:
+                lines = [l.strip() for l in f if l.strip()]
+            if len(lines) > 1:
+                header = lines[0].split('|')
+                id_idx = header.index('id') if 'id' in header else 0
+                seq_idx = header.index('seq') if 'seq' in header else 1
+                for line in lines[1:]:
+                    fields = line.split('|')
+                    if len(fields) > max(id_idx, seq_idx):
+                        try:
+                            seq_order[fields[id_idx]] = int(fields[seq_idx])
+                        except (ValueError, IndexError):
+                            pass
+            break
+
+    if seq_order:
+        ordered = sorted(scenes.keys(), key=lambda s: seq_order.get(s, 999))
+    else:
+        ordered = sorted(scenes.keys())
+
+    parts = []
+    for sid in ordered:
+        parts.append(f"=== SCENE: {sid} ===\n\n{scenes[sid]}")
+    return '\n\n'.join(parts)
+
+
+# ============================================================================
+# Phase 0: Characterize
+# ============================================================================
+
+def build_characterize_prompt(project_dir: str) -> str:
+    """Build prompt for Phase 0: manuscript characterization."""
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    title = read_yaml_field(yaml_path, 'project.title') or 'Untitled'
+    genre = read_yaml_field(yaml_path, 'project.genre') or ''
+
+    manuscript = _read_manuscript(project_dir)
+    if not manuscript:
+        return ''
+
+    # Truncate if extremely long (>200K chars) — Phase 0 needs the shape, not every word
+    if len(manuscript) > 200000:
+        manuscript = manuscript[:200000] + '\n\n[...truncated for characterization...]'
+
+    return f"""You are analyzing a manuscript to characterize its structure before detailed extraction.
+
+## Project
+**Title:** {title}
+**Genre:** {genre}
+
+## Manuscript
+
+{manuscript}
+
+## Instructions
+
+Analyze this manuscript and produce a structural profile. Output each field on its own labeled line.
+
+NARRATIVE_MODE: [first-person / third-limited / third-omniscient / multiple-POV / other]
+POV_CHARACTERS: [semicolon-separated list of POV characters, in order of appearance]
+TIMELINE: [linear / non-linear / fragmented / frame-narrative]
+TIMELINE_SPAN: [approximate time span of the story, e.g., "3 days", "6 months", "20 years"]
+SCENE_BREAK_STYLE: [explicit-markers / chapter-based / unmarked / mixed]
+ESTIMATED_SCENES: [approximate number of distinct scenes]
+ACT_STRUCTURE: [number of acts/parts and their approximate boundaries, e.g., "3 acts: scenes 1-12, 13-28, 29-42"]
+MAJOR_THREADS: [semicolon-separated list of major story threads/subplots]
+CENTRAL_CONFLICT: [one sentence describing the core conflict]
+PROTAGONIST_ARC: [one sentence: wound/lie → confrontation → resolution/refusal]
+TONE: [1-3 words describing the overall tone]
+CAST_SIZE: [approximate number of named characters]
+KEY_LOCATIONS: [semicolon-separated list of major locations]
+COMPRESSION_POINTS: [semicolon-separated list of moments that feel compressed or rushed — these are expansion opportunities if the work is being developed into a longer form]
+STRUCTURAL_CONCERNS: [semicolon-separated list of any structural issues visible at this level — dropped threads, pacing problems, arc gaps]
+
+Be precise. Base every field on what's actually in the text, not what you'd expect from the genre."""
+
+
+def parse_characterize_response(response: str) -> dict[str, str]:
+    """Parse the Phase 0 characterization response into a dict."""
+    result = {}
+    for line in response.split('\n'):
+        line = line.strip()
+        if ':' not in line:
+            continue
+        # Match LABEL: value pattern
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line)
+        if match:
+            key = match.group(1).lower()
+            value = match.group(2).strip()
+            if value and value not in ('[]', '()', 'N/A', 'none'):
+                result[key] = value
+    return result
+
+
+# ============================================================================
+# Phase 1: Skeleton (scenes.csv fields)
+# ============================================================================
+
+def build_skeleton_prompt(scene_id: str, scene_text: str,
+                          profile: dict[str, str],
+                          existing_metadata: dict[str, str] | None = None) -> str:
+    """Build prompt for Phase 1: extract scenes.csv fields from a single scene."""
+    context = f"""POV characters in this manuscript: {profile.get('pov_characters', 'unknown')}
+Timeline: {profile.get('timeline', 'unknown')}
+Key locations: {profile.get('key_locations', 'unknown')}"""
+
+    existing = ''
+    if existing_metadata:
+        known = {k: v for k, v in existing_metadata.items() if v and k != 'id'}
+        if known:
+            existing = "Already known about this scene:\n" + '\n'.join(
+                f"  {k}: {v}" for k, v in known.items())
+
+    return f"""Extract structural metadata from this scene.
+
+## Manuscript Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+{existing}
+
+## Instructions
+
+Output each field on its own labeled line. If a value cannot be determined, output UNKNOWN.
+
+TITLE: [a short evocative title for this scene, 3-7 words]
+POV: [the POV character's full name]
+LOCATION: [the primary physical location — use a consistent canonical name]
+TIMELINE_DAY: [integer day number within the story chronology, starting from 1]
+TIME_OF_DAY: [morning / afternoon / evening / night / dawn / dusk]
+DURATION: [approximate in-story duration, e.g., "2 hours", "30 minutes", "an afternoon"]
+TARGET_WORDS: [current word count is a reasonable target — output the approximate word count]
+PART: [which act/part number this scene belongs to, based on its position in the story]"""
+
+
+def parse_skeleton_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 1 response into scenes.csv field values."""
+    result = {'id': scene_id}
+    label_map = {
+        'TITLE': 'title',
+        'POV': 'pov',
+        'LOCATION': 'location',
+        'TIMELINE_DAY': 'timeline_day',
+        'TIME_OF_DAY': 'time_of_day',
+        'DURATION': 'duration',
+        'TARGET_WORDS': 'target_words',
+        'PART': 'part',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 2: Intent (scene-intent.csv fields)
+# ============================================================================
+
+def build_intent_prompt(scene_id: str, scene_text: str,
+                        profile: dict[str, str],
+                        skeleton: dict[str, str]) -> str:
+    """Build prompt for Phase 2: extract scene-intent.csv fields."""
+    context = f"""Title: {skeleton.get('title', scene_id)}
+POV: {skeleton.get('pov', 'unknown')}
+Location: {skeleton.get('location', 'unknown')}
+Part: {skeleton.get('part', 'unknown')}
+Major threads in this manuscript: {profile.get('major_threads', 'unknown')}
+Central conflict: {profile.get('central_conflict', 'unknown')}"""
+
+    return f"""Extract the narrative intent and dynamics from this scene.
+
+## Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line. Use semicolons to separate list items.
+
+FUNCTION: [one sentence: why this scene exists — what it accomplishes in the story. Must be specific and testable, not vague like "develops character"]
+SCENE_TYPE: [action or sequel — action scenes have goal/conflict/outcome; sequel scenes have reaction/dilemma/decision]
+EMOTIONAL_ARC: [starting emotion giving way to ending emotion, e.g., "controlled competence to buried unease"]
+VALUE_AT_STAKE: [the abstract value being tested: safety, love, justice, truth, freedom, honor, etc.]
+VALUE_SHIFT: [polarity change using +/- notation: +/- means positive to negative, -/+ means negative to positive, +/++ means good to better, -/-- means bad to worse]
+TURNING_POINT: [action or revelation — action means a character does something that changes the situation; revelation means new information changes the situation]
+THREADS: [semicolon-separated story threads this scene advances]
+CHARACTERS: [semicolon-separated list of ALL characters present or referenced by name]
+ON_STAGE: [semicolon-separated list of characters physically present in the scene — subset of CHARACTERS]
+MICE_THREADS: [semicolon-separated MICE thread operations — +milieu:location-name to open, -inquiry:question to close, etc. Use + for opening, - for closing. Types: milieu, inquiry, character, event]
+CONFIDENCE: [high / medium / low — your overall confidence in these extractions]"""
+
+
+def parse_intent_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 2 response into scene-intent.csv field values."""
+    result = {'id': scene_id}
+    label_map = {
+        'FUNCTION': 'function',
+        'SCENE_TYPE': 'scene_type',
+        'EMOTIONAL_ARC': 'emotional_arc',
+        'VALUE_AT_STAKE': 'value_at_stake',
+        'VALUE_SHIFT': 'value_shift',
+        'TURNING_POINT': 'turning_point',
+        'THREADS': 'threads',
+        'CHARACTERS': 'characters',
+        'ON_STAGE': 'on_stage',
+        'MICE_THREADS': 'mice_threads',
+        'CONFIDENCE': '_confidence',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 3a: Briefs — parallel fields
+# ============================================================================
+
+def build_brief_parallel_prompt(scene_id: str, scene_text: str,
+                                 profile: dict[str, str],
+                                 skeleton: dict[str, str],
+                                 intent: dict[str, str]) -> str:
+    """Build prompt for Phase 3a: extract brief fields that don't require
+    sequential knowledge tracking."""
+    context = f"""Title: {skeleton.get('title', scene_id)}
+POV: {skeleton.get('pov', 'unknown')}
+Function: {intent.get('function', 'unknown')}
+Scene type: {intent.get('scene_type', 'unknown')}
+Value at stake: {intent.get('value_at_stake', 'unknown')}
+Value shift: {intent.get('value_shift', 'unknown')}
+Emotional arc: {intent.get('emotional_arc', 'unknown')}"""
+
+    return f"""Extract the drafting contract details from this scene — the specific actions, choices, and dialogue that make it work.
+
+## Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line. Use semicolons to separate list items.
+
+GOAL: [the POV character's concrete objective entering this scene — what are they trying to do?]
+CONFLICT: [what specifically opposes the goal?]
+OUTCOME: [how does the scene end for the POV character? Use: yes / no / yes-but / no-and]
+CRISIS: [the key dilemma — a best bad choice or irreconcilable goods that the character faces]
+DECISION: [what the character actively chooses in response to the crisis]
+KEY_ACTIONS: [semicolon-separated concrete things that happen in this scene]
+KEY_DIALOGUE: [semicolon-separated specific lines or exchanges that are essential to the scene — quote directly from the text]
+EMOTIONS: [semicolon-separated emotional beats in sequence as they occur through the scene]
+MOTIFS: [semicolon-separated recurring images, symbols, or sensory details that carry thematic weight]"""
+
+
+def parse_brief_parallel_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 3a response."""
+    result = {'id': scene_id}
+    label_map = {
+        'GOAL': 'goal',
+        'CONFLICT': 'conflict',
+        'OUTCOME': 'outcome',
+        'CRISIS': 'crisis',
+        'DECISION': 'decision',
+        'KEY_ACTIONS': 'key_actions',
+        'KEY_DIALOGUE': 'key_dialogue',
+        'EMOTIONS': 'emotions',
+        'MOTIFS': 'motifs',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 3b: Knowledge chain (sequential)
+# ============================================================================
+
+def build_knowledge_prompt(scene_id: str, scene_text: str,
+                           skeleton: dict[str, str],
+                           intent: dict[str, str],
+                           prior_knowledge: dict[str, str],
+                           prior_scene_summaries: list[str]) -> str:
+    """Build prompt for Phase 3b: extract knowledge_in, knowledge_out, and
+    continuity_deps. Must be called sequentially.
+
+    Args:
+        prior_knowledge: Dict mapping character names to their current
+            knowledge state (accumulated from prior scenes' knowledge_out).
+        prior_scene_summaries: List of "scene_id: one-line summary" for
+            all prior scenes, providing narrative context.
+    """
+    pov = skeleton.get('pov', 'unknown')
+    prior_context = '\n'.join(prior_scene_summaries[-10:]) if prior_scene_summaries else '(first scene)'
+
+    pov_knowledge = prior_knowledge.get(pov, 'No prior knowledge established')
+
+    return f"""Track the knowledge state of the POV character through this scene.
+
+## POV Character: {pov}
+
+## What {pov} knows entering this scene (from prior scenes):
+{pov_knowledge}
+
+## Recent prior scenes (for context):
+{prior_context}
+
+## Scene: {scene_id}
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line.
+
+KNOWLEDGE_IN: [semicolon-separated facts that {pov} knows at the START of this scene — carry forward from prior knowledge above, including only facts relevant to this scene]
+KNOWLEDGE_OUT: [semicolon-separated facts that {pov} knows at the END of this scene — includes knowledge_in plus anything new learned during the scene]
+CONTINUITY_DEPS: [semicolon-separated scene IDs that this scene directly depends on — which prior scenes established facts that this scene uses?]
+SCENE_SUMMARY: [one sentence summarizing what happens in this scene — this will be used as context for subsequent scenes]
+
+IMPORTANT: Use EXACT wording for knowledge facts. If a prior scene established "the eastern readings don't match", use that exact phrase, not a paraphrase. This enables automated validation."""
+
+
+def parse_knowledge_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 3b response."""
+    result = {'id': scene_id}
+    label_map = {
+        'KNOWLEDGE_IN': 'knowledge_in',
+        'KNOWLEDGE_OUT': 'knowledge_out',
+        'CONTINUITY_DEPS': 'continuity_deps',
+        'SCENE_SUMMARY': '_summary',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value:
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Expansion analysis (novella-to-novel)
+# ============================================================================
+
+def analyze_expansion_opportunities(ref_dir: str) -> list[dict]:
+    """Analyze extracted data for expansion opportunities.
+
+    Identifies scenes and structural elements that suggest the work
+    could be expanded. Useful for novella-to-novel development.
+
+    Returns a list of opportunity dicts with:
+      - type: compressed_scene | knowledge_jump | timeline_gap |
+              thin_thread | underused_character | missing_sequel
+      - scene_id: affected scene(s)
+      - description: what the opportunity is
+      - priority: high / medium / low
+    """
+    from .elaborate import _read_csv_as_map
+
+    scenes_map = _read_csv_as_map(os.path.join(ref_dir, 'scenes.csv'))
+    intent_map = _read_csv_as_map(os.path.join(ref_dir, 'scene-intent.csv'))
+    briefs_map = _read_csv_as_map(os.path.join(ref_dir, 'scene-briefs.csv'))
+
+    opportunities = []
+    sorted_ids = sorted(scenes_map.keys(),
+                        key=lambda s: int(scenes_map[s].get('seq', 0)))
+
+    # 1. Compressed scenes: low word count relative to function importance
+    for sid in sorted_ids:
+        scene = scenes_map[sid]
+        wc = int(scene.get('word_count', 0) or 0)
+        intent = intent_map.get(sid, {})
+        vs = intent.get('value_shift', '')
+
+        # Major value shifts in under 1000 words suggest compression
+        if wc > 0 and wc < 1000 and vs and '/' in vs:
+            parts = vs.split('/')
+            if parts[0].strip() != parts[1].strip():
+                opportunities.append({
+                    'type': 'compressed_scene',
+                    'scene_id': sid,
+                    'description': f"Scene has major value shift ({vs}) in only {wc} words — may need expansion",
+                    'priority': 'high' if wc < 500 else 'medium',
+                })
+
+    # 2. Knowledge jumps: large knowledge_out minus knowledge_in
+    for sid in sorted_ids:
+        brief = briefs_map.get(sid, {})
+        k_in = brief.get('knowledge_in', '').strip()
+        k_out = brief.get('knowledge_out', '').strip()
+        if k_in and k_out:
+            in_facts = {f.strip() for f in k_in.split(';') if f.strip()}
+            out_facts = {f.strip() for f in k_out.split(';') if f.strip()}
+            new_facts = out_facts - in_facts
+            if len(new_facts) >= 3:
+                opportunities.append({
+                    'type': 'knowledge_jump',
+                    'scene_id': sid,
+                    'description': f"Character learns {len(new_facts)} new facts in one scene — may need multiple scenes to earn these revelations",
+                    'priority': 'high' if len(new_facts) >= 5 else 'medium',
+                })
+
+    # 3. Timeline gaps
+    prev_day = None
+    prev_id = None
+    for sid in sorted_ids:
+        day_str = scenes_map[sid].get('timeline_day', '').strip()
+        if not day_str:
+            continue
+        try:
+            day = int(day_str)
+        except ValueError:
+            continue
+        if prev_day is not None and day - prev_day > 2:
+            opportunities.append({
+                'type': 'timeline_gap',
+                'scene_id': f"{prev_id}→{sid}",
+                'description': f"Gap of {day - prev_day} days between scenes — bridging scenes may be needed",
+                'priority': 'medium' if day - prev_day <= 7 else 'high',
+            })
+        prev_day = day
+        prev_id = sid
+
+    # 4. Thin threads: appear in only 1-2 scenes
+    thread_counts: dict[str, list[str]] = {}
+    for sid in sorted_ids:
+        intent = intent_map.get(sid, {})
+        threads = intent.get('threads', '').strip()
+        if threads:
+            for t in threads.split(';'):
+                t = t.strip()
+                if t:
+                    thread_counts.setdefault(t, []).append(sid)
+
+    for thread, scene_ids in thread_counts.items():
+        if len(scene_ids) <= 2:
+            opportunities.append({
+                'type': 'thin_thread',
+                'scene_id': ';'.join(scene_ids),
+                'description': f"Thread '{thread}' appears in only {len(scene_ids)} scene(s) — may be underdeveloped",
+                'priority': 'medium',
+            })
+
+    # 5. Missing sequels: action scenes without a following sequel
+    for i, sid in enumerate(sorted_ids[:-1]):
+        intent = intent_map.get(sid, {})
+        next_intent = intent_map.get(sorted_ids[i + 1], {})
+        if intent.get('scene_type') == 'action' and next_intent.get('scene_type') == 'action':
+            opportunities.append({
+                'type': 'missing_sequel',
+                'scene_id': sid,
+                'description': f"Action scene followed by another action scene — reaction/processing beat may be needed between {sid} and {sorted_ids[i+1]}",
+                'priority': 'low',
+            })
+
+    # Sort by priority
+    priority_order = {'high': 0, 'medium': 1, 'low': 2}
+    opportunities.sort(key=lambda o: priority_order.get(o['priority'], 3))
+
+    return opportunities
+```
+
+Write this to `scripts/lib/python/storyforge/extract.py`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/extract.py
+git commit -m "Add extraction prompt builders and parsers for reverse elaboration"
+```
+
+---
+
+## Task 2: Tests for extraction helpers
+
+**Files:**
+- Create: `tests/test-extract.sh`
+
+- [ ] **Step 1: Write tests for response parsers and expansion analysis**
+
+```bash
+#!/bin/bash
+# test-extract.sh — Tests for reverse elaboration extraction helpers
+
+PY="import sys; sys.path.insert(0, '${PLUGIN_DIR}/scripts/lib/python'"
+
+# ============================================================================
+# parse_characterize_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import parse_characterize_response
+response = '''NARRATIVE_MODE: third-limited
+POV_CHARACTERS: Dorren Hayle;Tessa Merrin
+TIMELINE: linear
+TIMELINE_SPAN: 3 weeks
+SCENE_BREAK_STYLE: explicit-markers
+ESTIMATED_SCENES: 42
+MAJOR_THREADS: institutional-failure;chosen-blindness;the-anomaly
+CENTRAL_CONFLICT: A cartographer must choose between institutional loyalty and truth
+CAST_SIZE: 12'''
+result = parse_characterize_response(response)
+print(result.get('narrative_mode', ''))
+print(result.get('pov_characters', ''))
+print(result.get('estimated_scenes', ''))
+print(result.get('major_threads', ''))
+")
+
+assert_contains "$RESULT" "third-limited" "parse_characterize: extracts narrative mode"
+assert_contains "$RESULT" "Dorren Hayle;Tessa Merrin" "parse_characterize: extracts POV characters"
+assert_contains "$RESULT" "42" "parse_characterize: extracts scene count"
+assert_contains "$RESULT" "institutional-failure" "parse_characterize: extracts threads"
+
+# ============================================================================
+# parse_skeleton_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import parse_skeleton_response
+response = '''TITLE: The Arranged Dead
+POV: Emmett Slade
+LOCATION: Alkali Flat
+TIMELINE_DAY: 1
+TIME_OF_DAY: afternoon
+DURATION: 2 hours
+TARGET_WORDS: 1300
+PART: 1'''
+result = parse_skeleton_response(response, 'arranged-dead')
+print(result.get('id', ''))
+print(result.get('title', ''))
+print(result.get('pov', ''))
+print(result.get('timeline_day', ''))
+print(result.get('part', ''))
+")
+
+assert_equals "arranged-dead" "$(echo "$RESULT" | head -1)" "parse_skeleton: preserves scene id"
+assert_contains "$RESULT" "The Arranged Dead" "parse_skeleton: extracts title"
+assert_contains "$RESULT" "Emmett Slade" "parse_skeleton: extracts POV"
+
+# ============================================================================
+# parse_intent_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import parse_intent_response
+response = '''FUNCTION: Emmett reads the staged crime scene and connects the murder to a disappearance
+SCENE_TYPE: action
+EMOTIONAL_ARC: Professional detachment to resolved determination
+VALUE_AT_STAKE: truth
+VALUE_SHIFT: +/-
+TURNING_POINT: revelation
+THREADS: murder-investigation;land-fraud
+CHARACTERS: Emmett Slade;Samuel Orcutt;Colson
+ON_STAGE: Emmett Slade;Colson
+MICE_THREADS: +inquiry:who-killed-orcutt
+CONFIDENCE: high'''
+result = parse_intent_response(response, 'arranged-dead')
+print(result.get('function', ''))
+print(result.get('scene_type', ''))
+print(result.get('value_shift', ''))
+print(result.get('threads', ''))
+print(result.get('_confidence', ''))
+")
+
+assert_contains "$RESULT" "staged crime scene" "parse_intent: extracts function"
+assert_contains "$RESULT" "action" "parse_intent: extracts scene type"
+assert_contains "$RESULT" "+/-" "parse_intent: extracts value shift"
+assert_contains "$RESULT" "murder-investigation" "parse_intent: extracts threads"
+assert_contains "$RESULT" "high" "parse_intent: extracts confidence"
+
+# ============================================================================
+# parse_brief_parallel_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import parse_brief_parallel_response
+response = '''GOAL: Determine cause of death and establish whether it's murder
+CONFLICT: The crime scene has been deliberately staged to look accidental
+OUTCOME: no-and
+CRISIS: Report the staging and alert the territorial marshal, or investigate quietly
+DECISION: Investigates quietly — keeps the staging knowledge to himself
+KEY_ACTIONS: Examines body;Notes staged positioning;Finds survey equipment;Interviews Colson
+KEY_DIALOGUE: \"The body was found like this?\";\"Exactly like this, Sheriff\"
+EMOTIONS: professional-calm;suspicion;recognition;quiet-resolve
+MOTIFS: arranged-bodies;survey-equipment;patience'''
+result = parse_brief_parallel_response(response, 'arranged-dead')
+print(result.get('goal', ''))
+print(result.get('outcome', ''))
+print(result.get('crisis', ''))
+")
+
+assert_contains "$RESULT" "cause of death" "parse_brief: extracts goal"
+assert_contains "$RESULT" "no-and" "parse_brief: extracts outcome"
+assert_contains "$RESULT" "Report the staging" "parse_brief: extracts crisis"
+
+# ============================================================================
+# parse_knowledge_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import parse_knowledge_response
+response = '''KNOWLEDGE_IN: Orcutt was found dead at the alkali flat
+KNOWLEDGE_OUT: Orcutt was found dead at the alkali flat;the body was deliberately staged;survey equipment was present at the scene
+CONTINUITY_DEPS: discovery-at-flat
+SCENE_SUMMARY: Emmett examines the staged crime scene and decides to investigate quietly'''
+result = parse_knowledge_response(response, 'arranged-dead')
+print(result.get('knowledge_in', ''))
+print(result.get('knowledge_out', ''))
+print(result.get('continuity_deps', ''))
+print(result.get('_summary', ''))
+")
+
+assert_contains "$RESULT" "Orcutt was found dead" "parse_knowledge: extracts knowledge_in"
+assert_contains "$RESULT" "deliberately staged" "parse_knowledge: extracts knowledge_out"
+assert_contains "$RESULT" "discovery-at-flat" "parse_knowledge: extracts continuity_deps"
+assert_contains "$RESULT" "examines the staged" "parse_knowledge: extracts summary"
+
+# ============================================================================
+# analyze_expansion_opportunities
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import analyze_expansion_opportunities
+import json
+opps = analyze_expansion_opportunities('${FIXTURE_DIR}/reference')
+for o in opps:
+    print(f\"{o['type']}: {o['priority']} — {o['scene_id']}\")
+")
+
+# Fixture has scenes — check that analysis runs without error
+assert_not_empty "$RESULT" "analyze_expansion: produces output"
+
+# ============================================================================
+# build_characterize_prompt
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY})
+from storyforge.extract import build_characterize_prompt
+prompt = build_characterize_prompt('${FIXTURE_DIR}')
+print(len(prompt))
+")
+
+# Fixtures have scene files, so prompt should be non-empty
+assert_not_empty "$RESULT" "build_characterize: produces non-empty prompt"
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+./tests/run-tests.sh tests/test-extract.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test-extract.sh
+git commit -m "Add tests for extraction parsers and expansion analysis"
+```
+
+---
+
+## Task 3: The `storyforge-extract` CLI script
+
+**Files:**
+- Create: `scripts/storyforge-extract`
+
+The script orchestrates all four phases. Each phase produces output, commits, and the next phase reads from the committed data.
+
+Key design decisions:
+- Phase 0 uses Opus (full manuscript comprehension)
+- Phases 1-2 use batch API with Sonnet (parallel, structured extraction)
+- Phase 3a uses batch API with Sonnet (parallel)
+- Phase 3b uses direct API with Sonnet (sequential — each scene needs prior knowledge state)
+- Each phase commits its results before the next phase starts
+- `--phase 0|1|2|3` flag allows running individual phases
+- `--dry-run` prints prompts without invoking
+- Expansion analysis runs after Phase 3 completes
+
+The script follows the same patterns as storyforge-enrich and storyforge-elaborate: source common.sh, detect_project_root, create_branch, create_draft_pr, batch submission, result processing, commit per phase, run_review_phase at end.
+
+---
+
+## Task 4: The `extract` skill
+
+**Files:**
+- Create: `skills/extract/SKILL.md`
+
+Interactive skill that guides the author through extraction. Offers:
+- Full extraction (all phases) — delegates to the script
+- Phase-by-phase with review between phases
+- Expansion analysis for novella-to-novel work
+- Review and correction of extracted data
+
+Coaching levels:
+- Full: Run extraction autonomously, present results for review
+- Coach: Run extraction, walk through results with author, discuss concerns
+- Strict: Run extraction, present raw data for author correction
+
+---
+
+## Task 5: Add expansion analysis to elaborate.py
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/elaborate.py`
+
+Add an `analyze_expansion` function that wraps the extraction module's expansion analysis and formats it as a validation-style report.
+
+---
+
+## Task 6: Tests, version bump, final verification
+
+- [ ] Run full test suite
+- [ ] Bump version to 0.44.0
+- [ ] Commit and push
+- [ ] Create PR

--- a/scripts/lib/python/storyforge/extract.py
+++ b/scripts/lib/python/storyforge/extract.py
@@ -1,0 +1,509 @@
+"""Reverse elaboration — extract structural data from existing prose.
+
+Four extraction phases:
+  Phase 0: Characterize (full manuscript → manuscript profile)
+  Phase 1: Skeleton (per scene → scenes.csv fields)
+  Phase 2: Intent (per scene, parallel → scene-intent.csv fields)
+  Phase 3: Briefs (per scene, knowledge chain sequential → scene-briefs.csv fields)
+"""
+
+import json
+import os
+import re
+from typing import Any
+
+from .prompts import read_yaml_field
+
+
+def _read_file(path: str) -> str:
+    if not os.path.isfile(path):
+        return ''
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+def _read_all_scenes(project_dir: str) -> dict[str, str]:
+    """Read all scene files, returning {scene_id: prose_text}."""
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    if not os.path.isdir(scenes_dir):
+        return {}
+    result = {}
+    for fname in sorted(os.listdir(scenes_dir)):
+        if fname.endswith('.md'):
+            scene_id = fname[:-3]
+            with open(os.path.join(scenes_dir, fname), encoding='utf-8') as f:
+                result[scene_id] = f.read()
+    return result
+
+
+def _read_manuscript(project_dir: str) -> str:
+    """Read the full manuscript by concatenating scene files in seq order."""
+    scenes = _read_all_scenes(project_dir)
+    if not scenes:
+        return ''
+
+    # Try to order by seq from scenes.csv or scene-metadata.csv
+    ref_dir = os.path.join(project_dir, 'reference')
+    seq_order = {}
+    for csv_name in ['scenes.csv', 'scene-metadata.csv']:
+        csv_path = os.path.join(ref_dir, csv_name)
+        if os.path.isfile(csv_path):
+            with open(csv_path, encoding='utf-8') as f:
+                lines = [l.strip() for l in f if l.strip()]
+            if len(lines) > 1:
+                header = lines[0].split('|')
+                id_idx = header.index('id') if 'id' in header else 0
+                seq_idx = header.index('seq') if 'seq' in header else 1
+                for line in lines[1:]:
+                    fields = line.split('|')
+                    if len(fields) > max(id_idx, seq_idx):
+                        try:
+                            seq_order[fields[id_idx]] = int(fields[seq_idx])
+                        except (ValueError, IndexError):
+                            pass
+            break
+
+    if seq_order:
+        ordered = sorted(scenes.keys(), key=lambda s: seq_order.get(s, 999))
+    else:
+        ordered = sorted(scenes.keys())
+
+    parts = []
+    for sid in ordered:
+        parts.append(f"=== SCENE: {sid} ===\n\n{scenes[sid]}")
+    return '\n\n'.join(parts)
+
+
+# ============================================================================
+# Phase 0: Characterize
+# ============================================================================
+
+def build_characterize_prompt(project_dir: str) -> str:
+    """Build prompt for Phase 0: manuscript characterization."""
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    title = read_yaml_field(yaml_path, 'project.title') or 'Untitled'
+    genre = read_yaml_field(yaml_path, 'project.genre') or ''
+
+    manuscript = _read_manuscript(project_dir)
+    if not manuscript:
+        return ''
+
+    # Truncate if extremely long — Phase 0 needs the shape, not every word
+    if len(manuscript) > 200000:
+        manuscript = manuscript[:200000] + '\n\n[...truncated for characterization...]'
+
+    return f"""You are analyzing a manuscript to characterize its structure before detailed extraction.
+
+## Project
+**Title:** {title}
+**Genre:** {genre}
+
+## Manuscript
+
+{manuscript}
+
+## Instructions
+
+Analyze this manuscript and produce a structural profile. Output each field on its own labeled line.
+
+NARRATIVE_MODE: [first-person / third-limited / third-omniscient / multiple-POV / other]
+POV_CHARACTERS: [semicolon-separated list of POV characters, in order of appearance]
+TIMELINE: [linear / non-linear / fragmented / frame-narrative]
+TIMELINE_SPAN: [approximate time span of the story, e.g., "3 days", "6 months", "20 years"]
+SCENE_BREAK_STYLE: [explicit-markers / chapter-based / unmarked / mixed]
+ESTIMATED_SCENES: [approximate number of distinct scenes]
+ACT_STRUCTURE: [number of acts/parts and their approximate boundaries, e.g., "3 acts: scenes 1-12, 13-28, 29-42"]
+MAJOR_THREADS: [semicolon-separated list of major story threads/subplots]
+CENTRAL_CONFLICT: [one sentence describing the core conflict]
+PROTAGONIST_ARC: [one sentence: wound/lie → confrontation → resolution/refusal]
+TONE: [1-3 words describing the overall tone]
+CAST_SIZE: [approximate number of named characters]
+KEY_LOCATIONS: [semicolon-separated list of major locations]
+COMPRESSION_POINTS: [semicolon-separated list of moments that feel compressed or rushed — these are expansion opportunities if the work is being developed into a longer form]
+STRUCTURAL_CONCERNS: [semicolon-separated list of any structural issues visible at this level — dropped threads, pacing problems, arc gaps]
+
+Be precise. Base every field on what's actually in the text, not what you'd expect from the genre."""
+
+
+def parse_characterize_response(response: str) -> dict[str, str]:
+    """Parse the Phase 0 characterization response into a dict."""
+    result = {}
+    for line in response.split('\n'):
+        line = line.strip()
+        if ':' not in line:
+            continue
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line)
+        if match:
+            key = match.group(1).lower()
+            value = match.group(2).strip()
+            if value and value not in ('[]', '()', 'N/A', 'none'):
+                result[key] = value
+    return result
+
+
+# ============================================================================
+# Phase 1: Skeleton (scenes.csv fields)
+# ============================================================================
+
+def build_skeleton_prompt(scene_id: str, scene_text: str,
+                          profile: dict[str, str],
+                          existing_metadata: dict[str, str] | None = None) -> str:
+    """Build prompt for Phase 1: extract scenes.csv fields from a single scene."""
+    context = f"""POV characters in this manuscript: {profile.get('pov_characters', 'unknown')}
+Timeline: {profile.get('timeline', 'unknown')}
+Key locations: {profile.get('key_locations', 'unknown')}"""
+
+    existing = ''
+    if existing_metadata:
+        known = {k: v for k, v in existing_metadata.items() if v and k != 'id'}
+        if known:
+            existing = "Already known about this scene:\n" + '\n'.join(
+                f"  {k}: {v}" for k, v in known.items())
+
+    return f"""Extract structural metadata from this scene.
+
+## Manuscript Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+{existing}
+
+## Instructions
+
+Output each field on its own labeled line. If a value cannot be determined, output UNKNOWN.
+
+TITLE: [a short evocative title for this scene, 3-7 words]
+POV: [the POV character's full name]
+LOCATION: [the primary physical location — use a consistent canonical name]
+TIMELINE_DAY: [integer day number within the story chronology, starting from 1]
+TIME_OF_DAY: [morning / afternoon / evening / night / dawn / dusk]
+DURATION: [approximate in-story duration, e.g., "2 hours", "30 minutes", "an afternoon"]
+TARGET_WORDS: [current word count is a reasonable target — output the approximate word count]
+PART: [which act/part number this scene belongs to, based on its position in the story]"""
+
+
+def parse_skeleton_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 1 response into scenes.csv field values."""
+    result = {'id': scene_id}
+    label_map = {
+        'TITLE': 'title',
+        'POV': 'pov',
+        'LOCATION': 'location',
+        'TIMELINE_DAY': 'timeline_day',
+        'TIME_OF_DAY': 'time_of_day',
+        'DURATION': 'duration',
+        'TARGET_WORDS': 'target_words',
+        'PART': 'part',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 2: Intent (scene-intent.csv fields)
+# ============================================================================
+
+def build_intent_prompt(scene_id: str, scene_text: str,
+                        profile: dict[str, str],
+                        skeleton: dict[str, str]) -> str:
+    """Build prompt for Phase 2: extract scene-intent.csv fields."""
+    context = f"""Title: {skeleton.get('title', scene_id)}
+POV: {skeleton.get('pov', 'unknown')}
+Location: {skeleton.get('location', 'unknown')}
+Part: {skeleton.get('part', 'unknown')}
+Major threads in this manuscript: {profile.get('major_threads', 'unknown')}
+Central conflict: {profile.get('central_conflict', 'unknown')}"""
+
+    return f"""Extract the narrative intent and dynamics from this scene.
+
+## Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line. Use semicolons to separate list items.
+
+FUNCTION: [one sentence: why this scene exists — what it accomplishes in the story. Must be specific and testable, not vague like "develops character"]
+SCENE_TYPE: [action or sequel — action scenes have goal/conflict/outcome; sequel scenes have reaction/dilemma/decision]
+EMOTIONAL_ARC: [starting emotion giving way to ending emotion, e.g., "controlled competence to buried unease"]
+VALUE_AT_STAKE: [the abstract value being tested: safety, love, justice, truth, freedom, honor, etc.]
+VALUE_SHIFT: [polarity change using +/- notation: +/- means positive to negative, -/+ means negative to positive, +/++ means good to better, -/-- means bad to worse]
+TURNING_POINT: [action or revelation — action means a character does something that changes the situation; revelation means new information changes the situation]
+THREADS: [semicolon-separated story threads this scene advances]
+CHARACTERS: [semicolon-separated list of ALL characters present or referenced by name]
+ON_STAGE: [semicolon-separated list of characters physically present in the scene — subset of CHARACTERS]
+MICE_THREADS: [semicolon-separated MICE thread operations — +milieu:location-name to open, -inquiry:question to close, etc. Use + for opening, - for closing. Types: milieu, inquiry, character, event]
+CONFIDENCE: [high / medium / low — your overall confidence in these extractions]"""
+
+
+def parse_intent_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 2 response into scene-intent.csv field values."""
+    result = {'id': scene_id}
+    label_map = {
+        'FUNCTION': 'function',
+        'SCENE_TYPE': 'scene_type',
+        'EMOTIONAL_ARC': 'emotional_arc',
+        'VALUE_AT_STAKE': 'value_at_stake',
+        'VALUE_SHIFT': 'value_shift',
+        'TURNING_POINT': 'turning_point',
+        'THREADS': 'threads',
+        'CHARACTERS': 'characters',
+        'ON_STAGE': 'on_stage',
+        'MICE_THREADS': 'mice_threads',
+        'CONFIDENCE': '_confidence',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 3a: Briefs — parallel fields
+# ============================================================================
+
+def build_brief_parallel_prompt(scene_id: str, scene_text: str,
+                                 profile: dict[str, str],
+                                 skeleton: dict[str, str],
+                                 intent: dict[str, str]) -> str:
+    """Build prompt for Phase 3a: extract brief fields that don't require
+    sequential knowledge tracking."""
+    context = f"""Title: {skeleton.get('title', scene_id)}
+POV: {skeleton.get('pov', 'unknown')}
+Function: {intent.get('function', 'unknown')}
+Scene type: {intent.get('scene_type', 'unknown')}
+Value at stake: {intent.get('value_at_stake', 'unknown')}
+Value shift: {intent.get('value_shift', 'unknown')}
+Emotional arc: {intent.get('emotional_arc', 'unknown')}"""
+
+    return f"""Extract the drafting contract details from this scene — the specific actions, choices, and dialogue that make it work.
+
+## Context
+{context}
+
+## Scene: {scene_id}
+
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line. Use semicolons to separate list items.
+
+GOAL: [the POV character's concrete objective entering this scene — what are they trying to do?]
+CONFLICT: [what specifically opposes the goal?]
+OUTCOME: [how does the scene end for the POV character? Use: yes / no / yes-but / no-and]
+CRISIS: [the key dilemma — a best bad choice or irreconcilable goods that the character faces]
+DECISION: [what the character actively chooses in response to the crisis]
+KEY_ACTIONS: [semicolon-separated concrete things that happen in this scene]
+KEY_DIALOGUE: [semicolon-separated specific lines or exchanges that are essential to the scene — quote directly from the text]
+EMOTIONS: [semicolon-separated emotional beats in sequence as they occur through the scene]
+MOTIFS: [semicolon-separated recurring images, symbols, or sensory details that carry thematic weight]"""
+
+
+def parse_brief_parallel_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 3a response."""
+    result = {'id': scene_id}
+    label_map = {
+        'GOAL': 'goal',
+        'CONFLICT': 'conflict',
+        'OUTCOME': 'outcome',
+        'CRISIS': 'crisis',
+        'DECISION': 'decision',
+        'KEY_ACTIONS': 'key_actions',
+        'KEY_DIALOGUE': 'key_dialogue',
+        'EMOTIONS': 'emotions',
+        'MOTIFS': 'motifs',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value and value.upper() != 'UNKNOWN':
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Phase 3b: Knowledge chain (sequential)
+# ============================================================================
+
+def build_knowledge_prompt(scene_id: str, scene_text: str,
+                           skeleton: dict[str, str],
+                           intent: dict[str, str],
+                           prior_knowledge: dict[str, str],
+                           prior_scene_summaries: list[str]) -> str:
+    """Build prompt for Phase 3b: extract knowledge_in, knowledge_out, and
+    continuity_deps. Must be called sequentially."""
+    pov = skeleton.get('pov', 'unknown')
+    prior_context = '\n'.join(prior_scene_summaries[-10:]) if prior_scene_summaries else '(first scene)'
+    pov_knowledge = prior_knowledge.get(pov, 'No prior knowledge established')
+
+    return f"""Track the knowledge state of the POV character through this scene.
+
+## POV Character: {pov}
+
+## What {pov} knows entering this scene (from prior scenes):
+{pov_knowledge}
+
+## Recent prior scenes (for context):
+{prior_context}
+
+## Scene: {scene_id}
+{scene_text}
+
+## Instructions
+
+Output each field on its own labeled line.
+
+KNOWLEDGE_IN: [semicolon-separated facts that {pov} knows at the START of this scene — carry forward from prior knowledge above, including only facts relevant to this scene]
+KNOWLEDGE_OUT: [semicolon-separated facts that {pov} knows at the END of this scene — includes knowledge_in plus anything new learned during the scene]
+CONTINUITY_DEPS: [semicolon-separated scene IDs that this scene directly depends on — which prior scenes established facts that this scene uses?]
+SCENE_SUMMARY: [one sentence summarizing what happens in this scene — this will be used as context for subsequent scenes]
+
+IMPORTANT: Use EXACT wording for knowledge facts. If a prior scene established "the eastern readings don't match", use that exact phrase, not a paraphrase. This enables automated validation."""
+
+
+def parse_knowledge_response(response: str, scene_id: str) -> dict[str, str]:
+    """Parse Phase 3b response."""
+    result = {'id': scene_id}
+    label_map = {
+        'KNOWLEDGE_IN': 'knowledge_in',
+        'KNOWLEDGE_OUT': 'knowledge_out',
+        'CONTINUITY_DEPS': 'continuity_deps',
+        'SCENE_SUMMARY': '_summary',
+    }
+    for line in response.split('\n'):
+        match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
+        if match:
+            label = match.group(1)
+            value = match.group(2).strip()
+            if label in label_map and value:
+                result[label_map[label]] = value
+    return result
+
+
+# ============================================================================
+# Expansion analysis (novella-to-novel)
+# ============================================================================
+
+def analyze_expansion_opportunities(ref_dir: str) -> list[dict]:
+    """Analyze extracted data for expansion opportunities.
+
+    Returns a list of opportunity dicts with type, scene_id, description, priority.
+    """
+    from .elaborate import _read_csv_as_map
+
+    scenes_map = _read_csv_as_map(os.path.join(ref_dir, 'scenes.csv'))
+    intent_map = _read_csv_as_map(os.path.join(ref_dir, 'scene-intent.csv'))
+    briefs_map = _read_csv_as_map(os.path.join(ref_dir, 'scene-briefs.csv'))
+
+    opportunities = []
+    sorted_ids = sorted(scenes_map.keys(),
+                        key=lambda s: int(scenes_map[s].get('seq', 0)))
+
+    # Compressed scenes: major value shift in under 1000 words
+    for sid in sorted_ids:
+        scene = scenes_map[sid]
+        wc = int(scene.get('word_count', 0) or 0)
+        intent = intent_map.get(sid, {})
+        vs = intent.get('value_shift', '')
+        if wc > 0 and wc < 1000 and vs and '/' in vs:
+            parts = vs.split('/')
+            if parts[0].strip() != parts[1].strip():
+                opportunities.append({
+                    'type': 'compressed_scene',
+                    'scene_id': sid,
+                    'description': f"Major value shift ({vs}) in only {wc} words",
+                    'priority': 'high' if wc < 500 else 'medium',
+                })
+
+    # Knowledge jumps: 3+ new facts in one scene
+    for sid in sorted_ids:
+        brief = briefs_map.get(sid, {})
+        k_in = brief.get('knowledge_in', '').strip()
+        k_out = brief.get('knowledge_out', '').strip()
+        if k_in and k_out:
+            in_facts = {f.strip() for f in k_in.split(';') if f.strip()}
+            out_facts = {f.strip() for f in k_out.split(';') if f.strip()}
+            new_facts = out_facts - in_facts
+            if len(new_facts) >= 3:
+                opportunities.append({
+                    'type': 'knowledge_jump',
+                    'scene_id': sid,
+                    'description': f"Character learns {len(new_facts)} new facts in one scene",
+                    'priority': 'high' if len(new_facts) >= 5 else 'medium',
+                })
+
+    # Timeline gaps: more than 2 days between consecutive scenes
+    prev_day = None
+    prev_id = None
+    for sid in sorted_ids:
+        day_str = scenes_map[sid].get('timeline_day', '').strip()
+        if not day_str:
+            continue
+        try:
+            day = int(day_str)
+        except ValueError:
+            continue
+        if prev_day is not None and day - prev_day > 2:
+            opportunities.append({
+                'type': 'timeline_gap',
+                'scene_id': f"{prev_id}→{sid}",
+                'description': f"Gap of {day - prev_day} days between scenes",
+                'priority': 'medium' if day - prev_day <= 7 else 'high',
+            })
+        prev_day = day
+        prev_id = sid
+
+    # Thin threads: appear in only 1-2 scenes
+    thread_counts: dict[str, list[str]] = {}
+    for sid in sorted_ids:
+        intent = intent_map.get(sid, {})
+        threads = intent.get('threads', '').strip()
+        if threads:
+            for t in threads.split(';'):
+                t = t.strip()
+                if t:
+                    thread_counts.setdefault(t, []).append(sid)
+    for thread, sids in thread_counts.items():
+        if len(sids) <= 2:
+            opportunities.append({
+                'type': 'thin_thread',
+                'scene_id': ';'.join(sids),
+                'description': f"Thread '{thread}' appears in only {len(sids)} scene(s)",
+                'priority': 'medium',
+            })
+
+    # Missing sequels: consecutive action scenes
+    for i, sid in enumerate(sorted_ids[:-1]):
+        intent = intent_map.get(sid, {})
+        next_intent = intent_map.get(sorted_ids[i + 1], {})
+        if intent.get('scene_type') == 'action' and next_intent.get('scene_type') == 'action':
+            opportunities.append({
+                'type': 'missing_sequel',
+                'scene_id': sid,
+                'description': f"Action scene followed by action — reaction beat may be needed between {sid} and {sorted_ids[i+1]}",
+                'priority': 'low',
+            })
+
+    priority_order = {'high': 0, 'medium': 1, 'low': 2}
+    opportunities.sort(key=lambda o: priority_order.get(o['priority'], 3))
+    return opportunities

--- a/scripts/storyforge-extract
+++ b/scripts/storyforge-extract
@@ -1,0 +1,679 @@
+#!/bin/bash
+# storyforge-extract — Extract structural data from existing prose
+#
+# Usage:
+#   ./storyforge extract                        # Run all phases
+#   ./storyforge extract --phase 0              # Characterize only
+#   ./storyforge extract --phase 1              # Skeleton only
+#   ./storyforge extract --phase 2              # Intent only (needs phase 1)
+#   ./storyforge extract --phase 3              # Briefs only (needs phases 1-2)
+#   ./storyforge extract --expand               # Run expansion analysis after extraction
+#   ./storyforge extract --dry-run              # Print prompts without invoking
+#
+# Extracts structural data from scene prose into the three-file CSV model:
+#   scenes.csv, scene-intent.csv, scene-briefs.csv
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/lib"
+PYTHON_LIB="${SCRIPT_DIR}/lib/python"
+
+source "${LIB_DIR}/common.sh"
+detect_project_root
+
+LOG_DIR="${PROJECT_DIR}/working/logs"
+mkdir -p "$LOG_DIR"
+
+# ============================================================================
+# Arguments
+# ============================================================================
+
+PHASE=""  # empty = all phases
+DRY_RUN=false
+EXPAND=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --phase N         Run only phase N (0=characterize, 1=skeleton, 2=intent, 3=briefs)
+  --expand          Run expansion analysis after extraction
+  --dry-run         Print prompts without invoking Claude
+  -h, --help        Show this help
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --phase)   PHASE="${2:?ERROR: --phase requires a value}"; shift 2 ;;
+        --expand)  EXPAND=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help) usage ;;
+        -*)        echo "ERROR: Unknown option: $1" >&2; usage ;;
+        *)         shift ;;
+    esac
+done
+
+if [[ "$DRY_RUN" != true && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    log "ERROR: ANTHROPIC_API_KEY not set. Required for extraction."
+    exit 1
+fi
+
+# ============================================================================
+# Project info
+# ============================================================================
+
+PROJECT_TITLE=$(read_yaml_field "project.title" 2>/dev/null || echo "Untitled")
+REF_DIR="${PROJECT_DIR}/reference"
+SCENES_DIR="${PROJECT_DIR}/scenes"
+PLUGIN_DIR="${SCRIPT_DIR}/.."
+
+# Check for scene files
+SCENE_COUNT=$(ls "${SCENES_DIR}"/*.md 2>/dev/null | wc -l | tr -d ' ')
+if (( SCENE_COUNT == 0 )); then
+    log "ERROR: No scene files found in ${SCENES_DIR}/"
+    log "  Split your manuscript into scenes first using /storyforge:scenes (setup mode)"
+    exit 1
+fi
+
+log "============================================"
+log "Storyforge Extract"
+log "Project: ${PROJECT_TITLE}"
+log "Scenes: ${SCENE_COUNT}"
+log "============================================"
+
+# ============================================================================
+# Branch and PR
+# ============================================================================
+
+if [[ "$DRY_RUN" != true ]]; then
+    create_branch "extract" "$PROJECT_DIR"
+    ensure_branch_pushed "$PROJECT_DIR"
+
+    PR_BODY="## Extraction: Reverse Elaboration
+
+**Project:** ${PROJECT_TITLE}
+**Scenes:** ${SCENE_COUNT}
+
+### Tasks
+- [ ] Phase 0: Characterize manuscript
+- [ ] Phase 1: Extract skeleton (scenes.csv)
+- [ ] Phase 2: Extract intent (scene-intent.csv)
+- [ ] Phase 3: Extract briefs (scene-briefs.csv)
+- [ ] Validate
+- [ ] Review"
+
+    create_draft_pr "Extract: ${PROJECT_TITLE} (${SCENE_COUNT} scenes)" "$PR_BODY" "$PROJECT_DIR" "extraction"
+fi
+
+# ============================================================================
+# Scene list
+# ============================================================================
+
+SCENE_IDS=()
+for f in "${SCENES_DIR}"/*.md; do
+    [[ -f "$f" ]] || continue
+    SCENE_IDS+=("$(basename "$f" .md)")
+done
+
+# Sort by seq if CSV exists
+SORTED_IDS=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import os, sys
+sys.path.insert(0, '${PYTHON_LIB}')
+
+ref_dir = '${REF_DIR}'
+scene_ids = '''$(printf '%s\n' "${SCENE_IDS[@]}")'''.strip().split('\n')
+
+# Try to read seq from existing CSV
+seq_map = {}
+for csv_name in ['scenes.csv', 'scene-metadata.csv']:
+    csv_path = os.path.join(ref_dir, csv_name)
+    if os.path.isfile(csv_path):
+        with open(csv_path) as f:
+            lines = [l.strip() for l in f if l.strip()]
+        if len(lines) > 1:
+            header = lines[0].split('|')
+            id_idx = header.index('id') if 'id' in header else 0
+            seq_idx = header.index('seq') if 'seq' in header else 1
+            for line in lines[1:]:
+                fields = line.split('|')
+                if len(fields) > max(id_idx, seq_idx):
+                    try:
+                        seq_map[fields[id_idx]] = int(fields[seq_idx])
+                    except (ValueError, IndexError):
+                        pass
+        break
+
+# Sort: by seq if available, else alphabetically
+if seq_map:
+    scene_ids.sort(key=lambda s: seq_map.get(s, 999))
+else:
+    scene_ids.sort()
+
+for sid in scene_ids:
+    print(sid)
+" 2>/dev/null)
+
+readarray -t SORTED_SCENE_IDS <<< "$SORTED_IDS"
+
+# ============================================================================
+# Phase 0: Characterize
+# ============================================================================
+
+PROFILE_FILE="${PROJECT_DIR}/working/extraction-profile.json"
+
+if [[ -z "$PHASE" || "$PHASE" == "0" ]]; then
+    log ""
+    log "--- Phase 0: Characterize manuscript ---"
+
+    CHAR_PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_characterize_prompt
+print(build_characterize_prompt('${PROJECT_DIR}'))
+")
+
+    if [[ -z "$CHAR_PROMPT" ]]; then
+        log "ERROR: Could not build characterize prompt — no manuscript content found"
+        exit 1
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "===== DRY RUN: Phase 0 (characterize) ====="
+        echo "$CHAR_PROMPT" | head -20
+        echo "... (${#CHAR_PROMPT} chars total)"
+        echo "===== END DRY RUN ====="
+    else
+        CHAR_LOG="${LOG_DIR}/extract-phase0.log"
+        CHAR_MODEL=$(select_model "synthesis")  # Opus for full-manuscript comprehension
+
+        log "  Invoking ${CHAR_MODEL} for manuscript characterization..."
+        _SF_INVOCATION_START=$(date +%s); export _SF_INVOCATION_START
+
+        begin_healing_zone "characterize manuscript"
+        invoke_anthropic_api "$CHAR_PROMPT" "$CHAR_MODEL" "$CHAR_LOG" 4096
+        end_healing_zone
+
+        RESPONSE=$(extract_api_response "$CHAR_LOG" 2>/dev/null)
+        log_api_usage "$CHAR_LOG" "extract-characterize" "manuscript" "$CHAR_MODEL" 2>/dev/null || true
+
+        # Parse and save profile
+        PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import parse_characterize_response
+response = open('${CHAR_LOG}', encoding='utf-8').read()
+try:
+    data = json.loads(response)
+    text = ''.join(item.get('text', '') for item in data.get('content', []) if item.get('type') == 'text')
+    if text: response = text
+except (json.JSONDecodeError, KeyError):
+    pass
+profile = parse_characterize_response(response)
+with open('${PROFILE_FILE}', 'w') as f:
+    json.dump(profile, f, indent=2)
+print(f'Characterized: {len(profile)} fields extracted')
+for k, v in sorted(profile.items()):
+    print(f'  {k}: {v[:80]}')
+" 2>&1 | while IFS= read -r line; do log "  $line"; done
+
+        (cd "$PROJECT_DIR" && git add working/ && git commit -m "Extract: Phase 0 — manuscript characterization" && git push) 2>/dev/null || true
+        update_pr_task "Phase 0: Characterize manuscript" "$PROJECT_DIR" 2>/dev/null || true
+    fi
+fi
+
+# ============================================================================
+# Phase 1: Skeleton (scenes.csv)
+# ============================================================================
+
+if [[ -z "$PHASE" || "$PHASE" == "1" ]]; then
+    log ""
+    log "--- Phase 1: Extract skeleton (scenes.csv) ---"
+
+    # Load profile
+    PROFILE="{}"
+    [[ -f "$PROFILE_FILE" ]] && PROFILE=$(cat "$PROFILE_FILE")
+
+    if [[ "$DRY_RUN" == true ]]; then
+        SAMPLE_ID="${SORTED_SCENE_IDS[0]}"
+        SAMPLE_TEXT=$(cat "${SCENES_DIR}/${SAMPLE_ID}.md" 2>/dev/null | head -20)
+        echo "===== DRY RUN: Phase 1 (skeleton) — sample for ${SAMPLE_ID} ====="
+        PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_skeleton_prompt
+profile = json.loads('${PROFILE}')
+print(build_skeleton_prompt('${SAMPLE_ID}', '''${SAMPLE_TEXT}''', profile)[:500])
+"
+        echo "... (${#SORTED_SCENE_IDS[@]} scenes total)"
+        echo "===== END DRY RUN ====="
+    else
+        SKEL_MODEL=$(select_model "evaluation")  # Sonnet for structured extraction
+        BATCH_FILE="${LOG_DIR}/extract-phase1-batch.jsonl"
+        rm -f "$BATCH_FILE"
+
+        log "  Building batch for ${#SORTED_SCENE_IDS[@]} scenes..."
+        for SCENE_ID in "${SORTED_SCENE_IDS[@]}"; do
+            SCENE_TEXT=$(cat "${SCENES_DIR}/${SCENE_ID}.md" 2>/dev/null || echo "")
+            [[ -z "$SCENE_TEXT" ]] && continue
+
+            PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_skeleton_prompt
+profile = json.loads(open('${PROFILE_FILE}').read()) if __import__('os').path.isfile('${PROFILE_FILE}') else {}
+scene_text = open('${SCENES_DIR}/${SCENE_ID}.md', encoding='utf-8').read()
+print(build_skeleton_prompt('${SCENE_ID}', scene_text, profile))
+")
+            json_prompt=$(jq -Rs '.' <<< "$PROMPT")
+            printf '{"custom_id":"%s","params":{"model":"%s","max_tokens":1024,"messages":[{"role":"user","content":%s}]}}\n' \
+                "$SCENE_ID" "$SKEL_MODEL" "$json_prompt" >> "$BATCH_FILE"
+        done
+
+        log "  Submitting batch..."
+        _SF_INVOCATION_START=$(date +%s); export _SF_INVOCATION_START
+        begin_healing_zone "extract skeleton batch"
+
+        BATCH_ID=$(submit_batch "$BATCH_FILE")
+        poll_batch "$BATCH_ID"
+
+        SKEL_OUTPUT="${LOG_DIR}/extract-phase1-output"
+        mkdir -p "$SKEL_OUTPUT"
+        download_batch_results "$BATCH_ID" "$SKEL_OUTPUT" "$LOG_DIR"
+
+        end_healing_zone
+
+        # Process results → scenes.csv
+        log "  Processing skeleton results..."
+        PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import parse_skeleton_response
+from storyforge.elaborate import _read_csv_as_map, _write_csv, _FILE_MAP
+
+output_dir = '${SKEL_OUTPUT}'
+ref_dir = '${REF_DIR}'
+scene_ids = '''$(printf '%s\n' "${SORTED_SCENE_IDS[@]}")'''.strip().split('\n')
+
+# Read existing scenes.csv or start fresh
+existing = _read_csv_as_map(os.path.join(ref_dir, 'scenes.csv'))
+
+count = 0
+for i, sid in enumerate(scene_ids):
+    txt_file = os.path.join(output_dir, f'{sid}.txt')
+    if not os.path.isfile(txt_file):
+        continue
+    response = open(txt_file, encoding='utf-8').read()
+    result = parse_skeleton_response(response, sid)
+
+    # Merge with existing or create new
+    if sid in existing:
+        for k, v in result.items():
+            if v and k != 'id':
+                existing[sid][k] = v
+    else:
+        row = {c: '' for c in _FILE_MAP['scenes.csv']}
+        row.update(result)
+        row['seq'] = str(i + 1)
+        row['status'] = 'drafted'
+        # Count words from scene file
+        scene_file = os.path.join('${SCENES_DIR}', f'{sid}.md')
+        if os.path.isfile(scene_file):
+            wc = len(open(scene_file).read().split())
+            row['word_count'] = str(wc)
+        existing[sid] = row
+    count += 1
+
+# Write sorted by seq
+ordered = sorted(existing.values(), key=lambda r: int(r.get('seq', 0)))
+_write_csv(os.path.join(ref_dir, 'scenes.csv'), ordered, _FILE_MAP['scenes.csv'])
+print(f'Updated scenes.csv: {count} scenes')
+" 2>&1 | while IFS= read -r line; do log "  $line"; done
+
+        (cd "$PROJECT_DIR" && git add reference/scenes.csv working/ && git commit -m "Extract: Phase 1 — skeleton (scenes.csv)" && git push) 2>/dev/null || true
+        update_pr_task "Phase 1: Extract skeleton" "$PROJECT_DIR" 2>/dev/null || true
+        rm -f "$BATCH_FILE"
+        rm -rf "$SKEL_OUTPUT"
+    fi
+fi
+
+# ============================================================================
+# Phase 2: Intent (scene-intent.csv) — batch, parallel
+# ============================================================================
+
+if [[ -z "$PHASE" || "$PHASE" == "2" ]]; then
+    log ""
+    log "--- Phase 2: Extract intent (scene-intent.csv) ---"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "===== DRY RUN: Phase 2 (intent) — ${#SORTED_SCENE_IDS[@]} scenes ====="
+        echo "===== END DRY RUN ====="
+    else
+        INTENT_MODEL=$(select_model "evaluation")
+        BATCH_FILE="${LOG_DIR}/extract-phase2-batch.jsonl"
+        rm -f "$BATCH_FILE"
+
+        log "  Building batch for ${#SORTED_SCENE_IDS[@]} scenes..."
+        for SCENE_ID in "${SORTED_SCENE_IDS[@]}"; do
+            PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_intent_prompt
+from storyforge.elaborate import get_scene
+
+profile = json.loads(open('${PROFILE_FILE}').read()) if os.path.isfile('${PROFILE_FILE}') else {}
+skeleton = get_scene('${SCENE_ID}', '${REF_DIR}') or {}
+scene_text = open('${SCENES_DIR}/${SCENE_ID}.md', encoding='utf-8').read()
+print(build_intent_prompt('${SCENE_ID}', scene_text, profile, skeleton))
+")
+            json_prompt=$(jq -Rs '.' <<< "$PROMPT")
+            printf '{"custom_id":"%s","params":{"model":"%s","max_tokens":1024,"messages":[{"role":"user","content":%s}]}}\n' \
+                "$SCENE_ID" "$INTENT_MODEL" "$json_prompt" >> "$BATCH_FILE"
+        done
+
+        log "  Submitting batch..."
+        _SF_INVOCATION_START=$(date +%s); export _SF_INVOCATION_START
+        begin_healing_zone "extract intent batch"
+
+        BATCH_ID=$(submit_batch "$BATCH_FILE")
+        poll_batch "$BATCH_ID"
+
+        INTENT_OUTPUT="${LOG_DIR}/extract-phase2-output"
+        mkdir -p "$INTENT_OUTPUT"
+        download_batch_results "$BATCH_ID" "$INTENT_OUTPUT" "$LOG_DIR"
+
+        end_healing_zone
+
+        # Process results → scene-intent.csv
+        log "  Processing intent results..."
+        PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import parse_intent_response
+from storyforge.elaborate import _read_csv_as_map, _write_csv, _FILE_MAP
+
+output_dir = '${INTENT_OUTPUT}'
+ref_dir = '${REF_DIR}'
+scene_ids = '''$(printf '%s\n' "${SORTED_SCENE_IDS[@]}")'''.strip().split('\n')
+
+existing = _read_csv_as_map(os.path.join(ref_dir, 'scene-intent.csv'))
+
+count = 0
+for sid in scene_ids:
+    txt_file = os.path.join(output_dir, f'{sid}.txt')
+    if not os.path.isfile(txt_file):
+        continue
+    response = open(txt_file, encoding='utf-8').read()
+    result = parse_intent_response(response, sid)
+
+    if sid in existing:
+        for k, v in result.items():
+            if v and k != 'id' and not k.startswith('_'):
+                existing[sid][k] = v
+    else:
+        row = {c: '' for c in _FILE_MAP['scene-intent.csv']}
+        row.update({k: v for k, v in result.items() if not k.startswith('_')})
+        existing[sid] = row
+    count += 1
+
+ordered = sorted(existing.values(), key=lambda r: r.get('id', ''))
+_write_csv(os.path.join(ref_dir, 'scene-intent.csv'), ordered, _FILE_MAP['scene-intent.csv'])
+print(f'Updated scene-intent.csv: {count} scenes')
+" 2>&1 | while IFS= read -r line; do log "  $line"; done
+
+        (cd "$PROJECT_DIR" && git add reference/scene-intent.csv working/ && git commit -m "Extract: Phase 2 — intent (scene-intent.csv)" && git push) 2>/dev/null || true
+        update_pr_task "Phase 2: Extract intent" "$PROJECT_DIR" 2>/dev/null || true
+        rm -f "$BATCH_FILE"
+        rm -rf "$INTENT_OUTPUT"
+    fi
+fi
+
+# ============================================================================
+# Phase 3: Briefs — 3a parallel + 3b sequential knowledge chain
+# ============================================================================
+
+if [[ -z "$PHASE" || "$PHASE" == "3" ]]; then
+    log ""
+    log "--- Phase 3a: Extract briefs (parallel fields) ---"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "===== DRY RUN: Phase 3a (briefs parallel) — ${#SORTED_SCENE_IDS[@]} scenes ====="
+        echo "===== END DRY RUN ====="
+    else
+        BRIEF_MODEL=$(select_model "evaluation")
+        BATCH_FILE="${LOG_DIR}/extract-phase3a-batch.jsonl"
+        rm -f "$BATCH_FILE"
+
+        log "  Building batch for ${#SORTED_SCENE_IDS[@]} scenes..."
+        for SCENE_ID in "${SORTED_SCENE_IDS[@]}"; do
+            PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_brief_parallel_prompt
+from storyforge.elaborate import get_scene
+
+profile = json.loads(open('${PROFILE_FILE}').read()) if os.path.isfile('${PROFILE_FILE}') else {}
+scene_data = get_scene('${SCENE_ID}', '${REF_DIR}') or {}
+skeleton = {k: scene_data.get(k, '') for k in ['title', 'pov', 'location', 'part']}
+intent = {k: scene_data.get(k, '') for k in ['function', 'scene_type', 'value_at_stake', 'value_shift', 'emotional_arc']}
+scene_text = open('${SCENES_DIR}/${SCENE_ID}.md', encoding='utf-8').read()
+print(build_brief_parallel_prompt('${SCENE_ID}', scene_text, profile, skeleton, intent))
+")
+            json_prompt=$(jq -Rs '.' <<< "$PROMPT")
+            printf '{"custom_id":"%s","params":{"model":"%s","max_tokens":1024,"messages":[{"role":"user","content":%s}]}}\n' \
+                "$SCENE_ID" "$BRIEF_MODEL" "$json_prompt" >> "$BATCH_FILE"
+        done
+
+        log "  Submitting batch..."
+        _SF_INVOCATION_START=$(date +%s); export _SF_INVOCATION_START
+        begin_healing_zone "extract briefs batch"
+
+        BATCH_ID=$(submit_batch "$BATCH_FILE")
+        poll_batch "$BATCH_ID"
+
+        BRIEF_OUTPUT="${LOG_DIR}/extract-phase3a-output"
+        mkdir -p "$BRIEF_OUTPUT"
+        download_batch_results "$BATCH_ID" "$BRIEF_OUTPUT" "$LOG_DIR"
+
+        end_healing_zone
+
+        # Process results → scene-briefs.csv (partial — no knowledge fields yet)
+        log "  Processing brief results..."
+        PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import parse_brief_parallel_response
+from storyforge.elaborate import _read_csv_as_map, _write_csv, _FILE_MAP
+
+output_dir = '${BRIEF_OUTPUT}'
+ref_dir = '${REF_DIR}'
+scene_ids = '''$(printf '%s\n' "${SORTED_SCENE_IDS[@]}")'''.strip().split('\n')
+
+existing = _read_csv_as_map(os.path.join(ref_dir, 'scene-briefs.csv'))
+
+count = 0
+for sid in scene_ids:
+    txt_file = os.path.join(output_dir, f'{sid}.txt')
+    if not os.path.isfile(txt_file):
+        continue
+    response = open(txt_file, encoding='utf-8').read()
+    result = parse_brief_parallel_response(response, sid)
+
+    if sid in existing:
+        for k, v in result.items():
+            if v and k != 'id':
+                existing[sid][k] = v
+    else:
+        row = {c: '' for c in _FILE_MAP['scene-briefs.csv']}
+        row.update(result)
+        existing[sid] = row
+    count += 1
+
+ordered = sorted(existing.values(), key=lambda r: r.get('id', ''))
+_write_csv(os.path.join(ref_dir, 'scene-briefs.csv'), ordered, _FILE_MAP['scene-briefs.csv'])
+print(f'Updated scene-briefs.csv: {count} scenes (knowledge fields pending)')
+" 2>&1 | while IFS= read -r line; do log "  $line"; done
+
+        (cd "$PROJECT_DIR" && git add reference/scene-briefs.csv working/ && git commit -m "Extract: Phase 3a — briefs (parallel fields)" && git push) 2>/dev/null || true
+        rm -f "$BATCH_FILE"
+        rm -rf "$BRIEF_OUTPUT"
+
+        # --- Phase 3b: Knowledge chain (sequential) ---
+        log ""
+        log "--- Phase 3b: Extract knowledge chain (sequential) ---"
+
+        KNOWLEDGE_MODEL=$(select_model "evaluation")
+        KNOWLEDGE_STATE="{}"  # accumulated per-character knowledge
+        SCENE_SUMMARIES=""
+
+        for SCENE_ID in "${SORTED_SCENE_IDS[@]}"; do
+            SCENE_TEXT=$(cat "${SCENES_DIR}/${SCENE_ID}.md" 2>/dev/null || echo "")
+            [[ -z "$SCENE_TEXT" ]] && continue
+
+            KNOWLEDGE_LOG="${LOG_DIR}/extract-knowledge-${SCENE_ID}.log"
+
+            PROMPT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import build_knowledge_prompt
+from storyforge.elaborate import get_scene
+
+scene_data = get_scene('${SCENE_ID}', '${REF_DIR}') or {}
+skeleton = {k: scene_data.get(k, '') for k in ['title', 'pov', 'location', 'part']}
+intent = {k: scene_data.get(k, '') for k in ['function', 'scene_type']}
+
+prior_knowledge = json.loads('''${KNOWLEDGE_STATE}''')
+prior_summaries = [s for s in '''${SCENE_SUMMARIES}'''.strip().split('\n') if s.strip()]
+
+scene_text = open('${SCENES_DIR}/${SCENE_ID}.md', encoding='utf-8').read()
+print(build_knowledge_prompt('${SCENE_ID}', scene_text, skeleton, intent, prior_knowledge, prior_summaries))
+")
+
+            _SF_INVOCATION_START=$(date +%s); export _SF_INVOCATION_START
+            invoke_anthropic_api "$PROMPT" "$KNOWLEDGE_MODEL" "$KNOWLEDGE_LOG" 1024 || {
+                log "  WARNING: Knowledge extraction failed for ${SCENE_ID}"
+                continue
+            }
+
+            RESPONSE=$(extract_api_response "$KNOWLEDGE_LOG" 2>/dev/null)
+            log_api_usage "$KNOWLEDGE_LOG" "extract-knowledge" "$SCENE_ID" "$KNOWLEDGE_MODEL" 2>/dev/null || true
+
+            # Parse and apply
+            PARSED=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys, os, json; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import parse_knowledge_response
+from storyforge.elaborate import update_scene, get_scene
+
+response = open('${KNOWLEDGE_LOG}', encoding='utf-8').read()
+try:
+    data = json.loads(response)
+    text = ''.join(item.get('text', '') for item in data.get('content', []) if item.get('type') == 'text')
+    if text: response = text
+except (json.JSONDecodeError, KeyError):
+    pass
+
+result = parse_knowledge_response(response, '${SCENE_ID}')
+
+# Update briefs CSV
+updates = {}
+for k in ['knowledge_in', 'knowledge_out', 'continuity_deps']:
+    if k in result and result[k]:
+        updates[k] = result[k]
+if updates:
+    update_scene('${SCENE_ID}', '${REF_DIR}', updates)
+
+# Output for bash: knowledge_out and summary for next iteration
+scene_data = get_scene('${SCENE_ID}', '${REF_DIR}') or {}
+pov = scene_data.get('pov', 'unknown')
+knowledge_out = result.get('knowledge_out', '')
+summary = result.get('_summary', '')
+
+# Output as JSON for bash to capture
+print(json.dumps({'pov': pov, 'knowledge_out': knowledge_out, 'summary': summary}))
+")
+
+            # Update accumulated state for next scene
+            POV=$(echo "$PARSED" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('pov', ''))")
+            K_OUT=$(echo "$PARSED" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('knowledge_out', ''))")
+            SUMMARY=$(echo "$PARSED" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('summary', ''))")
+
+            # Update knowledge state (replace POV character's knowledge)
+            KNOWLEDGE_STATE=$(echo "$KNOWLEDGE_STATE" | python3 -c "
+import sys, json
+state = json.load(sys.stdin)
+pov = '${POV}'
+k_out = '${K_OUT}'
+if pov and k_out:
+    state[pov] = k_out
+print(json.dumps(state))
+")
+
+            # Append summary
+            [[ -n "$SUMMARY" ]] && SCENE_SUMMARIES="${SCENE_SUMMARIES}${SCENE_ID}: ${SUMMARY}
+"
+
+            log "  ${SCENE_ID}: knowledge extracted"
+        done
+
+        (cd "$PROJECT_DIR" && git add reference/scene-briefs.csv working/ && git commit -m "Extract: Phase 3b — knowledge chain" && git push) 2>/dev/null || true
+        update_pr_task "Phase 3: Extract briefs" "$PROJECT_DIR" 2>/dev/null || true
+    fi
+fi
+
+# ============================================================================
+# Validate
+# ============================================================================
+
+if [[ "$DRY_RUN" != true ]]; then
+    log ""
+    log "--- Running validation ---"
+
+    VALIDATE_RESULT=$(PYTHONPATH="$PYTHON_LIB" python3 -c "
+import json; import sys; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.elaborate import validate_structure
+report = validate_structure('${REF_DIR}')
+print(json.dumps(report))
+")
+
+    VALIDATE_PASSED=$(echo "$VALIDATE_RESULT" | python3 -c "import sys, json; r=json.load(sys.stdin); print(r['passed'])")
+    VALIDATE_FAILURES=$(echo "$VALIDATE_RESULT" | python3 -c "import sys, json; r=json.load(sys.stdin); print(len(r['failures']))")
+
+    if [[ "$VALIDATE_PASSED" == "True" ]]; then
+        log "Validation passed"
+    else
+        log "Validation found ${VALIDATE_FAILURES} issue(s) — review recommended"
+    fi
+
+    update_pr_task "Validate" "$PROJECT_DIR" 2>/dev/null || true
+fi
+
+# ============================================================================
+# Expansion analysis
+# ============================================================================
+
+if [[ "$EXPAND" == true && "$DRY_RUN" != true ]]; then
+    log ""
+    log "--- Expansion analysis ---"
+
+    PYTHONPATH="$PYTHON_LIB" python3 -c "
+import sys; sys.path.insert(0, '${PYTHON_LIB}')
+from storyforge.extract import analyze_expansion_opportunities
+
+opps = analyze_expansion_opportunities('${REF_DIR}')
+if not opps:
+    print('No expansion opportunities identified.')
+else:
+    print(f'{len(opps)} expansion opportunities:')
+    for o in opps:
+        print(f'  [{o[\"priority\"]}] {o[\"type\"]}: {o[\"description\"]} ({o[\"scene_id\"]})')
+" 2>&1 | while IFS= read -r line; do log "$line"; done
+fi
+
+# ============================================================================
+# Review and summary
+# ============================================================================
+
+if [[ "$DRY_RUN" != true ]]; then
+    run_review_phase "extraction" "$PROJECT_DIR" 2>/dev/null || true
+fi
+
+log ""
+log "============================================"
+log "Extraction complete."
+log "  scenes.csv, scene-intent.csv, scene-briefs.csv populated"
+log "  Run /storyforge:validate to verify, then review and correct the extracted data"
+log "============================================"
+
+print_cost_summary "extract" 2>/dev/null || true

--- a/skills/extract/SKILL.md
+++ b/skills/extract/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: extract
+description: Extract structural data from existing prose into the elaboration pipeline's three-file CSV model. Use when an author has an existing manuscript or scenes and wants to reverse-engineer the structural data (scenes.csv, scene-intent.csv, scene-briefs.csv) for validation, analysis, or expansion planning.
+---
+
+# Storyforge Extract — Reverse Elaboration
+
+You are helping an author extract structural data from their existing prose. This is the reverse of the elaboration pipeline: instead of building structure first and writing prose second, you're analyzing prose that already exists and extracting the structural skeleton, narrative intent, and drafting contracts from it.
+
+The goal is to produce data accurate enough for the author to **review and correct**, not build from scratch.
+
+## Locating the Storyforge Plugin
+
+The Storyforge plugin root is two levels up from this skill file's directory (this skill's directory → `skills/` → plugin root).
+
+Store this resolved plugin path for use throughout the session.
+
+## Step 1: Read Project State
+
+1. `storyforge.yaml` — project title, genre, coaching level
+2. `scenes/` directory — check how many scene files exist
+3. `reference/scenes.csv` or `reference/scene-metadata.csv` — does scene data already exist?
+4. `reference/scene-intent.csv` — does intent data exist?
+5. `reference/scene-briefs.csv` — does brief data exist?
+
+## Step 2: Determine What Needs Extraction
+
+Based on project state:
+
+- **No scene files** → Author needs to split their manuscript first. Route to `/storyforge:scenes` (setup mode) or help them split interactively.
+- **Scene files exist, no CSV data** → Full extraction needed (all 4 phases)
+- **Scene files + old metadata CSV** → Migration + extraction. Run `./storyforge migrate-elaborate` first, then extract to fill the new columns.
+- **Scene files + partial elaboration data** → Targeted extraction — only run phases for missing data.
+
+## Step 3: Execute Extraction
+
+### Option A: Run Autonomously
+
+Provide the command for the author to run:
+
+```bash
+cd [project_dir] && [plugin_path]/scripts/storyforge-extract [options]
+```
+
+Options:
+- `--phase 0` — Characterize manuscript only (cheap, fast, good first step)
+- `--phase 1` — Extract skeleton (scenes.csv) only
+- `--phase 2` — Extract intent only (needs phase 1)
+- `--phase 3` — Extract briefs only (needs phases 1-2)
+- `--expand` — Include expansion analysis (for novella-to-novel work)
+- `--dry-run` — Print prompts without calling the API
+
+For full extraction: `./storyforge extract` (runs all phases)
+For expansion planning: `./storyforge extract --expand`
+
+### Option B: Run Interactively
+
+Work through each phase in this conversation:
+
+**Phase 0: Characterize.** Read the full manuscript (concatenate scene files) and produce a structural profile — narrative mode, POV characters, timeline, act structure, threads, central conflict, compression points. Present the profile to the author for confirmation.
+
+**Phase 1: Skeleton.** For each scene, extract: title, POV, location, timeline day, time of day, duration, part assignment. Write to `reference/scenes.csv`. This can be done in batches — present a batch of 10 scenes at a time for the author to review.
+
+**Phase 2: Intent.** For each scene, extract: function, scene type (action/sequel), emotional arc, value at stake, value shift, turning point, threads, characters, on-stage characters, MICE threads. Write to `reference/scene-intent.csv`.
+
+**Phase 3: Briefs.** Two sub-phases:
+- 3a (parallel): goal, conflict, outcome, crisis, decision, key actions, key dialogue, emotions, motifs
+- 3b (sequential): knowledge_in, knowledge_out, continuity_deps — must process in scene order
+
+Write to `reference/scene-briefs.csv`.
+
+After each phase, commit: `git add -A && git commit -m "Extract: Phase N — [description]" && git push`
+
+## Step 4: Review and Validate
+
+After extraction completes:
+
+1. Run validation: `./storyforge validate`
+2. Present the validation report to the author
+3. Highlight low-confidence extractions (the intent phase includes a confidence field)
+4. Walk through any validation failures and help the author correct them
+
+## Step 5: Expansion Analysis (Optional)
+
+If the author is developing a novella into a novel, or wants to identify structural expansion opportunities:
+
+1. Run: `./storyforge extract --expand`
+2. Or interactively analyze the extracted data for:
+   - **Compressed scenes** — major value shifts in very few words
+   - **Knowledge jumps** — characters learning 3+ facts in one scene
+   - **Timeline gaps** — days missing between scenes
+   - **Thin threads** — subplots appearing in only 1-2 scenes
+   - **Missing sequels** — action scenes without reaction beats
+
+Present opportunities ranked by priority and let the author decide which to pursue. Then route to `/storyforge:elaborate` to plan the expansion.
+
+## Coaching Level Behavior
+
+- **Full:** Run extraction autonomously, present results with analysis and recommendations for correction.
+- **Coach:** Run extraction, walk through each phase's results with the author, discuss concerns and ambiguities, help them decide what to correct.
+- **Strict:** Run extraction, present raw data tables for the author to review and correct independently. Flag validation failures but don't interpret them.
+
+## Commit After Every Deliverable
+
+Each phase's output gets committed immediately:
+
+```bash
+git add -A && git commit -m "Extract: Phase N — [description]" && git push
+```

--- a/tests/test-extract.sh
+++ b/tests/test-extract.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# test-extract.sh — Tests for reverse elaboration extraction helpers
+
+PY="import sys; sys.path.insert(0, '${PLUGIN_DIR}/scripts/lib/python')"
+
+# ============================================================================
+# parse_characterize_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_characterize_response
+response = '''NARRATIVE_MODE: third-limited
+POV_CHARACTERS: Dorren Hayle;Tessa Merrin
+TIMELINE: linear
+TIMELINE_SPAN: 3 weeks
+SCENE_BREAK_STYLE: explicit-markers
+ESTIMATED_SCENES: 42
+MAJOR_THREADS: institutional-failure;chosen-blindness;the-anomaly
+CENTRAL_CONFLICT: A cartographer must choose between institutional loyalty and truth
+CAST_SIZE: 12'''
+result = parse_characterize_response(response)
+print(result.get('narrative_mode', ''))
+print(result.get('pov_characters', ''))
+print(result.get('estimated_scenes', ''))
+print(result.get('major_threads', ''))
+")
+
+assert_contains "$RESULT" "third-limited" "parse_characterize: extracts narrative mode"
+assert_contains "$RESULT" "Dorren Hayle;Tessa Merrin" "parse_characterize: extracts POV characters"
+assert_contains "$RESULT" "42" "parse_characterize: extracts scene count"
+assert_contains "$RESULT" "institutional-failure" "parse_characterize: extracts threads"
+
+# ============================================================================
+# parse_skeleton_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_skeleton_response
+response = '''TITLE: The Arranged Dead
+POV: Emmett Slade
+LOCATION: Alkali Flat
+TIMELINE_DAY: 1
+TIME_OF_DAY: afternoon
+DURATION: 2 hours
+TARGET_WORDS: 1300
+PART: 1'''
+result = parse_skeleton_response(response, 'arranged-dead')
+print(result.get('id', ''))
+print(result.get('title', ''))
+print(result.get('pov', ''))
+print(result.get('timeline_day', ''))
+print(result.get('part', ''))
+")
+
+assert_equals "arranged-dead" "$(echo "$RESULT" | head -1)" "parse_skeleton: preserves scene id"
+assert_contains "$RESULT" "The Arranged Dead" "parse_skeleton: extracts title"
+assert_contains "$RESULT" "Emmett Slade" "parse_skeleton: extracts POV"
+assert_contains "$RESULT" "1" "parse_skeleton: extracts timeline day"
+
+# ============================================================================
+# parse_intent_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_intent_response
+response = '''FUNCTION: Emmett reads the staged crime scene and connects the murder to a disappearance
+SCENE_TYPE: action
+EMOTIONAL_ARC: Professional detachment to resolved determination
+VALUE_AT_STAKE: truth
+VALUE_SHIFT: +/-
+TURNING_POINT: revelation
+THREADS: murder-investigation;land-fraud
+CHARACTERS: Emmett Slade;Samuel Orcutt;Colson
+ON_STAGE: Emmett Slade;Colson
+MICE_THREADS: +inquiry:who-killed-orcutt
+CONFIDENCE: high'''
+result = parse_intent_response(response, 'arranged-dead')
+print(result.get('function', ''))
+print(result.get('scene_type', ''))
+print(result.get('value_shift', ''))
+print(result.get('threads', ''))
+print(result.get('_confidence', ''))
+")
+
+assert_contains "$RESULT" "staged crime scene" "parse_intent: extracts function"
+assert_contains "$RESULT" "action" "parse_intent: extracts scene type"
+assert_contains "$RESULT" "+/-" "parse_intent: extracts value shift"
+assert_contains "$RESULT" "murder-investigation" "parse_intent: extracts threads"
+assert_contains "$RESULT" "high" "parse_intent: extracts confidence"
+
+# ============================================================================
+# parse_brief_parallel_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_brief_parallel_response
+response = '''GOAL: Determine cause of death and establish whether it is murder
+CONFLICT: The crime scene has been deliberately staged to look accidental
+OUTCOME: no-and
+CRISIS: Report the staging and alert the territorial marshal, or investigate quietly
+DECISION: Investigates quietly — keeps the staging knowledge to himself
+KEY_ACTIONS: Examines body;Notes staged positioning;Finds survey equipment;Interviews Colson
+KEY_DIALOGUE: The body was found like this?;Exactly like this, Sheriff
+EMOTIONS: professional-calm;suspicion;recognition;quiet-resolve
+MOTIFS: arranged-bodies;survey-equipment;patience'''
+result = parse_brief_parallel_response(response, 'arranged-dead')
+print(result.get('goal', ''))
+print(result.get('outcome', ''))
+print(result.get('crisis', ''))
+")
+
+assert_contains "$RESULT" "cause of death" "parse_brief: extracts goal"
+assert_contains "$RESULT" "no-and" "parse_brief: extracts outcome"
+assert_contains "$RESULT" "Report the staging" "parse_brief: extracts crisis"
+
+# ============================================================================
+# parse_knowledge_response
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_knowledge_response
+response = '''KNOWLEDGE_IN: Orcutt was found dead at the alkali flat
+KNOWLEDGE_OUT: Orcutt was found dead at the alkali flat;the body was deliberately staged;survey equipment was present at the scene
+CONTINUITY_DEPS: discovery-at-flat
+SCENE_SUMMARY: Emmett examines the staged crime scene and decides to investigate quietly'''
+result = parse_knowledge_response(response, 'arranged-dead')
+print(result.get('knowledge_in', ''))
+print(result.get('knowledge_out', ''))
+print(result.get('continuity_deps', ''))
+print(result.get('_summary', ''))
+")
+
+assert_contains "$RESULT" "Orcutt was found dead" "parse_knowledge: extracts knowledge_in"
+assert_contains "$RESULT" "deliberately staged" "parse_knowledge: extracts knowledge_out"
+assert_contains "$RESULT" "discovery-at-flat" "parse_knowledge: extracts continuity_deps"
+assert_contains "$RESULT" "examines the staged" "parse_knowledge: extracts summary"
+
+# ============================================================================
+# analyze_expansion_opportunities
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import analyze_expansion_opportunities
+opps = analyze_expansion_opportunities('${FIXTURE_DIR}/reference')
+for o in opps:
+    print(f\"{o['type']}: {o['priority']} — {o['scene_id']}\")
+print(f'total: {len(opps)}')
+")
+
+assert_not_empty "$RESULT" "analyze_expansion: produces output"
+assert_contains "$RESULT" "total:" "analyze_expansion: completes without error"
+
+# ============================================================================
+# build_characterize_prompt
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import build_characterize_prompt
+prompt = build_characterize_prompt('${FIXTURE_DIR}')
+print(len(prompt))
+")
+
+assert_not_empty "$RESULT" "build_characterize: produces non-empty prompt"
+
+# ============================================================================
+# build_skeleton_prompt
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import build_skeleton_prompt
+prompt = build_skeleton_prompt('act1-sc01', 'Some scene prose here.', {'pov_characters': 'Alice', 'timeline': 'linear'})
+print('POV' in prompt and 'TITLE' in prompt and 'LOCATION' in prompt)
+")
+
+assert_equals "True" "$RESULT" "build_skeleton: prompt contains expected field labels"
+
+# ============================================================================
+# build_intent_prompt
+# ============================================================================
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import build_intent_prompt
+prompt = build_intent_prompt('act1-sc01', 'Scene prose.', {'major_threads': 'thread-a'}, {'title': 'Test', 'pov': 'Alice'})
+print('FUNCTION' in prompt and 'VALUE_SHIFT' in prompt and 'MICE_THREADS' in prompt)
+")
+
+assert_equals "True" "$RESULT" "build_intent: prompt contains expected field labels"


### PR DESCRIPTION
## Summary

Reverse elaboration — takes existing prose and extracts structural data into the three-file CSV model. Four extraction phases:

- **Phase 0: Characterize** (Opus, full manuscript) — narrative mode, POV characters, timeline, act structure, threads, central conflict, compression points
- **Phase 1: Skeleton** (Sonnet, batch) — title, POV, location, timeline day, time of day, duration, part → `scenes.csv`
- **Phase 2: Intent** (Sonnet, batch) — function, scene type, emotional arc, value shift, turning point, threads, characters, MICE threads → `scene-intent.csv`
- **Phase 3: Briefs** — 3a parallel (goal, conflict, outcome, crisis, decision, key actions/dialogue, emotions, motifs) + 3b sequential knowledge chain (knowledge_in, knowledge_out, continuity_deps) → `scene-briefs.csv`

**Expansion analysis** identifies novella-to-novel opportunities: compressed scenes, knowledge jumps, timeline gaps, thin threads, missing sequels.

Estimated cost: ~$15-25 for a 90K-word manuscript (~60 scenes).

## New files
- `scripts/lib/python/storyforge/extract.py` — prompt builders, response parsers, expansion analysis
- `scripts/storyforge-extract` — CLI orchestrating all phases
- `skills/extract/SKILL.md` — interactive extraction skill

## Test plan

- [x] 25 new tests for all response parsers, expansion analysis, and prompt builders
- [x] Full suite: 778 tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)