### PR TITLE
Add subtext field to scene-briefs schema

### DIFF
--- a/scripts/lib/python/storyforge/elaborate.py
+++ b/scripts/lib/python/storyforge/elaborate.py
@@ -29,7 +29,7 @@ _INTENT_COLS = [
 _BRIEFS_COLS = [
     'id', 'goal', 'conflict', 'outcome', 'crisis', 'decision',
     'knowledge_in', 'knowledge_out', 'key_actions', 'key_dialogue',
-    'emotions', 'motifs', 'continuity_deps', 'has_overflow',
+    'emotions', 'motifs', 'subtext', 'continuity_deps', 'has_overflow',
     'physical_state_in', 'physical_state_out',
 ]
 

--- a/scripts/lib/python/storyforge/extract.py
+++ b/scripts/lib/python/storyforge/extract.py
@@ -324,7 +324,8 @@ DECISION: [what the character actively chooses in response to the crisis]
 KEY_ACTIONS: [semicolon-separated concrete things that happen in this scene]
 KEY_DIALOGUE: [semicolon-separated specific lines or exchanges that are essential to the scene — quote directly from the text]
 EMOTIONS: [semicolon-separated emotional beats in sequence as they occur through the scene]
-MOTIFS: [semicolon-separated recurring images, symbols, or sensory details that carry thematic weight]"""
+MOTIFS: [semicolon-separated recurring images, symbols, or sensory details that carry thematic weight]
+SUBTEXT: [what is happening beneath the surface — the gap between what characters say/do and what they mean. Phrase as a drafting instruction: "Character says X but means Y; do not state Y directly." If no meaningful subtext, write NONE]"""
 
 
 def parse_brief_parallel_response(response: str, scene_id: str) -> dict[str, str]:
@@ -340,13 +341,14 @@ def parse_brief_parallel_response(response: str, scene_id: str) -> dict[str, str
         'KEY_DIALOGUE': 'key_dialogue',
         'EMOTIONS': 'emotions',
         'MOTIFS': 'motifs',
+        'SUBTEXT': 'subtext',
     }
     for line in response.split('\n'):
         match = re.match(r'^([A-Z_]+):\s*(.*)', line.strip())
         if match:
             label = match.group(1)
             value = match.group(2).strip()
-            if label in label_map and value and value.upper() != 'UNKNOWN':
+            if label in label_map and value and value.upper() not in ('UNKNOWN', 'NONE'):
                 result[label_map[label]] = value
     return result
 

--- a/scripts/lib/python/storyforge/hone.py
+++ b/scripts/lib/python/storyforge/hone.py
@@ -909,6 +909,7 @@ _TERSE_FIELDS = {
 _PROSE_FIELDS = {
     'decision': 80,        # max chars — one action choice
     'crisis': 100,         # max chars — one dilemma
+    'subtext': 150,        # max chars — directive, not a paragraph
 }
 
 # Prose indicators: patterns that suggest the field became a paragraph.

--- a/scripts/lib/python/storyforge/prompts.py
+++ b/scripts/lib/python/storyforge/prompts.py
@@ -1098,9 +1098,19 @@ def build_scene_prompt_from_briefs(
     if not scene:
         return f"ERROR: Scene {scene_id} not found in scenes.csv"
 
-    # Build scene data block
+    # Build scene data block (exclude subtext — it gets special framing below)
     scene_block = '\n'.join(f"**{k}:** {v}" for k, v in scene.items()
-                            if v and k != 'id')
+                            if v and k not in ('id', 'subtext'))
+
+    # Subtext gets its own section so the drafter treats it as a constraint
+    subtext_value = scene.get('subtext', '').strip()
+    if subtext_value:
+        scene_block += (
+            f'\n\n**SUBTEXT (show, never tell):** {subtext_value}\n'
+            'This is what is happening beneath the surface. The reader should '
+            'feel it through action, dialogue, and detail — never through '
+            'narrator explanation.'
+        )
 
     # Build dependency context
     dep_block = ''

--- a/scripts/lib/python/storyforge/prompts_elaborate.py
+++ b/scripts/lib/python/storyforge/prompts_elaborate.py
@@ -415,13 +415,14 @@ For each scene that needs a brief, define the complete drafting contract:
 - **key_dialogue**: Specific lines or exchanges that must appear in the prose
 - **emotions**: Semicolon-separated emotional beats in sequence
 - **motifs**: Semicolon-separated recurring images/symbols deployed
+- **subtext**: What is happening beneath the surface of the scene — phrased as a drafting instruction. This is the gap between what characters say/do and what they mean. Write it as: "Character says/does X but means Y; do not state Y directly" or "The tension is Z; show it through [specific physical behavior], never name it." One to two sentences. If the scene has no meaningful subtext (pure action, pure exposition), leave empty.
 - **continuity_deps**: Semicolon-separated scene IDs this scene depends on (for parallel drafting)
 - **has_overflow**: false (unless you indicate a scene needs extended brief)
 
 ### Output Format
 
 ```briefs-csv
-id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow|physical_state_in|physical_state_out
+id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|subtext|continuity_deps|has_overflow|physical_state_in|physical_state_out
 (one row per scene being briefed)
 ```
 

--- a/scripts/lib/python/storyforge/schema.py
+++ b/scripts/lib/python/storyforge/schema.py
@@ -214,6 +214,10 @@ COLUMN_SCHEMA = {
         'file': 'scene-briefs.csv', 'stage': 'brief',
         'description': 'Recurring images/symbols deployed. Normalized against reference/motif-taxonomy.csv.',
     },
+    'subtext': {
+        'type': 'free_text', 'file': 'scene-briefs.csv', 'stage': 'brief',
+        'description': 'What is happening beneath the surface — phrased as a drafting instruction. "Character says X but means Y; do not state Y directly."',
+    },
     'continuity_deps': {
         'type': 'scene_ids', 'file': 'scene-briefs.csv', 'stage': 'brief',
         'description': 'Scene IDs this scene depends on (for parallel drafting). Each entry must exist in scenes.csv.',

--- a/tests/test-hone.sh
+++ b/tests/test-hone.sh
@@ -503,3 +503,151 @@ print('ok')
 " 2>/dev/null)
 
 assert_contains "$RESULT" "ok" "combined: _CONCRETIZABLE_FIELDS includes goal, conflict, emotions"
+
+# ============================================================================
+# Subtext field support
+# ============================================================================
+
+echo "--- subtext: included in _BRIEFS_COLS ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.elaborate import _BRIEFS_COLS
+assert 'subtext' in _BRIEFS_COLS, f'subtext missing: {_BRIEFS_COLS}'
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "subtext: present in _BRIEFS_COLS"
+
+echo "--- subtext: defined in schema ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.schema import COLUMN_SCHEMA
+assert 'subtext' in COLUMN_SCHEMA, f'subtext missing from schema'
+s = COLUMN_SCHEMA['subtext']
+assert s['file'] == 'scene-briefs.csv', f'wrong file: {s[\"file\"]}'
+assert s['type'] == 'free_text', f'wrong type: {s[\"type\"]}'
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "subtext: defined in COLUMN_SCHEMA"
+
+echo "--- subtext: verbose detection flags long subtext ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.hone import detect_verbose_fields
+
+briefs = {
+    's1': {
+        'id': 's1',
+        'subtext': 'Zara says she is fine but her synesthesia is worsening and she knows it and everyone around her knows it too but nobody is willing to say it out loud because they are all afraid of what it means for the community and for her specifically.',
+    },
+}
+results = detect_verbose_fields(briefs)
+fields = [r['field'] for r in results]
+assert 'subtext' in fields, f'subtext not flagged: {fields}'
+print(f'issues={len(results)}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "issues=1" "subtext: verbose detection flags long subtext"
+assert_contains "$RESULT" "ok" "subtext: verbose detection runs"
+
+echo "--- subtext: terse subtext not flagged ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.hone import detect_verbose_fields
+
+briefs = {
+    's1': {
+        'id': 's1',
+        'subtext': 'Zara says she is fine but means the opposite; show through her hands shaking',
+    },
+}
+results = detect_verbose_fields(briefs)
+fields = [r['field'] for r in results]
+assert 'subtext' not in fields, f'subtext wrongly flagged: {fields}'
+print(f'issues={len(results)}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "issues=0" "subtext: terse subtext passes"
+assert_contains "$RESULT" "ok" "subtext: terse check runs"
+
+echo "--- subtext: extract parser handles SUBTEXT label ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_brief_parallel_response
+
+response = '''GOAL: Find the map
+CONFLICT: Guards block the way
+OUTCOME: yes-but
+CRISIS: Fight or sneak
+DECISION: Sneaks past
+KEY_ACTIONS: Opens door; Grabs map
+KEY_DIALOGUE: Where is it?
+EMOTIONS: tension;relief
+MOTIFS: maps;darkness
+SUBTEXT: She tells the guard she is lost but she knows exactly where she is; show through confident body language that contradicts her words'''
+
+result = parse_brief_parallel_response(response, 'test-scene')
+assert 'subtext' in result, f'subtext missing: {list(result.keys())}'
+assert 'confident body language' in result['subtext'], f'wrong value: {result[\"subtext\"]}'
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "subtext: extract parser handles SUBTEXT label"
+
+echo "--- subtext: extract parser filters NONE ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.extract import parse_brief_parallel_response
+
+response = '''GOAL: Find the map
+SUBTEXT: NONE'''
+
+result = parse_brief_parallel_response(response, 'test-scene')
+assert 'subtext' not in result, f'NONE should be filtered: {list(result.keys())}'
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "subtext: NONE value filtered in extract"
+
+echo "--- subtext: drafting prompt includes subtext framing ---"
+
+RESULT=$(python3 -c "
+${PY}
+import os, tempfile, shutil
+from storyforge.elaborate import _read_csv, _write_csv, _FILE_MAP
+
+# Create temp project with subtext
+tmpdir = tempfile.mkdtemp()
+ref = os.path.join(tmpdir, 'reference')
+shutil.copytree('${FIXTURE_DIR}/reference', ref)
+
+# Add subtext to act1-sc01
+briefs_path = os.path.join(ref, 'scene-briefs.csv')
+rows = _read_csv(briefs_path)
+for r in rows:
+    if r['id'] == 'act1-sc01':
+        r['subtext'] = 'Dorren files as error but knows she is lying to the institution; show through the private note, not inner monologue'
+_write_csv(briefs_path, rows, _FILE_MAP['scene-briefs.csv'])
+
+# Verify column is written and readable
+rows2 = _read_csv(briefs_path)
+for r in rows2:
+    if r['id'] == 'act1-sc01':
+        assert 'subtext' in r, f'subtext column missing after write: {list(r.keys())}'
+        assert 'lying to the institution' in r['subtext'], f'wrong value: {r[\"subtext\"]}'
+        print('ok')
+        break
+
+shutil.rmtree(tmpdir)
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "subtext: CSV round-trip preserves subtext"


### PR DESCRIPTION
## Summary
- Adds `subtext` column to `scene-briefs.csv` — captures what's beneath the surface, phrased as a drafting instruction
- Wired into all five touchpoints: schema, elaborate, drafting prompts, hone, extract
- Drafting prompt gives subtext special "SUBTEXT (show, never tell)" framing so the drafter treats it as a constraint
- Hone flags verbose subtext (>150 chars) — subtext should be directive, not a paragraph
- Extract infers subtext from existing prose, filters "NONE" responses

## Test plan
- [ ] 1031/1031 tests pass (9 new subtext tests)
- [ ] Elaborate a few scenes and verify subtext is populated
- [ ] Re-draft a scene with subtext and verify prose shows (not tells) the subtext

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)