### PR TITLE
Fix gap-fill batch custom_id containing invalid colon

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.56.2",
+  "version": "0.56.3",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/storyforge-elaborate
+++ b/scripts/storyforge-elaborate
@@ -214,7 +214,7 @@ with open('${BATCH_FILE}', 'w') as f:
                 scenes_dir=scenes_dir,
                 registries_text=registries,
             )
-            custom_id = f'{group_name}:{scene_id}'
+            custom_id = f'{group_name}__{scene_id}'
             req = {
                 'custom_id': custom_id,
                 'params': {
@@ -269,7 +269,7 @@ for fname in os.listdir(batch_logs):
     normalize_fields(row, alias_maps)
     scene_id = row.get('id', '')
     if not scene_id:
-        scene_id = custom_id.split(':', 1)[-1] if ':' in custom_id else ''
+        scene_id = custom_id.split('__', 1)[-1] if '__' in custom_id else ''
     if not scene_id:
         continue
 


### PR DESCRIPTION
## Summary

Replace `:` with `__` in gap-fill batch custom_ids to match the Anthropic API pattern `^[a-zA-Z0-9_-]{1,64}$`. Updated both generation and parsing sides.

Fixes #83

## Test plan

- [x] All 839 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)