### PR TITLE
Fix _redraft_scenes writing scene markers to disk

### DIFF
--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -692,6 +692,7 @@ def _redraft_scenes(project_dir: str, scene_ids: list[str]) -> int:
     """
     from storyforge.prompts import build_scene_prompt
     from storyforge.common import get_coaching_level
+    from storyforge.parsing import extract_single_scene
 
     scenes_dir = os.path.join(project_dir, 'scenes')
     coaching_level = get_coaching_level(project_dir)
@@ -717,8 +718,9 @@ def _redraft_scenes(project_dir: str, scene_ids: list[str]) -> int:
             log(f'  WARNING: No response for {scene_id} re-draft — skipping')
             continue
 
+        extracted = extract_single_scene(response)
         with open(scene_file, 'w', encoding='utf-8') as f:
-            f.write(response)
+            f.write(extracted if extracted else response)
 
         count += 1
         log(f'  Re-drafted {scene_id}')

--- a/tests/test_redraft_markers.py
+++ b/tests/test_redraft_markers.py
@@ -1,0 +1,72 @@
+"""Regression test for #151: _redraft_scenes must strip scene markers.
+
+When the Claude API returns text wrapped in === SCENE: id === / === END SCENE ===
+delimiters, _redraft_scenes should strip them before writing the scene file.
+"""
+
+import os
+from unittest.mock import patch
+
+
+def test_redraft_strips_scene_markers(project_dir):
+    """Verify that _redraft_scenes strips === SCENE === markers from API output."""
+    from storyforge.cmd_revise import _redraft_scenes
+
+    # Create a scene file so _redraft_scenes will process it
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    scene_file = os.path.join(scenes_dir, 'test-scene.md')
+    with open(scene_file, 'w') as f:
+        f.write('old content')
+
+    # Simulate an API response wrapped in scene markers
+    api_response = (
+        '=== SCENE: test-scene ===\n'
+        'The rain fell softly on the cobblestones.\n'
+        '\n'
+        'She paused at the corner, listening.\n'
+        '=== END SCENE: test-scene ==='
+    )
+
+    with patch('storyforge.cmd_revise.invoke_api', return_value=api_response), \
+         patch('storyforge.cmd_revise.select_model', return_value='claude-sonnet-4-6'), \
+         patch('storyforge.prompts.build_scene_prompt', return_value='fake prompt'), \
+         patch('storyforge.common.get_coaching_level', return_value='full'):
+        count = _redraft_scenes(project_dir, ['test-scene'])
+
+    assert count == 1
+    with open(scene_file) as f:
+        content = f.read()
+
+    # The markers must NOT appear in the written file
+    assert '=== SCENE:' not in content
+    assert '=== END SCENE:' not in content
+
+    # The actual prose must be present
+    assert 'The rain fell softly on the cobblestones.' in content
+    assert 'She paused at the corner, listening.' in content
+
+
+def test_redraft_preserves_clean_response(project_dir):
+    """When the API response has no markers, it should be written as-is."""
+    from storyforge.cmd_revise import _redraft_scenes
+
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    scene_file = os.path.join(scenes_dir, 'clean-scene.md')
+    with open(scene_file, 'w') as f:
+        f.write('old content')
+
+    clean_response = 'The rain fell softly on the cobblestones.\n\nShe paused at the corner.'
+
+    with patch('storyforge.cmd_revise.invoke_api', return_value=clean_response), \
+         patch('storyforge.cmd_revise.select_model', return_value='claude-sonnet-4-6'), \
+         patch('storyforge.prompts.build_scene_prompt', return_value='fake prompt'), \
+         patch('storyforge.common.get_coaching_level', return_value='full'):
+        count = _redraft_scenes(project_dir, ['clean-scene'])
+
+    assert count == 1
+    with open(scene_file) as f:
+        content = f.read()
+
+    assert content == clean_response


### PR DESCRIPTION
## Summary
- `_redraft_scenes` in `cmd_revise.py` was writing raw Claude API responses (including `=== SCENE: id ===` / `=== END SCENE: id ===` delimiters) directly to scene files
- Now calls `extract_single_scene()` from `storyforge.parsing` to strip markers before writing, matching the pattern already used in `cmd_write.py`
- Falls back to the raw response if no markers are found (clean responses written as-is)

Closes #151

## Test plan
- [x] Regression test `test_redraft_strips_scene_markers` verifies markers are removed
- [x] Regression test `test_redraft_preserves_clean_response` verifies marker-free responses are unchanged
- [x] Full test suite passes (889 passed, 10 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)