### PR TITLE
Fix bash boolean passed to Python in validate script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/storyforge-validate
+++ b/scripts/storyforge-validate
@@ -48,7 +48,7 @@ from storyforge.schema import validate_schema, validate_knowledge_granularity
 
 ref_dir = '${REF_DIR}'
 project_dir = '${PROJECT_DIR}'
-skip_schema = ${SKIP_SCHEMA} == True
+skip_schema = '${SKIP_SCHEMA}' == 'true'
 
 structural = validate_structure(ref_dir)
 


### PR DESCRIPTION
## Summary

`storyforge-validate` passed bash `false` directly into Python, causing `NameError: name 'false' is not defined`. Fixed to use string comparison: `'${SKIP_SCHEMA}' == 'true'`.

Fixes #81

## Test plan

- [x] All 839 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)