### PR TITLE
Fix extract pipeline overwriting prior branch work on re-run

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.56.3",
+  "version": "0.56.4",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1028,14 +1028,10 @@ ensure_branch_pushed() {
         return 1
     fi
 
-    # Check if the branch has any commits ahead of its merge base.
+    # Check if the branch has any commits ahead of main.
     # If not, we need an initial commit so gh pr create has a diff.
     local base_branch
-    base_branch=$(git -C "$project_dir" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null \
-               || git -C "$project_dir" config init.defaultBranch 2>/dev/null \
-               || echo "main")
-    # Strip remote prefix (e.g., "origin/main" -> "main")
-    base_branch="${base_branch#origin/}"
+    base_branch=$(git -C "$project_dir" config init.defaultBranch 2>/dev/null || echo "main")
 
     local ahead
     ahead=$(git -C "$project_dir" rev-list --count "${base_branch}..HEAD" 2>/dev/null || echo "0")

--- a/scripts/storyforge-extract
+++ b/scripts/storyforge-extract
@@ -337,10 +337,12 @@ for i, sid in enumerate(scene_ids):
 
     # Merge with existing or create new
     if sid in existing:
+        # Only fill empty fields — don't overwrite prior work
         for k, v in result.items():
-            if v and k != 'id':
+            if v and k != 'id' and not existing[sid].get(k, '').strip():
                 existing[sid][k] = v
-    else:
+    elif not existing:
+        # First extraction: CSV is empty, add all scenes
         row = {c: '' for c in _FILE_MAP['scenes.csv']}
         row.update(result)
         row['seq'] = str(i + 1)
@@ -351,6 +353,9 @@ for i, sid in enumerate(scene_ids):
             wc = len(open(scene_file).read().split())
             row['word_count'] = str(wc)
         existing[sid] = row
+    else:
+        # Re-run: scene not in CSV (was removed), skip it
+        continue
     count += 1
 
 # Write sorted by seq
@@ -440,13 +445,18 @@ for sid in scene_ids:
     normalize_fields(result, alias_maps)
 
     if sid in existing:
+        # Only fill empty fields — don't overwrite prior work
         for k, v in result.items():
-            if v and k != 'id' and not k.startswith('_'):
+            if v and k != 'id' and not k.startswith('_') and not existing[sid].get(k, '').strip():
                 existing[sid][k] = v
-    else:
+    elif not existing:
+        # First extraction: CSV is empty, add all scenes
         row = {c: '' for c in _FILE_MAP['scene-intent.csv']}
         row.update({k: v for k, v in result.items() if not k.startswith('_')})
         existing[sid] = row
+    else:
+        # Re-run: scene not in CSV (was removed), skip it
+        continue
     count += 1
 
 ordered = sorted(existing.values(), key=lambda r: r.get('id', ''))
@@ -537,13 +547,18 @@ for sid in scene_ids:
     normalize_fields(result, alias_maps)
 
     if sid in existing:
+        # Only fill empty fields — don't overwrite prior work
         for k, v in result.items():
-            if v and k != 'id':
+            if v and k != 'id' and not existing[sid].get(k, '').strip():
                 existing[sid][k] = v
-    else:
+    elif not existing:
+        # First extraction: CSV is empty, add all scenes
         row = {c: '' for c in _FILE_MAP['scene-briefs.csv']}
         row.update(result)
         existing[sid] = row
+    else:
+        # Re-run: scene not in CSV (was removed), skip it
+        continue
     count += 1
 
 ordered = sorted(existing.values(), key=lambda r: r.get('id', ''))


### PR DESCRIPTION
## Summary

- **Phases 1/2/3a only fill empty fields** — existing non-empty values are preserved, so manual MICE thread fixes, schema corrections, and orphan removals survive re-extraction
- **Removed scenes stay removed** — re-running extraction on an existing branch no longer re-adds scenes that were previously deleted from the CSV
- **No spurious "Start" commits** — `ensure_branch_pushed` now compares against main instead of the upstream tracking branch, so branches with existing commits don't get reset

Fixes #85

## Test plan

- [x] All 839 tests pass
- [ ] Re-run `--phase 3` on Night Watch branch to verify prior MICE fixes survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)