### PR TITLE
Add prose exemplar infrastructure — per-POV, validation, rhythm signatures

### DIFF
--- a/scripts/lib/python/storyforge/exemplars.py
+++ b/scripts/lib/python/storyforge/exemplars.py
@@ -1,0 +1,291 @@
+"""Prose exemplar validation and rhythm signature extraction.
+
+Validates exemplar quality (sentence variety, prohibited patterns, length)
+and extracts rhythm signatures for injection into drafting prompts.
+"""
+
+import os
+import re
+from typing import Optional
+
+
+# ============================================================================
+# Sentence splitting
+# ============================================================================
+
+# Split on sentence boundaries: period/exclamation/question followed by space
+# and capital letter, or end of string. Handles common abbreviations.
+_SENTENCE_RE = re.compile(
+    r'(?<=[.!?])\s+(?=[A-Z"])|(?<=[.!?])\s*$'
+)
+
+_ABBREVS = {'mr.', 'mrs.', 'ms.', 'dr.', 'st.', 'vs.', 'etc.', 'e.g.', 'i.e.'}
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text into sentences, handling common edge cases."""
+    # Pre-filter: remove markdown headers and empty lines
+    lines = [l for l in text.split('\n') if l.strip() and not l.strip().startswith('#')]
+    text = ' '.join(lines)
+
+    # Split on sentence boundaries
+    raw = _SENTENCE_RE.split(text)
+    sentences = []
+    for s in raw:
+        s = s.strip()
+        if not s:
+            continue
+        # Skip if it's just a markdown artifact or too short to be a sentence
+        if len(s) < 5:
+            continue
+        # Skip abbreviations that look like sentence ends
+        lower = s.lower()
+        if any(lower.endswith(abbr) for abbr in _ABBREVS):
+            if sentences:
+                sentences[-1] = sentences[-1] + ' ' + s
+            continue
+        sentences.append(s)
+    return sentences
+
+
+def word_count(text: str) -> int:
+    """Count words in text."""
+    return len(text.split())
+
+
+# ============================================================================
+# Rhythm signature
+# ============================================================================
+
+def compute_rhythm_signature(exemplar_text: str) -> Optional[dict]:
+    """Compute rhythm metrics from exemplar text.
+
+    Returns dict with:
+        sentence_count: total sentences
+        word_count: total words
+        mean_sentence_words: average words per sentence
+        stddev_sentence_words: standard deviation
+        min_sentence_words: shortest sentence
+        max_sentence_words: longest sentence
+        buckets: dict of word-count ranges to percentages
+            'short' (<8), 'medium' (8-15), 'standard' (15-25),
+            'long' (25-35), 'very_long' (35+)
+        paragraph_lengths: list of sentence counts per paragraph
+        short_ratio: fraction of sentences <8 words
+        long_ratio: fraction of sentences >25 words
+
+    Returns None if insufficient text (<3 sentences).
+    """
+    sentences = split_sentences(exemplar_text)
+    if len(sentences) < 3:
+        return None
+
+    lengths = [len(s.split()) for s in sentences]
+    n = len(lengths)
+    mean = sum(lengths) / n
+    variance = sum((l - mean) ** 2 for l in lengths) / n
+    stddev = variance ** 0.5
+
+    # Bucket distribution
+    short = sum(1 for l in lengths if l < 8)
+    medium = sum(1 for l in lengths if 8 <= l < 15)
+    standard = sum(1 for l in lengths if 15 <= l < 25)
+    long = sum(1 for l in lengths if 25 <= l < 35)
+    very_long = sum(1 for l in lengths if l >= 35)
+
+    # Paragraph lengths (split on double newline or markdown headers)
+    paragraphs = re.split(r'\n\s*\n|^###?\s', exemplar_text, flags=re.MULTILINE)
+    para_lengths = []
+    for p in paragraphs:
+        p = p.strip()
+        if not p:
+            continue
+        sents = split_sentences(p)
+        if sents:
+            para_lengths.append(len(sents))
+
+    return {
+        'sentence_count': n,
+        'word_count': sum(lengths),
+        'mean_sentence_words': round(mean, 1),
+        'stddev_sentence_words': round(stddev, 1),
+        'min_sentence_words': min(lengths),
+        'max_sentence_words': max(lengths),
+        'buckets': {
+            'short': round(short / n * 100),
+            'medium': round(medium / n * 100),
+            'standard': round(standard / n * 100),
+            'long': round(long / n * 100),
+            'very_long': round(very_long / n * 100),
+        },
+        'paragraph_lengths': para_lengths,
+        'short_ratio': round(short / n, 2),
+        'long_ratio': round(long / n + very_long / n, 2),
+    }
+
+
+def format_rhythm_for_prompt(sig: dict) -> str:
+    """Format a rhythm signature as a drafting constraint block.
+
+    Gives the drafter concrete targets instead of vague "vary sentence length."
+    """
+    b = sig['buckets']
+    return (
+        "## Rhythm Target (from your exemplars)\n\n"
+        f"Sentence length distribution: "
+        f"{b['short']}% under 8 words, "
+        f"{b['medium']}% between 8-15, "
+        f"{b['standard']}% between 15-25, "
+        f"{b['long'] + b['very_long']}% over 25.\n"
+        f"Range: {sig['min_sentence_words']}-{sig['max_sentence_words']} words "
+        f"(mean {sig['mean_sentence_words']}, stddev {sig['stddev_sentence_words']}).\n"
+        "Match this distribution. If your sentences cluster in the 15-25 range, "
+        "you're too uniform — add short punchy beats and longer flowing ones."
+    )
+
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+# Prohibited patterns — exemplars should NOT demonstrate these
+_PROHIBITED_PATTERNS = {
+    'antithesis': re.compile(
+        r'\bnot\b[^.]{5,40}\bbut\b', re.IGNORECASE
+    ),
+    'tricolon': re.compile(
+        r'(?:[^,;]+[,;]\s*){2}and\s+[^.]+\.', re.IGNORECASE
+    ),
+    'metaphor_restatement': re.compile(
+        r'like\s+\w+[^.]{10,}—\s*[a-z]', re.IGNORECASE
+    ),
+    'interpretive_tag': re.compile(
+        r'(?:It was (?:a gesture|her way|his way|their way)|as though|as if to say)',
+        re.IGNORECASE
+    ),
+}
+
+
+def validate_exemplars(exemplar_text: str) -> dict:
+    """Validate exemplar quality.
+
+    Returns dict with:
+        valid: bool — overall pass/fail
+        issues: list of issue strings
+        stats: rhythm signature (or None)
+        word_count: total words
+    """
+    issues = []
+    wc = word_count(exemplar_text)
+
+    # Length checks
+    if wc < 200:
+        issues.append(f'Too short ({wc} words, minimum 200). Add more passages.')
+    elif wc > 3000:
+        issues.append(f'Too long ({wc} words, maximum 3000). Trim to 3-5 best passages — more dilutes the signal.')
+
+    # Rhythm analysis
+    sig = compute_rhythm_signature(exemplar_text)
+    if sig:
+        # Check sentence length variety
+        if sig['stddev_sentence_words'] < 5:
+            issues.append(
+                f"Low sentence length variety (stddev {sig['stddev_sentence_words']}). "
+                "Exemplars should demonstrate varied rhythm — mix short punchy "
+                "sentences with longer flowing ones."
+            )
+
+        # Check clustering in 15-25 range
+        standard_pct = sig['buckets']['standard']
+        if standard_pct > 70:
+            issues.append(
+                f"{standard_pct}% of sentences fall in the 15-25 word range. "
+                "This is the AI-default rhythm. Choose exemplars that break this pattern."
+            )
+
+        # Check for any short sentences
+        if sig['short_ratio'] < 0.1:
+            issues.append(
+                "No short sentences (<8 words) in exemplars. "
+                "Short beats are crucial for rhythm variety."
+            )
+
+    # Prohibited pattern scanning
+    for name, pattern in _PROHIBITED_PATTERNS.items():
+        matches = pattern.findall(exemplar_text)
+        if matches:
+            label = name.replace('_', ' ')
+            issues.append(
+                f"Exemplar contains {label} pattern ({len(matches)} instance(s)). "
+                "Exemplars should demonstrate the absence of prohibited patterns."
+            )
+
+    return {
+        'valid': len(issues) == 0,
+        'issues': issues,
+        'stats': sig,
+        'word_count': wc,
+    }
+
+
+def validate_project_exemplars(project_dir: str) -> dict:
+    """Validate all exemplar files in a project.
+
+    Returns dict with:
+        files: list of {path, pov, validation} dicts
+        missing_povs: list of POV names without exemplars
+        has_any: bool
+    """
+    ref_dir = os.path.join(project_dir, 'reference')
+    results = {'files': [], 'missing_povs': [], 'has_any': False}
+
+    # Collect POV characters from scenes.csv
+    scenes_path = os.path.join(ref_dir, 'scenes.csv')
+    povs = set()
+    if os.path.isfile(scenes_path):
+        with open(scenes_path, encoding='utf-8') as f:
+            lines = f.read().splitlines()
+        if len(lines) > 1:
+            headers = lines[0].split('|')
+            pov_idx = headers.index('pov') if 'pov' in headers else -1
+            if pov_idx >= 0:
+                for line in lines[1:]:
+                    fields = line.split('|')
+                    if pov_idx < len(fields) and fields[pov_idx].strip():
+                        povs.add(fields[pov_idx].strip())
+
+    # Check per-POV exemplar files
+    exemplars_dir = os.path.join(ref_dir, 'exemplars')
+    for pov in sorted(povs):
+        pov_slug = pov.lower().replace(' ', '-')
+        pov_path = os.path.join(exemplars_dir, f'{pov_slug}.md')
+        if os.path.isfile(pov_path):
+            with open(pov_path, encoding='utf-8') as f:
+                content = f.read()
+            validation = validate_exemplars(content)
+            results['files'].append({
+                'path': pov_path,
+                'pov': pov,
+                'validation': validation,
+            })
+            results['has_any'] = True
+        else:
+            results['missing_povs'].append(pov)
+
+    # Check flat file fallback
+    flat_path = os.path.join(ref_dir, 'prose-exemplars.md')
+    if os.path.isfile(flat_path):
+        with open(flat_path, encoding='utf-8') as f:
+            content = f.read()
+        validation = validate_exemplars(content)
+        results['files'].append({
+            'path': flat_path,
+            'pov': '(all)',
+            'validation': validation,
+        })
+        results['has_any'] = True
+    elif not results['has_any']:
+        # No exemplars at all
+        results['missing_povs'] = sorted(povs) if povs else ['(no POV data)']
+
+    return results

--- a/scripts/lib/python/storyforge/prompts.py
+++ b/scripts/lib/python/storyforge/prompts.py
@@ -1037,20 +1037,45 @@ This POV character's interiority is grounded in the physical world. Reflective p
 This POV character withholds. Their interiority is sparse, physical, professional. Emotions are shown through action and observation, rarely named. Do not editorialize their feelings. Let the reader infer from what the character does and what they notice."""
 
 
