### PR TITLE
Remove last legacy threads column reference

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/elaborate.py
+++ b/scripts/lib/python/storyforge/elaborate.py
@@ -779,7 +779,7 @@ _GAP_GROUPS = {
         'batch_type': 'parallel',
     },
     'thread-fields': {
-        'fields': ['threads', 'mice_threads'],
+        'fields': ['mice_threads'],
         'file': 'scene-intent.csv',
         'batch_type': 'parallel',
     },


### PR DESCRIPTION
## Summary

Removes the final reference to the legacy `threads` column from `_GAP_GROUPS` in elaborate.py. All other references were already cleaned up in prior work (schema, enrich, templates, fixtures, _INTENT_COLS, _REQUIRED_BY_STATUS).

Fixes #77

## Test plan

- [x] All 839 tests pass across 22 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)