### PR TITLE
Simplify extraction cleanup — deterministic only

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/storyforge-extract
+++ b/scripts/storyforge-extract
@@ -723,6 +723,13 @@ for cat in ['timeline', 'knowledge', 'mice_threads']:
         else
             log "  No cleanup fixes needed"
         fi
+
+        # Claude-powered cleanup removed — deterministic cleanup handles
+        # the high-confidence fixes (timeline interpolation, knowledge fuzzy
+        # match, MICE duplicate/orphan removal). The remaining issues after
+        # deterministic cleanup genuinely need author review. Claude knowledge
+        # reconciliation was tested and produced marginal improvement (1 additional
+        # fix on a 64-scene manuscript) at high token cost (252KB prompt).
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Removes Claude-powered knowledge reconciliation (tested: 1 fix at 252KB prompt cost — not worth it)
- Removes migration script (`storyforge-migrate-elaborate`) — extraction is the right path
- Keeps deterministic cleanup: timeline interpolation, knowledge fuzzy match, MICE duplicate/orphan removal
- Result: 198 → 65 validation failures (67% reduction) on a 64-scene manuscript

The remaining 65 failures are genuine author review items, not automation gaps.

## Test plan

- [x] 784 tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)