-def _load_prose_exemplars(project_dir: str) -> str:
-    """Load prose exemplar text if available.
+def _load_prose_exemplars(project_dir: str, pov: str = '') -> str:
+    """Load prose exemplar text, preferring per-POV files.
 
-    Checks for reference/prose-exemplars.md in the project.
-    This file should contain 2-3 short excerpts of the manuscript's
-    target voice, labeled with what makes them exemplary.
+    Loading order:
+    1. reference/exemplars/{pov-slug}.md (per-POV, if pov is provided)
+    2. reference/prose-exemplars.md (flat file fallback)
+
+    Returns formatted prompt block, or empty string if no exemplars found.
     """
-    path = os.path.join(project_dir, 'reference', 'prose-exemplars.md')
-    if not os.path.isfile(path):
-        return ''
-    with open(path, encoding='utf-8') as f:
-        content = f.read().strip()
+    content = ''
+
+    # Try per-POV file first
+    if pov:
+        pov_slug = pov.lower().replace(' ', '-')
+        pov_path = os.path.join(project_dir, 'reference', 'exemplars', f'{pov_slug}.md')
+        if os.path.isfile(pov_path):
+            with open(pov_path, encoding='utf-8') as f:
+                content = f.read().strip()
+
+    # Fall back to flat file
+    if not content:
+        flat_path = os.path.join(project_dir, 'reference', 'prose-exemplars.md')
+        if os.path.isfile(flat_path):
+            with open(flat_path, encoding='utf-8') as f:
+                content = f.read().strip()
+
     if not content:
         return ''
+
+    # Extract rhythm signature if possible
+    rhythm_block = ''
+    try:
+        from .exemplars import compute_rhythm_signature, format_rhythm_for_prompt
+        sig = compute_rhythm_signature(content)
+        if sig:
+            rhythm_block = '\n\n' + format_rhythm_for_prompt(sig)
+    except (ImportError, Exception):
+        pass
+
     return (
         "## Voice Calibration — Write Like This\n\n"
         "These passages represent the manuscript's target voice. "
@@ -1058,6 +1083,7 @@ def _load_prose_exemplars(project_dir: str) -> str:
         "Notice what they do NOT do: they don't summarize, don't explain emotions, "
         "don't end with philosophical reflections.\n\n"
         + content
+        + rhythm_block
     )
 
 
@@ -1260,8 +1286,8 @@ Do NOT add creative interpretation or suggestions."""
     pov = scene.get('pov', '')
     pov_restraint = _build_pov_restraint_block(pov, ref_dir) if coaching_level == 'full' else ''
 
