### PR TITLE
Fix write pipeline: strip scene titles and continuity blocks

### DIFF
--- a/scripts/lib/python/storyforge/cmd_write.py
+++ b/scripts/lib/python/storyforge/cmd_write.py
@@ -326,15 +326,20 @@ def _build_prompt(scene_id: str, project_dir: str, coaching: str,
 
 def _extract_scene_from_response(log_file: str, scene_file: str) -> None:
     """Extract scene prose from API response."""
-    from storyforge.parsing import extract_single_scene
+    from storyforge.parsing import extract_single_scene, clean_scene_content
     text = extract_text_from_file(log_file)
     if not text:
         log(f'WARNING: Empty API response for {scene_file}')
         return
 
     extracted = extract_single_scene(text)
+    content = extracted if extracted else text
+
+    # Strip writing-agent artifacts (scene title headers, continuity blocks)
+    content = clean_scene_content(content)
+
     with open(scene_file, 'w') as f:
-        f.write(extracted if extracted else text)
+        f.write(content)
 
 
 def _verify_and_commit_scene(scene_id: str, project_dir: str, scenes_dir: str,

--- a/scripts/lib/python/storyforge/parsing.py
+++ b/scripts/lib/python/storyforge/parsing.py
@@ -172,6 +172,64 @@ def _write_scene(scene_id: str, lines: list[str], scene_dir: str, written: list[
     written.append(scene_id)
 
 
+def clean_scene_content(text: str) -> str:
+    """Strip writing-agent artifacts from scene content.
+
+    Removes two common artifacts that the writing agent sometimes produces:
+    1. Leading H1/H2 scene title headers (and any blank lines after them)
+    2. Trailing ``---`` separator followed by a Continuity Tracker Update block
+
+    The result is trimmed of leading/trailing whitespace and given a single
+    trailing newline.
+
+    Args:
+        text: Raw scene content (prose with possible artifacts).
+
+    Returns:
+        Cleaned scene content.
+    """
+    if not text or not text.strip():
+        return text
+
+    lines = text.splitlines()
+
+    # --- Strip leading H1/H2 title headers ---
+    # Skip any leading blank lines first, then check for a header.
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    if lines and re.match(r'^#{1,2}\s+\S', lines[0]):
+        lines.pop(0)
+        # Strip blank lines immediately after the removed header
+        while lines and not lines[0].strip():
+            lines.pop(0)
+
+    # --- Strip trailing Continuity Tracker Update block ---
+    # Look for a ``---`` separator followed by a ``# Continuity Tracker``
+    # header (any heading level). Everything from the separator onward is
+    # removed.
+    separator_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        stripped = lines[i].strip()
+        if re.match(r'^#{1,3}\s+[Cc]ontinuity\s+[Tt]racker', stripped):
+            # Walk backwards to find the preceding ``---`` separator
+            j = i - 1
+            while j >= 0 and not lines[j].strip():
+                j -= 1
+            if j >= 0 and lines[j].strip() == '---':
+                separator_idx = j
+            else:
+                # No separator — still strip from the header onward
+                separator_idx = i
+            break
+
+    if separator_idx is not None:
+        lines = lines[:separator_idx]
+
+    # Final trim
+    content = '\n'.join(lines).strip()
+    return content + '\n' if content else ''
+
+
 def _trim_blank_lines(text: str) -> str:
     """Remove leading and trailing blank lines."""
     lines = text.splitlines()

--- a/tests/test_clean_scene_content.py
+++ b/tests/test_clean_scene_content.py
@@ -1,0 +1,192 @@
+"""Regression tests for clean_scene_content in parsing.py.
+
+Issue #152: Write pipeline should strip scene titles and continuity tracker
+blocks from output before committing scene files.
+"""
+
+from storyforge.parsing import clean_scene_content
+
+
+class TestStripLeadingHeaders:
+    """Strip H1/H2 scene title headers from the start of scene content."""
+
+    def test_strip_h1_title(self):
+        text = "# The Third Drawer Stays Closed\n\nThe drawer had been sealed.\n"
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed.\n"
+
+    def test_strip_h2_title(self):
+        text = "## The Third Drawer Stays Closed\n\nThe drawer had been sealed.\n"
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed.\n"
+
+    def test_strip_h1_with_leading_blanks(self):
+        text = "\n\n# The Third Drawer Stays Closed\n\nThe drawer had been sealed.\n"
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed.\n"
+
+    def test_strip_h1_no_trailing_blank(self):
+        text = "# Scene Title\nThe prose starts here.\n"
+        result = clean_scene_content(text)
+        assert result == "The prose starts here.\n"
+
+    def test_no_header_unchanged(self):
+        text = "The drawer had been sealed for years.\n"
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed for years.\n"
+
+    def test_h3_not_stripped(self):
+        """H3 and below are not scene titles — they should be kept."""
+        text = "### A Section Header\n\nSome prose.\n"
+        result = clean_scene_content(text)
+        assert result == "### A Section Header\n\nSome prose.\n"
+
+    def test_midfile_header_not_stripped(self):
+        """Only leading headers are stripped; mid-file headers are kept."""
+        text = "Some prose.\n\n# A Later Section\n\nMore prose.\n"
+        result = clean_scene_content(text)
+        assert result == "Some prose.\n\n# A Later Section\n\nMore prose.\n"
+
+    def test_header_must_have_content_after_hash(self):
+        """A line that is just '#' or '## ' is not a header to strip."""
+        text = "#\n\nSome prose.\n"
+        result = clean_scene_content(text)
+        assert result == "#\n\nSome prose.\n"
+
+
+class TestStripContinuityTracker:
+    """Strip trailing Continuity Tracker Update blocks."""
+
+    def test_strip_continuity_block_with_separator(self):
+        text = (
+            "The drawer had been sealed.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "# Continuity Tracker Update\n"
+            "\n"
+            "## Character States\n"
+            "- Elara: frustrated\n"
+            "\n"
+            "## Established Details\n"
+            "- The drawer is locked\n"
+        )
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed.\n"
+
+    def test_strip_continuity_block_h2(self):
+        text = (
+            "Some prose here.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "## Continuity Tracker Update\n"
+            "\n"
+            "- Detail one\n"
+        )
+        result = clean_scene_content(text)
+        assert result == "Some prose here.\n"
+
+    def test_strip_continuity_block_h3(self):
+        text = (
+            "Some prose here.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "### Continuity tracker update\n"
+            "\n"
+            "- Detail one\n"
+        )
+        result = clean_scene_content(text)
+        assert result == "Some prose here.\n"
+
+    def test_strip_continuity_block_no_separator(self):
+        """Continuity block without --- separator should still be stripped."""
+        text = (
+            "Some prose here.\n"
+            "\n"
+            "# Continuity Tracker Update\n"
+            "\n"
+            "- Character states\n"
+        )
+        result = clean_scene_content(text)
+        assert result == "Some prose here.\n"
+
+    def test_no_continuity_block_unchanged(self):
+        text = "The drawer had been sealed.\n\nShe turned the key.\n"
+        result = clean_scene_content(text)
+        assert result == "The drawer had been sealed.\n\nShe turned the key.\n"
+
+    def test_separator_without_continuity_header_kept(self):
+        """A trailing --- that is NOT followed by a Continuity header stays."""
+        text = "Some prose.\n\n---\n\nMore prose.\n"
+        result = clean_scene_content(text)
+        assert result == "Some prose.\n\n---\n\nMore prose.\n"
+
+
+class TestBothArtifacts:
+    """Strip both title header and continuity block together."""
+
+    def test_strip_title_and_continuity(self):
+        text = (
+            "# The Third Drawer Stays Closed\n"
+            "\n"
+            "The drawer had been sealed for years.\n"
+            "\n"
+            "She reached for it anyway.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "# Continuity Tracker Update\n"
+            "\n"
+            "## Character States\n"
+            "- Elara: anxious\n"
+        )
+        result = clean_scene_content(text)
+        expected = (
+            "The drawer had been sealed for years.\n"
+            "\n"
+            "She reached for it anyway.\n"
+        )
+        assert result == expected
+
+
+class TestEdgeCases:
+    """Edge cases for clean_scene_content."""
+
+    def test_empty_string(self):
+        assert clean_scene_content("") == ""
+
+    def test_whitespace_only(self):
+        assert clean_scene_content("   \n\n  ") == "   \n\n  "
+
+    def test_none_passthrough(self):
+        """None input should pass through without error."""
+        # The function checks for falsy input first
+        assert clean_scene_content(None) is None
+
+    def test_only_header_then_empty(self):
+        text = "# Just a Title\n"
+        result = clean_scene_content(text)
+        assert result == ""
+
+    def test_preserves_internal_structure(self):
+        """Internal section breaks and formatting should be preserved."""
+        text = (
+            "She opened the door.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "Hours later, the sun set.\n"
+            "\n"
+            "The end.\n"
+        )
+        result = clean_scene_content(text)
+        assert result == text.strip() + "\n"
+
+    def test_ensures_single_trailing_newline(self):
+        text = "Some prose.\n\n\n"
+        result = clean_scene_content(text)
+        assert result == "Some prose.\n"
+        assert result.endswith("\n")
+        assert not result.endswith("\n\n")


### PR DESCRIPTION
## Summary
- Adds `clean_scene_content()` to `parsing.py` that strips two writing-agent artifacts from scene output before files are committed
- **Leading H1/H2 scene title headers** (and trailing blank lines) are removed — scene titles belong in `scenes.csv`, not the prose file
- **Trailing Continuity Tracker Update blocks** (preceded by `---` separator) are removed — metadata doesn't belong in scene files
- Called from `_extract_scene_from_response` in `cmd_write.py`, which is the single point where all write-pipeline scene content flows to disk

## Test plan
- [x] 21 regression tests in `tests/test_clean_scene_content.py` covering:
  - H1 and H2 header stripping (with/without leading blanks, mid-file headers preserved)
  - Continuity Tracker block stripping (with/without `---` separator, H1/H2/H3 variants)
  - Combined artifacts (both title + continuity block)
  - Edge cases (empty input, whitespace-only, internal `---` separators preserved)
- [x] Full test suite passes (908 passed, 10 skipped)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)