### PR TITLE
Bump version to 1.7.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": {
     "name": "Ben Norris"
   },


### PR DESCRIPTION
## Summary
- Patch version bump to 1.7.2 after merging bug fixes:
  - #153 — Strip scene markers in `_redraft_scenes`
  - #154 — Strip scene titles & continuity tracker blocks from write output
  - #155 — Handle CRLF line endings in CSV reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)