### PR TITLE
Fix CRLF line endings breaking CSV field appends

### DIFF
--- a/scripts/lib/python/storyforge/cmd_migrate.py
+++ b/scripts/lib/python/storyforge/cmd_migrate.py
@@ -29,11 +29,16 @@ from storyforge.git import commit_and_push, ensure_on_branch
 # ============================================================================
 
 def _read_csv(path: str) -> tuple[list[str], list[dict]]:
-    """Read a pipe-delimited CSV. Returns (header_fields, rows_as_dicts)."""
+    """Read a pipe-delimited CSV. Returns (header_fields, rows_as_dicts).
+
+    Strips ``\\r`` so CRLF line endings and stray carriage returns embedded
+    by awk-based CSV edits never propagate into field values.
+    """
     if not os.path.isfile(path):
         return [], []
-    with open(path, encoding='utf-8') as f:
-        lines = [l.rstrip('\n') for l in f if l.strip()]
+    with open(path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = [l for l in raw.splitlines() if l.strip()]
     if not lines:
         return [], []
     header = lines[0].split('|')

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -83,14 +83,18 @@ CSV_PLAN_FIELDS = ['pass', 'name', 'purpose', 'scope', 'targets', 'guidance',
 
 
 def _read_csv_plan(plan_file):
-    """Read the CSV revision plan. Returns list of row dicts."""
+    """Read the CSV revision plan. Returns list of row dicts.
+
+    Strips ``\\r`` so CRLF line endings never propagate into field values.
+    """
     if not os.path.isfile(plan_file):
         return []
+    with open(plan_file, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
     rows = []
-    with open(plan_file) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            rows.append({k: (v if v is not None else '') for k, v in row.items()})
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        rows.append({k: (v if v is not None else '') for k, v in row.items()})
     return rows
 
 
@@ -322,14 +326,15 @@ def _generate_structural_plan(project_dir, plan_file):
         log('Run: storyforge-validate --structural')
         sys.exit(1)
 
-    # Read proposals
+    # Read proposals (strip \r for CRLF safety)
     proposals = []
-    with open(proposals_file) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            row = {k: (v if v is not None else '') for k, v in row.items()}
-            if row.get('status', '').strip() == 'pending':
-                proposals.append(row)
+    with open(proposals_file, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        row = {k: (v if v is not None else '') for k, v in row.items()}
+        if row.get('status', '').strip() == 'pending':
+            proposals.append(row)
 
     if not proposals:
         log(f'ERROR: No pending proposals in {proposals_file}')
@@ -392,11 +397,12 @@ def _read_diagnosis(cycle_dir: str) -> list[dict]:
     diag_file = os.path.join(cycle_dir, 'diagnosis.csv')
     if not os.path.isfile(diag_file):
         return []
+    with open(diag_file, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
     rows = []
-    with open(diag_file) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            rows.append({k: (v if v is not None else '') for k, v in row.items()})
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        rows.append({k: (v if v is not None else '') for k, v in row.items()})
     return rows
 
 

--- a/scripts/lib/python/storyforge/csv_cli.py
+++ b/scripts/lib/python/storyforge/csv_cli.py
@@ -20,9 +20,14 @@ DELIMITER = '|'
 
 
 def _read_lines(path):
-    """Read file lines, stripping \\r and trailing whitespace."""
-    with open(path, encoding='utf-8') as f:
-        return [line.rstrip('\r\n') for line in f]
+    """Read file lines, stripping \\r and trailing whitespace.
+
+    Reads the entire file and normalises all line endings (CRLF and stray
+    ``\\r`` characters embedded by awk-based CSV edits) before splitting.
+    """
+    with open(path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    return raw.splitlines()
 
 
 def _write_lines(path, lines):

--- a/scripts/lib/python/storyforge/elaborate.py
+++ b/scripts/lib/python/storyforge/elaborate.py
@@ -49,13 +49,18 @@ def _read_csv(path: str) -> list[dict[str, str]]:
 
     Coerces None values to '' so callers can safely call .strip() etc.
     (csv.DictReader stores None when rows have fewer fields than headers.)
+
+    Strips ``\\r`` from all field values and header names so that CRLF line
+    endings (and stray ``\\r`` characters embedded by awk-based CSV edits)
+    never propagate into downstream code.
     """
     if not os.path.exists(path):
         return []
     with open(path, newline='', encoding='utf-8') as f:
-        reader = csv.DictReader(f, delimiter=DELIMITER)
-        return [{k: (v if v is not None else '') for k, v in row.items()}
-                for row in reader]
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    reader = csv.DictReader(raw.splitlines(), delimiter=DELIMITER)
+    return [{k: (v if v is not None else '') for k, v in row.items()}
+            for row in reader]
 
 
 def _read_csv_as_map(path: str) -> dict[str, dict[str, str]]:

--- a/scripts/lib/python/storyforge/history.py
+++ b/scripts/lib/python/storyforge/history.py
@@ -44,14 +44,16 @@ def _read_history(project_dir: str) -> list[dict[str, str]]:
 
     Returns [] if the file does not exist.
     Coerces None → '' (csv.DictReader returns None for short rows).
+    Strips ``\\r`` so CRLF line endings never propagate into field values.
     """
     path = _history_path(project_dir)
     if not os.path.exists(path):
         return []
     with open(path, newline='', encoding='utf-8') as f:
-        reader = csv.DictReader(f, delimiter=DELIMITER)
-        return [{k: (v if v is not None else '') for k, v in row.items()}
-                for row in reader]
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    reader = csv.DictReader(raw.splitlines(), delimiter=DELIMITER)
+    return [{k: (v if v is not None else '') for k, v in row.items()}
+            for row in reader]
 
 
 # ============================================================================
@@ -71,11 +73,12 @@ def append_cycle(scores_dir: str, cycle: int, project_dir: str) -> int:
     if not os.path.exists(scores_path):
         return 0
 
-    # Read the scene-scores CSV
+    # Read the scene-scores CSV (strip \r for CRLF safety)
     with open(scores_path, newline='', encoding='utf-8') as f:
-        reader = csv.DictReader(f, delimiter=DELIMITER)
-        score_rows = [{k: (v if v is not None else '') for k, v in row.items()}
-                      for row in reader]
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    reader = csv.DictReader(raw.splitlines(), delimiter=DELIMITER)
+    score_rows = [{k: (v if v is not None else '') for k, v in row.items()}
+                  for row in reader]
 
     if not score_rows:
         return 0

--- a/scripts/lib/python/storyforge/hone.py
+++ b/scripts/lib/python/storyforge/hone.py
@@ -1307,31 +1307,33 @@ def load_external_findings(findings_file: str) -> list[dict]:
     """
     if not os.path.isfile(findings_file):
         return []
+    # Strip \r for CRLF safety
+    with open(findings_file, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
     results = []
-    with open(findings_file) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            sid = row.get('scene_id', '').strip()
-            target_file = row.get('target_file', '').strip()
-            fields_raw = row.get('fields', '').strip()
-            guidance = row.get('guidance', '').strip()
-            if not sid:
-                continue
-            if fields_raw:
-                for field in fields_raw.split(';'):
-                    field = field.strip()
-                    if field:
-                        results.append({
-                            'scene_id': sid, 'field': field,
-                            'target_file': target_file,
-                            'guidance': guidance, 'issue': 'evaluation',
-                        })
-            else:
-                results.append({
-                    'scene_id': sid, 'field': '',
-                    'target_file': target_file,
-                    'guidance': guidance, 'issue': 'evaluation',
-                })
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        sid = row.get('scene_id', '').strip()
+        target_file = row.get('target_file', '').strip()
+        fields_raw = row.get('fields', '').strip()
+        guidance = row.get('guidance', '').strip()
+        if not sid:
+            continue
+        if fields_raw:
+            for field in fields_raw.split(';'):
+                field = field.strip()
+                if field:
+                    results.append({
+                        'scene_id': sid, 'field': field,
+                        'target_file': target_file,
+                        'guidance': guidance, 'issue': 'evaluation',
+                    })
+        else:
+            results.append({
+                'scene_id': sid, 'field': '',
+                'target_file': target_file,
+                'guidance': guidance, 'issue': 'evaluation',
+            })
     return results
 
 

--- a/scripts/lib/python/storyforge/prompts.py
+++ b/scripts/lib/python/storyforge/prompts.py
@@ -70,9 +70,14 @@ def _strip_yaml_value(raw: str) -> str:
 # ============================================================================
 
 def _read_csv_header_and_rows(csv_file: str) -> tuple[list[str], list[list[str]]]:
-    """Read a pipe-delimited CSV, returning (header_fields, data_rows)."""
-    with open(csv_file) as f:
-        lines = [l.rstrip('\n') for l in f if l.strip()]
+    """Read a pipe-delimited CSV, returning (header_fields, data_rows).
+
+    Strips ``\\r`` so CRLF line endings and stray carriage returns embedded
+    by awk-based CSV edits never propagate into field values.
+    """
+    with open(csv_file, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = [l for l in raw.splitlines() if l.strip()]
 
     if not lines:
         return [], []

--- a/scripts/lib/python/storyforge/revision.py
+++ b/scripts/lib/python/storyforge/revision.py
@@ -66,12 +66,17 @@ def resolve_scene_file(scene_dir: str, scene_id: str) -> str | None:
 # ============================================================================
 
 def _read_pipe_csv(csv_path: str) -> list[dict]:
-    """Read a pipe-delimited CSV file into a list of dicts."""
+    """Read a pipe-delimited CSV file into a list of dicts.
+
+    Strips ``\\r`` so CRLF line endings and stray carriage returns embedded
+    by awk-based CSV edits never propagate into field values.
+    """
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
     rows = []
-    with open(csv_path) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            rows.append({k: (v if v is not None else '') for k, v in row.items()})
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        rows.append({k: (v if v is not None else '') for k, v in row.items()})
     return rows
 
 
@@ -349,20 +354,21 @@ def _load_author_exemplars(project_dir: str, principles: list[str]) -> str:
     target_set = set(principles)
     entries = []
 
-    with open(exemplars_path) as f:
-        reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            principle = (row.get('principle') or '').strip()
-            if principle not in target_set:
-                continue
-            excerpt = (row.get('excerpt') or '').strip()
-            scene_id = (row.get('scene_id') or '').strip()
-            score = (row.get('score') or '').strip()
-            if excerpt:
-                entries.append(
-                    f'**{principle}** (score {score}, scene `{scene_id}`):\n'
-                    f'> {excerpt}'
-                )
+    with open(exemplars_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    reader = csv.DictReader(raw.splitlines(), delimiter='|')
+    for row in reader:
+        principle = (row.get('principle') or '').strip()
+        if principle not in target_set:
+            continue
+        excerpt = (row.get('excerpt') or '').strip()
+        scene_id = (row.get('scene_id') or '').strip()
+        score = (row.get('score') or '').strip()
+        if excerpt:
+            entries.append(
+                f'**{principle}** (score {score}, scene `{scene_id}`):\n'
+                f'> {excerpt}'
+            )
 
     return '\n\n'.join(entries)
 

--- a/scripts/lib/python/storyforge/scene_filter.py
+++ b/scripts/lib/python/storyforge/scene_filter.py
@@ -15,11 +15,16 @@ MIN_SCENE_WORDS = int(os.environ.get('STORYFORGE_MIN_SCENE_WORDS', '50'))
 
 
 def _read_csv_rows(csv_path: str) -> list[dict[str, str]]:
-    """Read a pipe-delimited CSV into a list of dicts."""
+    """Read a pipe-delimited CSV into a list of dicts.
+
+    Strips ``\\r`` so CRLF line endings and stray carriage returns embedded
+    by awk-based CSV edits never propagate into field values.
+    """
     if not os.path.isfile(csv_path):
         return []
-    with open(csv_path) as f:
-        lines = [l.strip() for l in f if l.strip()]
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = [l for l in raw.splitlines() if l.strip()]
     if not lines:
         return []
     headers = lines[0].split(DELIMITER)

--- a/scripts/lib/python/storyforge/scenes.py
+++ b/scripts/lib/python/storyforge/scenes.py
@@ -311,9 +311,10 @@ def generate_rename_plan(scenes_dir: str,
     if not os.path.isfile(metadata_csv):
         return []
 
-    # Read the CSV
-    with open(metadata_csv) as f:
-        csv_lines = [l.rstrip('\n') for l in f if l.strip()]
+    # Read the CSV (strip \r for CRLF safety)
+    with open(metadata_csv, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    csv_lines = [l for l in raw.splitlines() if l.strip()]
 
     if not csv_lines:
         return []

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -32,9 +32,14 @@ SCORE_FILES = [
 # ============================================================================
 
 def _read_csv(path: str) -> tuple[list[str], list[list[str]]]:
-    """Read a pipe-delimited CSV. Returns (header_fields, data_rows)."""
-    with open(path) as f:
-        lines = [line.rstrip('\n') for line in f if line.strip()]
+    """Read a pipe-delimited CSV. Returns (header_fields, data_rows).
+
+    Strips ``\\r`` so CRLF line endings and stray carriage returns embedded
+    by awk-based CSV edits never propagate into field values.
+    """
+    with open(path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = [line for line in raw.splitlines() if line.strip()]
     if not lines:
         return [], []
     header = lines[0].split('|')

--- a/scripts/lib/python/storyforge/visualize.py
+++ b/scripts/lib/python/storyforge/visualize.py
@@ -26,8 +26,9 @@ def csv_to_records(csv_file: str) -> list[dict]:
         return []
 
     try:
-        with open(csv_file, encoding='utf-8') as f:
-            lines = f.read().splitlines()
+        with open(csv_file, newline='', encoding='utf-8') as f:
+            raw = f.read().replace('\r\n', '\n').replace('\r', '')
+        lines = raw.splitlines()
     except (OSError, UnicodeDecodeError):
         return []
 

--- a/tests/test_crlf.py
+++ b/tests/test_crlf.py
@@ -1,0 +1,337 @@
+"""Regression tests for CRLF line-ending handling in CSV readers.
+
+Verifies that all CSV reading functions correctly handle:
+  1. Pure CRLF files (\\r\\n line endings)
+  2. Stray \\r embedded mid-field (from awk-based CSV edits on CRLF files)
+  3. Mixed line endings (\\r\\n and \\n)
+
+See GitHub issue #136: Hone/elaborate awk appends break on CRLF line endings.
+"""
+
+import os
+
+
+# ============================================================================
+# Helper: write CRLF content to a temp file
+# ============================================================================
+
+def _write_crlf(tmp_path, filename, content_bytes):
+    """Write raw bytes to a file, returning the path."""
+    path = str(tmp_path / filename)
+    with open(path, 'wb') as f:
+        f.write(content_bytes)
+    return path
+
+
+# ============================================================================
+# Pure CRLF line endings
+# ============================================================================
+
+CRLF_SCENES = (
+    b'id|seq|title|pov|status|word_count|target_words\r\n'
+    b'sc-01|1|Opening|Alice|drafted|500|2000\r\n'
+    b'sc-02|2|Midpoint|Bob|briefed|0|2500\r\n'
+)
+
+CRLF_INTENT = (
+    b'id|function|action_sequel|emotional_arc|value_at_stake|'
+    b'value_shift|turning_point|characters|on_stage|mice_threads\r\n'
+    b'sc-01|Setup|action|calm to tense|trust|+to-|yes|Alice;Bob|Alice|thread-a;thread-b\r\n'
+    b'sc-02|Rising|sequel|tense to resolve|loyalty|neutral|no|Bob|Bob|thread-b\r\n'
+)
+
+CRLF_BRIEFS = (
+    b'id|goal|conflict|outcome\r\n'
+    b'sc-01|Establish setting|Internal doubt|Tentative hope\r\n'
+    b'sc-02|Raise stakes|External threat|Cliffhanger\r\n'
+)
+
+
+class TestCsvCliCrlf:
+    """csv_cli functions handle CRLF files."""
+
+    def test_get_field_crlf(self, tmp_path):
+        from storyforge.csv_cli import get_field
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        assert get_field(path, 'sc-01', 'title') == 'Opening'
+        assert get_field(path, 'sc-02', 'status') == 'briefed'
+        # Last field should NOT have \r
+        assert get_field(path, 'sc-01', 'target_words') == '2000'
+
+    def test_get_column_crlf(self, tmp_path):
+        from storyforge.csv_cli import get_column
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        titles = get_column(path, 'title')
+        assert titles == ['Opening', 'Midpoint']
+        # No \r in any value
+        for t in titles:
+            assert '\r' not in t
+
+    def test_list_ids_crlf(self, tmp_path):
+        from storyforge.csv_cli import list_ids
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        ids = list_ids(path)
+        assert ids == ['sc-01', 'sc-02']
+
+    def test_update_field_crlf(self, tmp_path):
+        from storyforge.csv_cli import get_field, update_field
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        update_field(path, 'sc-01', 'word_count', '999')
+        assert get_field(path, 'sc-01', 'word_count') == '999'
+        # File should now be LF-only (our writers use \n)
+        with open(path, 'rb') as f:
+            assert b'\r' not in f.read()
+
+
+class TestElaborateCrlf:
+    """elaborate._read_csv and _read_csv_as_map handle CRLF files."""
+
+    def test_read_csv_crlf(self, tmp_path):
+        from storyforge.elaborate import _read_csv
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        rows = _read_csv(path)
+        assert len(rows) == 2
+        assert rows[0]['id'] == 'sc-01'
+        assert rows[0]['target_words'] == '2000'
+        assert rows[1]['status'] == 'briefed'
+        # No \r in any value
+        for row in rows:
+            for v in row.values():
+                assert '\r' not in v
+
+    def test_read_csv_as_map_crlf(self, tmp_path):
+        from storyforge.elaborate import _read_csv_as_map
+        path = _write_crlf(tmp_path, 'intent.csv', CRLF_INTENT)
+        m = _read_csv_as_map(path)
+        assert 'sc-01' in m
+        assert m['sc-01']['mice_threads'] == 'thread-a;thread-b'
+        assert '\r' not in m['sc-01']['mice_threads']
+
+    def test_read_csv_as_map_no_cr_in_keys(self, tmp_path):
+        from storyforge.elaborate import _read_csv_as_map
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        m = _read_csv_as_map(path)
+        for row in m.values():
+            for k in row:
+                assert '\r' not in k
+
+
+class TestScoringCrlf:
+    """scoring._read_csv handles CRLF files."""
+
+    def test_read_csv_crlf(self, tmp_path):
+        from storyforge.scoring import _read_csv
+        csv_data = (
+            b'id|pacing|voice\r\n'
+            b'sc-01|7|8\r\n'
+            b'sc-02|5|6\r\n'
+        )
+        path = _write_crlf(tmp_path, 'scores.csv', csv_data)
+        header, rows = _read_csv(path)
+        assert header == ['id', 'pacing', 'voice']
+        assert len(rows) == 2
+        assert rows[0] == ['sc-01', '7', '8']
+        assert rows[1] == ['sc-02', '5', '6']
+        # No \r anywhere
+        for field in header:
+            assert '\r' not in field
+        for row in rows:
+            for field in row:
+                assert '\r' not in field
+
+
+class TestVisualizeCrlf:
+    """visualize.csv_to_records handles CRLF files."""
+
+    def test_csv_to_records_crlf(self, tmp_path):
+        from storyforge.visualize import csv_to_records
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        records = csv_to_records(path)
+        assert len(records) == 2
+        assert records[0]['title'] == 'Opening'
+        assert records[1]['target_words'] == '2500'
+        for rec in records:
+            for v in rec.values():
+                assert '\r' not in v
+
+
+class TestSceneFilterCrlf:
+    """scene_filter._read_csv_rows handles CRLF files."""
+
+    def test_read_csv_rows_crlf(self, tmp_path):
+        from storyforge.scene_filter import _read_csv_rows
+        path = _write_crlf(tmp_path, 'scenes.csv', CRLF_SCENES)
+        rows = _read_csv_rows(path)
+        assert len(rows) == 2
+        assert rows[0]['target_words'] == '2000'
+        for row in rows:
+            for v in row.values():
+                assert '\r' not in v
+
+
+class TestPromptsCrlf:
+    """prompts._read_csv_header_and_rows handles CRLF files."""
+
+    def test_read_csv_header_and_rows_crlf(self, tmp_path):
+        from storyforge.prompts import _read_csv_header_and_rows
+        path = _write_crlf(tmp_path, 'scores.csv',
+                           b'id|pacing|voice\r\nsc-01|7|8\r\nsc-02|5|6\r\n')
+        header, rows = _read_csv_header_and_rows(path)
+        assert header == ['id', 'pacing', 'voice']
+        assert rows[0] == ['sc-01', '7', '8']
+        for field in header:
+            assert '\r' not in field
+        for row in rows:
+            for field in row:
+                assert '\r' not in field
+
+
+class TestHistoryCrlf:
+    """history._read_history handles CRLF files."""
+
+    def test_read_history_crlf(self, tmp_path):
+        from storyforge.history import _read_history
+        history_dir = tmp_path / 'working' / 'scores'
+        history_dir.mkdir(parents=True)
+        history_csv = str(history_dir / 'score-history.csv')
+        with open(history_csv, 'wb') as f:
+            f.write(b'cycle|scene_id|principle|score\r\n')
+            f.write(b'1|sc-01|pacing|7\r\n')
+            f.write(b'1|sc-02|pacing|5\r\n')
+        rows = _read_history(str(tmp_path))
+        assert len(rows) == 2
+        assert rows[0]['score'] == '7'
+        assert rows[1]['scene_id'] == 'sc-02'
+        for row in rows:
+            for v in row.values():
+                assert '\r' not in v
+
+
+class TestRevisionCrlf:
+    """revision._read_pipe_csv handles CRLF files."""
+
+    def test_read_pipe_csv_crlf(self, tmp_path):
+        from storyforge.revision import _read_pipe_csv
+        path = _write_crlf(tmp_path, 'briefs.csv', CRLF_BRIEFS)
+        rows = _read_pipe_csv(path)
+        assert len(rows) == 2
+        assert rows[0]['outcome'] == 'Tentative hope'
+        assert rows[1]['conflict'] == 'External threat'
+        for row in rows:
+            for v in row.values():
+                assert '\r' not in v
+
+
+# ============================================================================
+# Embedded \r (awk-induced corruption)
+# ============================================================================
+
+# Simulates what happens when awk appends to the last field of a CRLF file:
+# the \r ends up INSIDE the field value, not at the line ending.
+AWK_CORRUPTED_INTENT = (
+    b'id|function|mice_threads\n'
+    b'sc-01|Setup|thread-a\r;thread-b\n'  # \r embedded mid-field by awk
+    b'sc-02|Rising|thread-c\n'
+)
+
+
+class TestEmbeddedCr:
+    """All readers handle stray \\r embedded mid-field (awk corruption)."""
+
+    def test_elaborate_read_csv_embedded_cr(self, tmp_path):
+        from storyforge.elaborate import _read_csv
+        path = _write_crlf(tmp_path, 'intent.csv', AWK_CORRUPTED_INTENT)
+        rows = _read_csv(path)
+        assert len(rows) == 2
+        # The \r should be stripped, preserving both thread entries
+        mice = rows[0]['mice_threads']
+        assert '\r' not in mice
+        assert 'thread-a' in mice
+        assert 'thread-b' in mice
+
+    def test_elaborate_read_csv_as_map_embedded_cr(self, tmp_path):
+        from storyforge.elaborate import _read_csv_as_map
+        path = _write_crlf(tmp_path, 'intent.csv', AWK_CORRUPTED_INTENT)
+        m = _read_csv_as_map(path)
+        assert 'sc-01' in m
+        mice = m['sc-01']['mice_threads']
+        assert '\r' not in mice
+        # Both thread entries preserved
+        entries = [e.strip() for e in mice.split(';') if e.strip()]
+        assert 'thread-a' in entries
+        assert 'thread-b' in entries
+
+    def test_csv_cli_embedded_cr(self, tmp_path):
+        from storyforge.csv_cli import get_field
+        path = _write_crlf(tmp_path, 'intent.csv', AWK_CORRUPTED_INTENT)
+        mice = get_field(path, 'sc-01', 'mice_threads')
+        assert '\r' not in mice
+        assert 'thread-a' in mice
+        assert 'thread-b' in mice
+
+    def test_scoring_embedded_cr(self, tmp_path):
+        from storyforge.scoring import _read_csv
+        data = (
+            b'id|pacing|voice\n'
+            b'sc-01|7|8\r extra\n'  # \r embedded mid-field
+            b'sc-02|5|6\n'
+        )
+        path = _write_crlf(tmp_path, 'scores.csv', data)
+        header, rows = _read_csv(path)
+        # After fix: \r is stripped, so "8\r extra" becomes "8 extra"
+        assert len(rows) == 2
+        assert rows[0] == ['sc-01', '7', '8 extra']
+        assert rows[1] == ['sc-02', '5', '6']
+        for row in rows:
+            for field in row:
+                assert '\r' not in field
+
+    def test_visualize_embedded_cr(self, tmp_path):
+        from storyforge.visualize import csv_to_records
+        path = _write_crlf(tmp_path, 'intent.csv', AWK_CORRUPTED_INTENT)
+        records = csv_to_records(path)
+        assert len(records) == 2
+        mice = records[0]['mice_threads']
+        assert '\r' not in mice
+        assert 'thread-a' in mice
+        assert 'thread-b' in mice
+
+
+# ============================================================================
+# Mixed line endings
+# ============================================================================
+
+MIXED_ENDINGS = (
+    b'id|title|status\r\n'   # CRLF
+    b'sc-01|Opening|drafted\n'  # LF
+    b'sc-02|Midpoint|briefed\r\n'  # CRLF
+)
+
+
+class TestMixedLineEndings:
+    """Readers handle files with mixed \\r\\n and \\n line endings."""
+
+    def test_elaborate_mixed(self, tmp_path):
+        from storyforge.elaborate import _read_csv
+        path = _write_crlf(tmp_path, 'scenes.csv', MIXED_ENDINGS)
+        rows = _read_csv(path)
+        assert len(rows) == 2
+        assert rows[0]['title'] == 'Opening'
+        assert rows[1]['status'] == 'briefed'
+        for row in rows:
+            for v in row.values():
+                assert '\r' not in v
+
+    def test_csv_cli_mixed(self, tmp_path):
+        from storyforge.csv_cli import get_field
+        path = _write_crlf(tmp_path, 'scenes.csv', MIXED_ENDINGS)
+        assert get_field(path, 'sc-01', 'status') == 'drafted'
+        assert get_field(path, 'sc-02', 'status') == 'briefed'
+
+    def test_scoring_mixed(self, tmp_path):
+        from storyforge.scoring import _read_csv
+        data = b'id|score\r\nsc-01|7\nsc-02|5\r\n'
+        path = _write_crlf(tmp_path, 'scores.csv', data)
+        header, rows = _read_csv(path)
+        assert header == ['id', 'score']
+        assert rows == [['sc-01', '7'], ['sc-02', '5']]


### PR DESCRIPTION
## Summary
- Strip `\r` from all 12 CSV reading functions across the Python codebase so CRLF line endings and stray carriage returns embedded by awk-based field appends never propagate into downstream code
- Opens files with `newline=''` to prevent Python's universal newline translation from masking embedded `\r`, then explicitly removes all `\r` before parsing
- Adds 21 regression tests covering pure CRLF files, embedded `\r` from awk corruption, and mixed line endings

Closes #136

## Affected modules
`csv_cli.py`, `elaborate.py`, `scoring.py`, `visualize.py`, `scene_filter.py`, `prompts.py`, `history.py`, `revision.py`, `cmd_revise.py`, `cmd_migrate.py`, `hone.py`, `scenes.py`

## Test plan
- [x] 21 new CRLF regression tests pass (`tests/test_crlf.py`)
- [x] Full test suite passes (908 passed, 10 skipped)
- [ ] Verify on a project with CRLF line endings that `storyforge elaborate --stage mice-fill` works correctly
- [ ] Verify `storyforge hone --domain registries` works with CRLF files

🤖 Generated with [Claude Code](https://claude.com/claude-code)