### PR TITLE
Update all documentation for structural scoring and reconciliation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,9 +279,9 @@ Run: `./tests/run-tests.sh` (all suites) or `./tests/run-tests.sh tests/test-thi
 | `storyforge-revise` | Execute revision passes from a plan |
 | `storyforge-score` | Craft scoring (25 principles + fidelity scoring against briefs) |
 | `storyforge-elaborate` | Run elaboration stages (spine/architecture/map/briefs) |
-| `storyforge-extract` | Extract structural data from existing prose (reverse elaboration) |
+| `storyforge-extract` | Extract structural data from existing prose (reverse elaboration). `--force` overwrites existing fields. Runs reconciliation after each phase. |
 | `storyforge-polish` | Targeted prose polish on low-scoring scenes |
-| `storyforge-validate` | Structural validation against scene CSVs |
+| `storyforge-validate` | Structural validation against scene CSVs. `--structural` adds story-quality scoring (8 dimensions, deterministic). `--no-schema` skips schema validation. |
 | `storyforge-reconcile` | Build registries (Opus) and normalize CSV fields for cross-scene consistency |
 | `storyforge-enrich` | Metadata enrichment from prose |
 | `storyforge-assemble` | Chapter assembly + epub/PDF/HTML generation |
@@ -331,6 +331,7 @@ Key principles:
 | `prompts_elaborate.py` | Elaboration stage prompt builders |
 | `scoring.py` | Score parsing, diagnosis, proposals, fidelity scoring |
 | `structural.py` | Structural scoring engine — story quality from CSV data (8 dimensions, deterministic) |
+| `reconcile.py` | Post-extraction reconciliation — build registries (Opus) and normalize fields |
 | `visualize.py` | Dashboard data loading |
 | `enrich.py` | Metadata enrichment |
 | `assembly.py` | Chapter assembly |

--- a/references/structural-craft.md
+++ b/references/structural-craft.md
@@ -273,18 +273,22 @@ Fewer dependencies means more parallelism. Ask: does this scene really need to r
 
 ## 8. Structural Scoring
 
-### Pre-Draft Scoring
+### Pre-Draft Scoring (8 Dimensions)
 
-Before any prose exists, the elaboration data can be scored:
+Run `storyforge validate --structural` to score story quality from CSV data. This is deterministic, free, and instant — no API calls. It measures 8 dimensions:
 
-- Does every scene have a non-flat value shift?
-- Is the goal/conflict/outcome chain complete?
-- Is the crisis a genuine dilemma?
-- Do turning point types vary across sequences?
-- Is the action/sequel rhythm balanced?
-- Do knowledge states connect properly?
+1. **Arc Completeness** — Does each POV character have a complete arc with reversals? Grounded in Reagan's 6 emotional arc shapes (2016): compound arcs outperform simple ones.
+2. **Thematic Concentration** — Are 8-15 core values explored with clear dominance? Grounded in Archer & Jockers (2016): bestsellers dedicate ~30% of content to 1-2 themes.
+3. **Pacing Shape** — Do act proportions follow 25/50/25? Is there a midpoint reversal? Beat regularity? Grounded in Coyne, Brody, Archer & Jockers.
+4. **Character Presence** — Are important characters on stage enough? Antagonist visibility? Presence gaps?
+5. **MICE Thread Health** — Close ratio, dormancy, type balance, resolution positioning.
+6. **Knowledge Chain Integrity** — Coverage, fact utilization, dramatic irony potential, backstory dependency.
+7. **Scene Function Variety** — Action/sequel balance, outcome entropy, turning point variety.
+8. **Structural Completeness** — Are all required fields populated across the three CSVs?
 
-A scene scoring 5/5 on structural scoring has all the bones it needs. A scene scoring 0/5 has no brief data at all. The score doesn't predict prose quality — it predicts whether the scene has the structural foundation to support good prose.
+Each dimension produces a 0-1 score with a target threshold. Scores below target come with craft-grounded diagnosis (why it matters to the reader) and specific CSV-level prescriptions. Output adapts to coaching level (full/coach/strict).
+
+Scores persist to `working/scores/structural-latest.csv` and show deltas on re-run, enabling a tight improvement loop: score → fix CSVs → re-score → see movement.
 
 ### Post-Draft Fidelity Scoring
 

--- a/skills/elaborate/SKILL.md
+++ b/skills/elaborate/SKILL.md
@@ -279,14 +279,24 @@ After any stage completes, run validation:
 cd [project_dir] && [plugin_path]/scripts/storyforge-validate
 ```
 