-    # Prose exemplars (optional, project-specific)
-    exemplar_block = _load_prose_exemplars(project_dir) if coaching_level == 'full' else ''
+    # Prose exemplars (optional, per-POV preferred)
+    exemplar_block = _load_prose_exemplars(project_dir, pov) if coaching_level == 'full' else ''
 
     return f"""You are drafting a scene for "{title}" ({genre}).
 

--- a/scripts/storyforge-hone
+++ b/scripts/storyforge-hone
@@ -229,6 +229,44 @@ else:
     for sid, fields in sorted(by_scene.items()):
         print(f'  {sid}: missing {', '.join(fields)}')
 
+# --- Part 4: Exemplar quality ---
+print()
+print('=== Prose Exemplars ===')
+print()
+try:
+    import storyforge.exemplars as _ex_mod
+    ex = _ex_mod.validate_project_exemplars(project_dir)
+    if not ex['has_any']:
+        print('  No exemplars found. Add reference/prose-exemplars.md or reference/exemplars/{pov}.md')
+        print('  Exemplars are the single most effective technique for prose naturalness.')
+    else:
+        for f in ex['files']:
+            pov_label = f['pov']
+            v = f['validation']
+            status = 'PASS' if v['valid'] else 'ISSUES'
+            wc = v['word_count']
+            print(f'  {pov_label}: {wc} words [{status}]')
+            if v['stats']:
+                s = v['stats']
+                b = s['buckets']
+                sm = s['mean_sentence_words']
+                sd = s['stddev_sentence_words']
+                smin = s['min_sentence_words']
+                smax = s['max_sentence_words']
+                print(f'    Rhythm: mean {sm}w, stddev {sd}, range {smin}-{smax}')
+                bshort = b['short']
+                bmed = b['medium']
+                bstd = b['standard']
+                blong = b['long'] + b['very_long']
+                print(f'    Distribution: {bshort}% short, {bmed}% medium, {bstd}% standard, {blong}% long')
+            for issue in v['issues']:
+                print(f'    - {issue}')
+    if ex['missing_povs']:
+        missing = ', '.join(ex['missing_povs'])
+        print(f'  Missing per-POV exemplars: {missing}')
+except Exception as e:
+    print(f'  (exemplar validation unavailable: {e})')
+
 # --- Summary ---
 print()
 print('=== Summary ===')

--- a/tests/test-hone.sh
+++ b/tests/test-hone.sh
@@ -651,3 +651,180 @@ shutil.rmtree(tmpdir)
 " 2>/dev/null)
 
 assert_contains "$RESULT" "ok" "subtext: CSV round-trip preserves subtext"
+
+# ============================================================================
+# Prose exemplar validation and rhythm signatures
+# ============================================================================
+
+echo "--- exemplars: split_sentences handles prose ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import split_sentences
+
+text = 'The car horn hit me in the chest. Violet. Deep, wet violet, the color of a bruise two days old. I blinked and it was gone. The prep station was just a prep station.'
+sents = split_sentences(text)
+assert len(sents) >= 3, f'expected >=3, got {len(sents)}: {sents}'
+print(f'count={len(sents)}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "count=" "exemplars: splits sentences"
+assert_contains "$RESULT" "ok" "exemplars: split_sentences runs"
+
+echo "--- exemplars: compute_rhythm_signature returns metrics ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import compute_rhythm_signature
+
+text = '''The car horn hit me in the chest before I heard it.
+Violet. Deep, wet violet, the color of a bruise two days old, blooming across the stainless steel counter.
+I blinked and it was gone.
+The prep station was just a prep station again: cutting boards, mise en place, the half-sliced pile of Roma tomatoes.
+Outside, the horn blared again. Lighter this time.
+I went back to the tomatoes. Knife work was good for this. You could not think about colors when you had eight inches of carbon steel moving through flesh at speed.'''
+
+sig = compute_rhythm_signature(text)
+assert sig is not None, 'signature should not be None'
+assert 'mean_sentence_words' in sig, f'missing key: {list(sig.keys())}'
+assert 'buckets' in sig, 'missing buckets'
+assert sig['sentence_count'] >= 5, f'too few sentences: {sig[\"sentence_count\"]}'
+assert sig['stddev_sentence_words'] > 0, 'stddev should be positive'
+print(f'sentences={sig[\"sentence_count\"]}')
+print(f'mean={sig[\"mean_sentence_words\"]}')
+print(f'stddev={sig[\"stddev_sentence_words\"]}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "exemplars: rhythm signature computed"
+assert_contains "$RESULT" "mean=" "exemplars: has mean"
+assert_contains "$RESULT" "stddev=" "exemplars: has stddev"
+
+echo "--- exemplars: format_rhythm_for_prompt produces text ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import compute_rhythm_signature, format_rhythm_for_prompt
+
+text = 'Short. This is a medium sentence with some words. This is a much longer sentence that goes on and on and really extends the rhythm significantly beyond what you might expect from normal prose. Done.'
+sig = compute_rhythm_signature(text)
+if sig:
+    block = format_rhythm_for_prompt(sig)
+    assert 'Rhythm Target' in block, f'missing header: {block[:50]}'
+    assert '%' in block, 'missing percentages'
+    print('ok')
+else:
+    print('no_sig')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "exemplars: rhythm prompt formatted"
+
+echo "--- exemplars: validate_exemplars flags short text ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import validate_exemplars
+
+result = validate_exemplars('Too short.')
+assert not result['valid'], 'should fail'
+assert any('Too short' in i for i in result['issues']), f'missing length issue: {result[\"issues\"]}'
+print(f'issues={len(result[\"issues\"])}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "exemplars: validates short text"
+
+echo "--- exemplars: validate_exemplars passes good text ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import validate_exemplars
+
+# Good exemplar with varied rhythm
+text = '''The car horn hit me in the chest before I heard it.
+
+Violet. Deep, wet violet, the color of a bruise two days old, blooming across the stainless steel counter and dripping down the ticket rail like someone had upended a paint can. I blinked and it was gone. The prep station was just a prep station again: cutting boards, mise en place, the half-sliced pile of Roma tomatoes I had been working through for the past twenty minutes.
+
+Outside, the horn blared again. Lighter this time. Lilac around the edges.
+
+I went back to the tomatoes. Knife work was good for this. You could not think about colors that were not there when you had eight inches of carbon steel moving through flesh at speed.
+
+For twenty minutes we worked in parallel. I got the chicken into its marinade. The lentils went on to simmer. I started the onions for the soup, and the first sizzle of butter and diced yellow onion in the pan released a smell so correct, so exactly what this kitchen was supposed to smell like, that something in my chest unlocked a quarter-turn.
+
+I could do this. I was doing this.
+
+I was on the ground. My knees had hit first, I could feel the ache of impact, and my hands were flat on the tunnel floor, the stone gritty and damp under my palms. Warmth running down my upper lip. I touched my face and my fingers came away red.
+
+My hands were shaking. My whole body was shaking.'''
+
+result = validate_exemplars(text)
+print(f'valid={result[\"valid\"]}')
+print(f'issues={len(result[\"issues\"])}')
+if result['issues']:
+    for i in result['issues']:
+        print(f'  issue: {i}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "exemplars: validation runs on good text"
+
+echo "--- exemplars: validate_project_exemplars finds flat file ---"
+
+RESULT=$(python3 -c "
+${PY}
+from storyforge.exemplars import validate_project_exemplars
+
+result = validate_project_exemplars('${FIXTURE_DIR}')
+print(f'has_any={result[\"has_any\"]}')
+print(f'files={len(result[\"files\"])}')
+print('ok')
+" 2>/dev/null)
+
+assert_contains "$RESULT" "ok" "exemplars: project validation runs"
+
+echo "--- exemplars: per-POV loading prefers POV file ---"
+
+RESULT=$(python3 -c "
+${PY}
+import os, tempfile, shutil
+
+# Create temp project with per-POV exemplar
+tmpdir = tempfile.mkdtemp()
+ref = os.path.join(tmpdir, 'reference')
+shutil.copytree('${FIXTURE_DIR}/reference', ref)
+
+# Create per-POV exemplar directory and file
+exemplars_dir = os.path.join(ref, 'exemplars')
+os.makedirs(exemplars_dir, exist_ok=True)
+with open(os.path.join(exemplars_dir, 'dorren-hayle.md'), 'w') as f:
+    f.write('Per-POV content for Dorren.')
+
+# Also ensure flat file exists
+with open(os.path.join(ref, 'prose-exemplars.md'), 'w') as f:
+    f.write('Flat file content.')
+
+# Test loading with POV
+from storyforge.prompts import _load_prose_exemplars
+result = _load_prose_exemplars(tmpdir, 'Dorren Hayle')
+assert 'Per-POV content' in result, f'should load per-POV: {result[:80]}'
+print('per_pov=loaded')
+
+# Test fallback without matching POV
+result2 = _load_prose_exemplars(tmpdir, 'Unknown Character')
+assert 'Flat file content' in result2, f'should fall back to flat: {result2[:80]}'
+print('fallback=loaded')
+
+# Test no POV at all
+result3 = _load_prose_exemplars(tmpdir)
+assert 'Flat file content' in result3, f'should load flat: {result3[:80]}'
+print('no_pov=loaded')
+
+print('ok')
+shutil.rmtree(tmpdir)
+" 2>/dev/null)
+
+assert_contains "$RESULT" "per_pov=loaded" "exemplars: per-POV file loaded"
+assert_contains "$RESULT" "fallback=loaded" "exemplars: falls back to flat file"
+assert_contains "$RESULT" "no_pov=loaded" "exemplars: loads flat when no POV"
+assert_contains "$RESULT" "ok" "exemplars: per-POV loading works"


### PR DESCRIPTION
## Summary
- New `exemplars.py` module: sentence splitting, rhythm signature extraction, exemplar validation, project-level scanning
- Per-POV exemplar loading: `reference/exemplars/{pov-slug}.md` preferred, falls back to `reference/prose-exemplars.md`
- Rhythm signatures auto-injected into drafting prompt as quantified constraints (sentence length distribution, range, stddev)
- Exemplar validation checks: length, sentence variety (stddev), 15-25 word clustering, prohibited patterns (antithesis, tricolon, metaphor restatement, interpretive tagging)
- `--diagnose` now shows Prose Exemplars section with rhythm stats and quality flags

## Test plan
- [x] 1044/1044 tests pass (13 new)
- [x] Diagnose against unicorn-tail shows exemplar stats and flags tricolon pattern
- [ ] Verify per-POV loading with multi-POV project

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)