-Or use the Python helpers directly:
+After briefs are complete (before drafting), also run structural scoring:
 
-```python
-from storyforge.elaborate import validate_structure
-report = validate_structure('reference/')
+```bash
+cd [project_dir] && [plugin_path]/scripts/storyforge-validate --structural
 ```
 
-Report results to the author. Blocking failures must be fixed before advancing. Advisory findings are noted for author judgment.
+This scores 8 dimensions of story quality from CSV data (deterministic, free, instant):
+- Arc completeness, thematic concentration, pacing shape, character presence
+- MICE thread health, knowledge chain integrity, scene function variety, structural completeness
+
+If any dimension is below target, review the diagnosis (which includes craft-grounded explanations and specific CSV changes) and address findings before drafting. Structural fixes are much cheaper than prose rewrites.
+
+If registries are missing or thematic concentration is low, recommend reconciliation:
+```bash
+cd [project_dir] && [plugin_path]/scripts/storyforge-reconcile
+```
+
+Report results to the author. Blocking validation failures must be fixed before advancing. Structural scoring findings are advisory but strongly recommended before drafting.
 
 ## Step 6: Commit After Every Deliverable
 

--- a/skills/extract/SKILL.md
+++ b/skills/extract/SKILL.md
@@ -86,14 +86,23 @@ Write to `reference/scene-briefs.csv`.
 
 After each phase, commit: `git add -A && git commit -m "Extract: Phase N — [description]" && git push`
 
-## Step 4: Review and Validate
+## Step 4: Reconcile and Validate
 
-After extraction completes:
+After extraction completes (reconciliation runs automatically after each phase, but can also be run manually):
 
-1. Run validation: `./storyforge validate`
-2. Present the validation report to the author
-3. Highlight low-confidence extractions (the intent phase includes a confidence field)
-4. Walk through any validation failures and help the author correct them
+1. **Reconcile** (if not already done): `./storyforge reconcile`
+   - Builds/updates registries (characters, locations, values, MICE threads, knowledge) using Opus
+   - Normalizes all CSV fields against canonical IDs
+   - Normalizes outcome fields to enum values (yes/yes-but/no/no-and/no-but)
+2. **Validate structure**: `./storyforge validate`
+3. **Score structure** (optional but recommended): `./storyforge validate --structural`
+   - Scores 8 dimensions of story quality from CSV data (deterministic, free, instant)
+   - Produces diagnostic findings with craft-grounded explanations
+   - Generates proposals in `working/scores/structural-proposals.csv`
+4. Present the validation and scoring reports to the author
+5. Walk through any validation failures and structural findings
+
+Note: Re-running extraction on a branch with existing data only fills empty fields (preserves prior work). Use `--force` to overwrite existing values when a full re-extraction is desired.
 
 ## Step 5: Expansion Analysis (Optional)
 

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -30,6 +30,8 @@ Before doing anything else, orient yourself:
    - `reference/scenes.csv`
    - `working/evaluations/*/findings.csv` (preferred) or `working/evaluations/findings.yaml` (legacy)
    - `working/plans/revision-plan.csv` (preferred) or `working/plans/revision-plan.yaml` (legacy)
+   - `working/scores/structural-latest.csv` (structural scoring results)
+   - `working/scores/structural-proposals.csv` (unaddressed structural proposals)
    - The `scenes/` directory (any `.md` files = drafted scenes)
 4. **Read the key decisions file** — check the `key_decisions` artifact path in `storyforge.yaml` (typically `reference/key-decisions.md`). If it exists, read it in full. This file contains settled author decisions. **You must never re-ask a question that is already answered in this file.**
 
@@ -91,6 +93,20 @@ Invoke the `produce` skill for non-web formats.
 
 **"Extract" / "Analyze my manuscript":**
 Invoke the `extract` skill.
+
+**"Check my structure" / "Structural score" / "Are my bones right?" / "Validate structure":**
+Run structural scoring — this is a deterministic analysis of the CSV data (no API calls, instant, free). Provide the command:
+```bash
+./storyforge validate --structural
+```
+If scores are below target, review the diagnosis and proposals in `working/scores/structural-proposals.csv`. At coaching level full, the diagnosis includes craft-grounded explanations and specific CSV changes. At coach, it produces guiding questions.
+
+**"Reconcile" / "Normalize my data" / "Build registries" / "Clean up values":**
+Run reconciliation to normalize CSV fields against canonical registries. This uses Opus to build/update registries then deterministically normalizes all fields. Provide the command:
+```bash
+./storyforge reconcile [--domain characters|locations|values|mice-threads|knowledge|outcomes]
+```
+Without `--domain`, runs all 6 domains in order. This is especially valuable after extraction or when structural scoring shows thematic fragmentation.
 
 **"Title" / "Cover" / "Press kit":**
 Invoke the corresponding skill (`title`, `cover`, `press-kit`).
@@ -157,7 +173,11 @@ Determine the single highest-value next action based on project state. Work thro
 
 **1. Elaboration phase:** If phase is `spine`/`architecture`/`scene-map`/`briefs` → "Continue elaboration" → invoke `elaborate`.
 
-**1.5. Post-extraction gaps:** If `scenes.csv` has rows with `status=drafted` AND `scene-briefs.csv` is populated AND `validate_structure()` returns failures > 0 → "Your extracted data has structural gaps. Run elaborate to fill them." → invoke `elaborate` (which will detect gap-fill state).
+**1.5. Post-extraction reconciliation:** If `scenes.csv` has rows AND registries are missing or incomplete (no `characters.csv`, `values.csv`, etc.) → "Your data needs reconciliation to normalize cross-scene consistency." → Provide `./storyforge reconcile` command.
+
+**1.6. Post-extraction gaps:** If `scenes.csv` has rows with `status=drafted` AND `scene-briefs.csv` is populated AND `validate_structure()` returns failures > 0 → "Your extracted data has structural gaps. Run elaborate to fill them." → invoke `elaborate` (which will detect gap-fill state).
+
+**1.7. Structural scoring:** If briefs are populated AND no `working/scores/structural-latest.csv` exists (or it's older than the CSVs) → "Check your story structure before drafting." → Provide `./storyforge validate --structural`. Review scores and proposals. Address any below-target dimensions before drafting.
 
 **2. Ready to draft:** If briefs are complete and validated → "Draft your scenes" → provide `./storyforge write` command.
 

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -47,7 +47,18 @@ Based on the author's request and project state:
 
 ## Step 3: Plan the Revision
 
-Read evaluation findings and scoring data. If structural scoring results exist (`working/scores/structural-proposals.csv`), incorporate unaddressed structural proposals into the revision plan. Structural proposals use the same fix_location routing as evaluation findings.
+Read evaluation findings and scoring data. Categorize each finding by where the fix belongs.
+
+### Structural Proposals
+
+If `working/scores/structural-proposals.csv` exists, these are unaddressed structural findings from the last `storyforge validate --structural` run. Each proposal has:
+- **dimension**: which scoring dimension flagged it (arc_completeness, thematic_concentration, pacing_shape, etc.)
+- **fix_location**: where the fix lives (structural/intent/brief/registry) — same routing as evaluation findings
+- **target**: scene ID or 'global'
+- **change**: what to do
+- **rationale**: why (score + data)
+
+Structural fixes should generally precede craft passes, as they affect what the prose needs to deliver. Run `storyforge validate --structural` after structural/intent/brief passes to verify scores improved before starting craft passes.
 
 Categorize each finding by where the fix belongs:
 

--- a/skills/score/SKILL.md
+++ b/skills/score/SKILL.md
@@ -7,6 +7,8 @@ description: Review scores, calibrate craft weights, and provide author scoring.
 
 You are helping an author review craft scores, calibrate principle weights, and provide their own scoring assessments. Scoring measures how well each scene embodies the craft principles defined in the scoring rubrics.
 
+**Note: Craft scoring vs. structural scoring.** This skill handles **craft scoring** — evaluating prose quality (25 principles) via AI after scenes are drafted. **Structural scoring** (story architecture quality from CSV data, before prose) is handled by `storyforge validate --structural` and reviewed in the revise skill. Both inform the complete manuscript assessment, but they measure different things at different stages.
+
 ## Locating the Storyforge Plugin
 
 The Storyforge plugin root is two levels up from this skill file's directory


### PR DESCRIPTION
## Summary

Comprehensive documentation update across 8 files ensuring all skills and references know about structural scoring, reconciliation, and the improved drafting prompt.

### Changes by file

- **CLAUDE.md**: --structural flag, --force flag, reconcile.py module
- **forge/SKILL.md**: Routing for structural scoring + reconciliation in both directed and guided modes
- **extract/SKILL.md**: Reconcile + validate + structural scoring in post-extraction workflow
- **elaborate/SKILL.md**: Structural scoring before drafting, reconciliation recommendation
- **revise/SKILL.md**: Structural proposals format and prioritization guidance
- **score/SKILL.md**: Craft-vs-structural distinction
- **structural-craft.md**: Full 8-dimension scoring description with empirical grounding

## Test plan

- [x] All 915 tests pass (documentation-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)