### PR TITLE
Add structured cleanup report and cleanup skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,7 @@ Run: `./tests/run-tests.sh` or `python3 -m pytest tests/` or `pytest tests/test_
 | `revise` | Plan + execute revision (upstream CSV fixes + prose polish). `--polish` for craft-only. |
 | `score` | Craft + fidelity scoring |
 | `hone` | CSV data quality — registries, brief concretization, intent quality, evaluation-driven fixes, gap detection. `--diagnose` for read-only assessment. |
+| `cleanup` | Project health check — CSV schema validation, scene artifact cleanup, structural drift fixes. Generates report, works through action items. |
 | `publish` | Assemble web book + generate dashboard + push to bookshelf |
 | `produce` | Epub, PDF, print formats |
 | `init` | New project initialization |

--- a/scripts/lib/python/storyforge/cmd_cleanup.py
+++ b/scripts/lib/python/storyforge/cmd_cleanup.py
@@ -14,6 +14,7 @@ Usage:
 
 import argparse
 import glob
+import json
 import os
 import re
 import shutil
@@ -108,7 +109,7 @@ EXPECTED_WORKING_DIRS = set(
     'logs evaluations plans scores costs reviews recommendations coaching enrich timeline backups scenes-setup'.split()
 )
 EXPECTED_WORKING_FILES = set(
-    'pipeline.csv craft-weights.csv overrides.csv exemplars.csv dashboard.html'.split()
+    'pipeline.csv craft-weights.csv overrides.csv exemplars.csv dashboard.html cleanup-report.json'.split()
 )
 
 
@@ -685,72 +686,164 @@ def parse_args(argv):
 # Main
 # ============================================================================
 
-def _action_for_issue(issue: str, rename_pairs: dict[str, list[tuple[str, str]]]) -> str:
-    """Return an actionable description for a raw issue string."""
+def _classify_issue(issue: str, rename_pairs: dict[str, list[tuple[str, str]]]) -> dict | None:
+    """Convert a raw issue string into a structured finding dict.
+
+    Returns None for issues that should be suppressed (e.g. the EXTRA_COLUMN
+    side of a rename pair).
+
+    Each dict has: type, file, detail, action, command (optional), severity.
+    - severity: 'error' (breaks pipeline), 'warning' (should fix),
+                'info' (informational only)
+    """
     if issue.startswith('MISSING_CSV:'):
         path = issue.split(':', 1)[1]
         if path.startswith('working/'):
-            return f'{path} — will be created automatically on first use'
-        return f'{path} — run: storyforge elaborate (or copy from templates/)'
+            return {
+                'type': 'missing_csv', 'file': path,
+                'detail': f'{path} does not exist',
+                'action': 'Will be created automatically on first use',
+                'severity': 'info',
+            }
+        return {
+            'type': 'missing_csv', 'file': path,
+            'detail': f'{path} does not exist',
+            'action': f'Copy from templates/ or run storyforge elaborate',
+            'command': f'cp templates/{path.removeprefix("reference/")} {path}',
+            'severity': 'warning',
+        }
 
     if issue.startswith('EMPTY_CSV:'):
         path = issue.split(':', 1)[1]
-        return f'{path} is empty — check if file was truncated; restore header from templates/'
+        return {
+            'type': 'empty_csv', 'file': path,
+            'detail': f'{path} is empty (no header row)',
+            'action': 'Restore header from templates/',
+            'severity': 'error',
+        }
 
     if issue.startswith('MISSING_COLUMN:'):
         _, path, col = issue.split(':', 2)
-        # Check if this is part of a rename pair
         pairs = rename_pairs.get(path, [])
         for missing, extra in pairs:
             if col == missing:
-                return f'{path}: rename column "{extra}" → "{missing}"'
-        return f'{path}: add column "{col}" to header (and empty values to existing rows)'
+                return {
+                    'type': 'rename_column', 'file': path,
+                    'detail': f'Column "{extra}" should be "{missing}"',
+                    'action': f'Rename column "{extra}" to "{missing}" in header',
+                    'rename_from': extra, 'rename_to': missing,
+                    'severity': 'warning',
+                }
+        return {
+            'type': 'missing_column', 'file': path, 'column': col,
+            'detail': f'{path} is missing column "{col}"',
+            'action': f'Add "{col}" to header and empty values to existing rows',
+            'severity': 'warning',
+        }
 
     if issue.startswith('EXTRA_COLUMN:'):
         _, path, col = issue.split(':', 2)
-        # Suppress if already covered by a rename suggestion
         pairs = rename_pairs.get(path, [])
         for missing, extra in pairs:
             if col == extra:
-                return ''  # Already reported as a rename under MISSING_COLUMN
-        return f'{path}: unexpected column "{col}" — verify if it should be removed or added to schema'
+                return None  # Covered by the rename_column finding
+        return {
+            'type': 'extra_column', 'file': path, 'column': col,
+            'detail': f'{path} has unexpected column "{col}"',
+            'action': f'Verify if "{col}" should be removed or added to schema',
+            'severity': 'info',
+        }
 
     if issue.startswith('ORPHAN_FILE:'):
         sid = issue.split(':', 1)[1]
-        return f'scenes/{sid}.md has no metadata row — run: storyforge extract --scenes {sid}'
+        return {
+            'type': 'orphan_file', 'file': f'scenes/{sid}.md', 'scene_id': sid,
+            'detail': f'scenes/{sid}.md has no metadata row',
+            'action': 'Extract metadata or remove scene file',
+            'command': f'storyforge extract --scenes {sid}',
+            'severity': 'warning',
+        }
 
     if issue.startswith('ORPHAN_META:'):
         sid = issue.split(':', 1)[1]
-        return f'{sid} has metadata but no scene file — remove from CSVs or create scenes/{sid}.md'
+        return {
+            'type': 'orphan_meta', 'file': 'reference/scenes.csv',
+            'scene_id': sid,
+            'detail': f'"{sid}" has metadata but no scene file',
+            'action': f'Remove rows for "{sid}" from CSVs or create scenes/{sid}.md',
+            'severity': 'warning',
+        }
 
     if issue.startswith('MISSING_INTENT:'):
         sid = issue.split(':', 1)[1]
-        return f'{sid} is in scenes.csv but not scene-intent.csv — run: storyforge hone --domain gaps'
+        return {
+            'type': 'missing_intent', 'file': 'reference/scene-intent.csv',
+            'scene_id': sid,
+            'detail': f'"{sid}" is in scenes.csv but not scene-intent.csv',
+            'action': 'Fill intent gaps',
+            'command': 'storyforge hone --domain gaps',
+            'severity': 'warning',
+        }
 
     if issue.startswith('EXTRA_INTENT:'):
         sid = issue.split(':', 1)[1]
-        return f'{sid} is in scene-intent.csv but not scenes.csv — remove the row or add to scenes.csv'
+        return {
+            'type': 'extra_intent', 'file': 'reference/scene-intent.csv',
+            'scene_id': sid,
+            'detail': f'"{sid}" is in scene-intent.csv but not scenes.csv',
+            'action': f'Remove the row from scene-intent.csv or add "{sid}" to scenes.csv',
+            'severity': 'warning',
+        }
 
     if issue.startswith('BAD_CHAPTER_REF:'):
         sid = issue.split(':', 1)[1]
-        return f'chapter-map.csv references "{sid}" which doesn\'t exist — update the chapter map'
+        return {
+            'type': 'bad_chapter_ref', 'file': 'reference/chapter-map.csv',
+            'scene_id': sid,
+            'detail': f'chapter-map.csv references "{sid}" which doesn\'t exist',
+            'action': 'Update the chapter map to remove or replace the reference',
+            'severity': 'error',
+        }
 
     if issue.startswith('SEQ_NEEDS_RENUMBER:'):
-        return 'scenes.csv has sequence gaps or non-integer values — run: storyforge scenes-setup --renumber'
+        return {
+            'type': 'seq_needs_renumber', 'file': 'reference/scenes.csv',
+            'detail': 'Sequence has gaps or non-integer values',
+            'action': 'Renumber scene sequences',
+            'command': 'storyforge scenes-setup --renumber',
+            'severity': 'warning',
+        }
 
     if issue.startswith('UNKNOWN_CHARACTER:'):
         name = issue.split(':', 1)[1]
-        return f'"{name}" appears in scene-intent.csv but not characters.csv — run: storyforge hone --domain registries'
+        return {
+            'type': 'unknown_character', 'file': 'reference/characters.csv',
+            'character': name,
+            'detail': f'"{name}" appears in scene-intent.csv but not characters.csv',
+            'action': 'Normalize character registries',
+            'command': 'storyforge hone --domain registries',
+            'severity': 'warning',
+        }
 
     if issue.startswith('UNEXPECTED_DIR:'):
         path = issue.split(':', 1)[1]
-        return f'{path}/ — review manually; may be leftover from an old version'
+        return {
+            'type': 'unexpected_dir', 'file': path,
+            'detail': f'{path}/ is not expected',
+            'action': 'Review manually; may be leftover from an old version',
+            'severity': 'info',
+        }
 
     if issue.startswith('UNEXPECTED_FILE:'):
         path = issue.split(':', 1)[1]
-        return f'{path} — review manually; may be leftover from an old version'
+        return {
+            'type': 'unexpected_file', 'file': path,
+            'detail': f'{path} is not expected',
+            'action': 'Review manually; may be leftover from an old version',
+            'severity': 'info',
+        }
 
-    return issue
+    return {'type': 'unknown', 'detail': issue, 'action': issue, 'severity': 'info'}
 
 
 def _detect_rename_pairs(issues: list[str]) -> dict[str, list[tuple[str, str]]]:
@@ -779,59 +872,212 @@ def _detect_rename_pairs(issues: list[str]) -> dict[str, list[tuple[str, str]]]:
     return pairs
 
 
-def _run_csv_reports(project_dir: str) -> None:
-    """Run all CSV reports with actionable output and a summary."""
-    all_actions: list[str] = []
+def _check_scene_artifacts(project_dir: str) -> list[dict]:
+    """Check scene files for writing-agent artifacts without modifying them.
 
-    # --- Schema ---
-    log('=== CSV Schema Report ===')
+    Returns a list of finding dicts for scenes that need cleaning.
+    """
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    if not os.path.isdir(scenes_dir):
+        return []
+
+    findings: list[dict] = []
+    dirty_count = 0
+    for filename in sorted(os.listdir(scenes_dir)):
+        if not filename.endswith('.md'):
+            continue
+        filepath = os.path.join(scenes_dir, filename)
+        with open(filepath, encoding='utf-8') as f:
+            original = f.read()
+
+        cleaned = original
+        extracted = extract_single_scene(cleaned)
+        if extracted is not None:
+            cleaned = extracted
+        cleaned = clean_scene_content(cleaned)
+
+        if cleaned != original:
+            dirty_count += 1
+
+    if dirty_count > 0:
+        findings.append({
+            'type': 'scene_artifacts', 'file': 'scenes/',
+            'category': 'scenes',
+            'detail': f'{dirty_count} scene file(s) contain writing-agent artifacts '
+                      f'(title headers, continuity blocks, or scene markers)',
+            'action': 'Strip artifacts from scene files',
+            'command': 'storyforge cleanup --scenes',
+            'severity': 'warning',
+        })
+    return findings
+
+
+def _check_crlf(project_dir: str) -> list[dict]:
+    """Check CSV files for CRLF line endings."""
+    findings: list[dict] = []
+    dirty_files: list[str] = []
+    for rel_path in EXPECTED_CSV_SCHEMAS:
+        csv_path = os.path.join(project_dir, rel_path)
+        if not os.path.isfile(csv_path):
+            continue
+        with open(csv_path, 'rb') as f:
+            if b'\r\n' in f.read():
+                dirty_files.append(rel_path)
+
+    if dirty_files:
+        findings.append({
+            'type': 'crlf_line_endings', 'file': '; '.join(dirty_files),
+            'category': 'structure',
+            'detail': f'{len(dirty_files)} CSV file(s) have CRLF line endings: '
+                      f'{", ".join(dirty_files[:5])}'
+                      f'{"..." if len(dirty_files) > 5 else ""}',
+            'action': 'Normalize line endings to LF',
+            'command': "find reference working -name '*.csv' -exec sed -i '' $'s/\\r$//' {} +",
+            'severity': 'warning',
+        })
+    return findings
+
+
+def build_cleanup_report(project_dir: str) -> dict:
+    """Build a full structured cleanup report covering all checks.
+
+    Returns a dict with:
+        findings: list of finding dicts (type, file, detail, action, severity, category, ...)
+        action_items: list of actionable finding dicts (severity != 'info')
+        summary: dict with counts by severity and category
+    """
+    all_findings: list[dict] = []
+
+    # --- Structure checks ---
+    # Missing directories
+    for d in EXPECTED_DIRS:
+        if not os.path.isdir(os.path.join(project_dir, d)):
+            all_findings.append({
+                'type': 'missing_dir', 'file': d,
+                'category': 'structure',
+                'detail': f'{d}/ does not exist',
+                'action': f'Created by storyforge cleanup',
+                'severity': 'info',
+            })
+
+    # storyforge.yaml
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    if not os.path.isfile(yaml_path):
+        all_findings.append({
+            'type': 'missing_yaml', 'file': 'storyforge.yaml',
+            'category': 'structure',
+            'detail': 'storyforge.yaml not found',
+            'action': 'Initialize with storyforge init or create manually',
+            'command': 'storyforge init',
+            'severity': 'error',
+        })
+
+    # CRLF check
+    all_findings.extend(_check_crlf(project_dir))
+
+    # --- Scene artifacts ---
+    all_findings.extend(_check_scene_artifacts(project_dir))
+
+    # --- CSV schema ---
     schema_issues = report_csv_schema(project_dir)
     rename_pairs = _detect_rename_pairs(schema_issues)
-    if schema_issues:
-        for issue in schema_issues:
-            action = _action_for_issue(issue, rename_pairs)
-            if action:
-                log(f'  {action}')
-                # Collect non-informational actions for summary
-                if 'will be created automatically' not in action:
-                    all_actions.append(action)
-    else:
-        log('  All CSV files present with expected columns.')
+    for issue in schema_issues:
+        finding = _classify_issue(issue, rename_pairs)
+        if finding:
+            finding['category'] = 'schema'
+            all_findings.append(finding)
 
-    # --- Row integrity ---
-    log('')
-    log('=== CSV Integrity Report ===')
-    integrity_issues = report_csv_integrity(project_dir)
-    if integrity_issues:
-        for issue in integrity_issues:
-            action = _action_for_issue(issue, {})
-            if action:
-                log(f'  {action}')
-                all_actions.append(action)
-    else:
-        log('  No integrity issues found.')
+    # --- CSV row integrity ---
+    for issue in report_csv_integrity(project_dir):
+        finding = _classify_issue(issue, {})
+        if finding:
+            finding['category'] = 'integrity'
+            all_findings.append(finding)
 
     # --- Unexpected files ---
-    log('')
-    log('=== Unexpected Files Report ===')
-    unexpected_issues = report_unexpected_files(project_dir)
-    if unexpected_issues:
-        for issue in unexpected_issues:
-            action = _action_for_issue(issue, {})
-            if action:
-                log(f'  {action}')
-    else:
-        log('  No unexpected files found.')
+    for issue in report_unexpected_files(project_dir):
+        finding = _classify_issue(issue, {})
+        if finding:
+            finding['category'] = 'unexpected'
+            all_findings.append(finding)
 
-    # --- Summary ---
-    if all_actions:
+    action_items = [f for f in all_findings if f['severity'] != 'info']
+
+    return {
+        'findings': all_findings,
+        'action_items': action_items,
+        'summary': {
+            'total': len(all_findings),
+            'errors': sum(1 for f in all_findings if f['severity'] == 'error'),
+            'warnings': sum(1 for f in all_findings if f['severity'] == 'warning'),
+            'info': sum(1 for f in all_findings if f['severity'] == 'info'),
+        },
+    }
+
+
+def _print_report(report: dict) -> None:
+    """Print a human-readable report to stdout via log()."""
+    findings = report['findings']
+    action_items = report['action_items']
+    summary = report['summary']
+
+    # Group by category for display
+    categories = [
+        ('structure', 'Project Structure'),
+        ('scenes', 'Scene Files'),
+        ('schema', 'CSV Schema'),
+        ('integrity', 'CSV Integrity'),
+        ('unexpected', 'Unexpected Files'),
+    ]
+    for category, heading in categories:
+        group = [f for f in findings if f.get('category') == category]
+        if not group:
+            continue
+        log(f'=== {heading} ===')
+        for f in group:
+            severity_tag = f'[{f["severity"].upper()}]'
+            log(f'  {severity_tag} {f["detail"]}')
+            log(f'         → {f["action"]}')
+            if 'command' in f:
+                log(f'           $ {f["command"]}')
         log('')
-        log(f'=== Action Items ({len(all_actions)}) ===')
-        for i, action in enumerate(all_actions, 1):
-            log(f'  {i}. {action}')
+
+    # Action items summary
+    if action_items:
+        log(f'=== Action Items ({len(action_items)}) ===')
+        for i, item in enumerate(action_items, 1):
+            if 'command' in item:
+                log(f'  {i}. {item["action"]}  →  {item["command"]}')
+            else:
+                log(f'  {i}. {item["detail"]}: {item["action"]}')
     else:
-        log('')
-        log('=== No action items — project CSVs are clean ===')
+        log('=== No action items — project is clean ===')
+
+    log('')
+    log(f'Summary: {summary["errors"]} error(s), '
+        f'{summary["warnings"]} warning(s), {summary["info"]} info')
+
+
+def _write_report(report: dict, project_dir: str) -> str:
+    """Write the report as JSON to working/cleanup-report.json.
+
+    Returns the path to the written file.
+    """
+    working_dir = os.path.join(project_dir, 'working')
+    os.makedirs(working_dir, exist_ok=True)
+    report_path = os.path.join(working_dir, 'cleanup-report.json')
+    with open(report_path, 'w') as f:
+        json.dump(report, f, indent=2)
+        f.write('\n')
+    return report_path
+
+
+def _run_and_write_report(project_dir: str) -> None:
+    """Build the full cleanup report, print it, and write JSON."""
+    report = build_cleanup_report(project_dir)
+    _print_report(report)
+    report_path = _write_report(report, project_dir)
+    log(f'Report written to {report_path}')
 
 
 def main(argv=None):
@@ -839,11 +1085,11 @@ def main(argv=None):
     project_dir = detect_project_root()
     log(f'Project root: {project_dir}')
 
-    # --csv: run only the CSV reports and exit
+    # --csv: run only the report and exit (no modifications)
     if args.csv:
-        _run_csv_reports(project_dir)
+        _run_and_write_report(project_dir)
         log('')
-        log('CSV check complete.')
+        log('Check complete.')
         return
 
     def vlog(msg):
@@ -999,9 +1245,9 @@ def main(argv=None):
         else:
             log('  All scene files are clean.')
 
-    # Steps 10-12: CSV reports
+    # Steps 10-12: Full report
     log('')
-    _run_csv_reports(project_dir)
+    _run_and_write_report(project_dir)
 
     # Step 13: Commit (unless dry-run)
     if not args.dry_run:

--- a/scripts/lib/python/storyforge/cmd_cleanup.py
+++ b/scripts/lib/python/storyforge/cmd_cleanup.py
@@ -1000,6 +1000,11 @@ def build_cleanup_report(project_dir: str) -> dict:
             finding['category'] = 'unexpected'
             all_findings.append(finding)
 
+    # Set default status on all findings
+    for f in all_findings:
+        if 'status' not in f:
+            f['status'] = 'pending' if f['severity'] != 'info' else ''
+
     action_items = [f for f in all_findings if f['severity'] != 'info']
 
     return {
@@ -1057,7 +1062,7 @@ def _print_report(report: dict) -> None:
         f'{summary["warnings"]} warning(s), {summary["info"]} info')
 
 
-REPORT_COLUMNS = ['category', 'type', 'severity', 'file', 'detail', 'action', 'command']
+REPORT_COLUMNS = ['category', 'type', 'severity', 'file', 'detail', 'action', 'command', 'status']
 
 
 def _write_report(report: dict, project_dir: str) -> str:

--- a/scripts/lib/python/storyforge/cmd_cleanup.py
+++ b/scripts/lib/python/storyforge/cmd_cleanup.py
@@ -14,7 +14,6 @@ Usage:
 
 import argparse
 import glob
-import json
 import os
 import re
 import shutil
@@ -109,7 +108,7 @@ EXPECTED_WORKING_DIRS = set(
     'logs evaluations plans scores costs reviews recommendations coaching enrich timeline backups scenes-setup'.split()
 )
 EXPECTED_WORKING_FILES = set(
-    'pipeline.csv craft-weights.csv overrides.csv exemplars.csv dashboard.html cleanup-report.json'.split()
+    'pipeline.csv craft-weights.csv overrides.csv exemplars.csv dashboard.html cleanup-report.csv'.split()
 )
 
 
@@ -1058,17 +1057,22 @@ def _print_report(report: dict) -> None:
         f'{summary["warnings"]} warning(s), {summary["info"]} info')
 
 
+REPORT_COLUMNS = ['category', 'type', 'severity', 'file', 'detail', 'action', 'command']
+
+
 def _write_report(report: dict, project_dir: str) -> str:
-    """Write the report as JSON to working/cleanup-report.json.
+    """Write the report as pipe-delimited CSV to working/cleanup-report.csv.
 
     Returns the path to the written file.
     """
     working_dir = os.path.join(project_dir, 'working')
     os.makedirs(working_dir, exist_ok=True)
-    report_path = os.path.join(working_dir, 'cleanup-report.json')
+    report_path = os.path.join(working_dir, 'cleanup-report.csv')
     with open(report_path, 'w') as f:
-        json.dump(report, f, indent=2)
-        f.write('\n')
+        f.write('|'.join(REPORT_COLUMNS) + '\n')
+        for finding in report['findings']:
+            row = [finding.get(col, '') for col in REPORT_COLUMNS]
+            f.write('|'.join(row) + '\n')
     return report_path
 
 

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: cleanup
+description: Project health check and cleanup — run diagnostics, fix CSV schema issues, strip scene artifacts, normalize data, and resolve structural drift. Use when the author wants to check project health, clean up their project, fix CSV issues, or when starting work on a project that may have drifted.
+---
+
+# Storyforge Cleanup
+
+You are helping an author diagnose and fix structural issues in their Storyforge novel project. This skill runs the cleanup report, works through action items, and delegates to other skills/scripts as needed.
+
+**When to use cleanup vs. other tools:**
+- **Cleanup** — project structure health: missing CSVs, wrong columns, scene artifacts, CRLF, orphan files
+- **Hone** — CSV data *content* quality: abstract briefs, overspecified beats, registry normalization
+- **Elaborate** — building new structure from scratch
+
+## Locating the Storyforge Plugin
+
+The Storyforge plugin root is two levels up from this skill file's directory (this skill's directory → `skills/` → plugin root).
+
+Store this resolved plugin path for use throughout the session.
+
+## Step 1: Check for Existing Report
+
+Look for `working/cleanup-report.csv` in the project directory.
+
+- **If it exists and has pending items:** Read it and resume from where the last session left off. Skip to Step 3.
+- **If it exists but all items are done:** Delete it, commit, and tell the author the project is clean.
+- **If it doesn't exist:** Proceed to Step 2.
+
+## Step 2: Generate the Report
+
+Run the cleanup check:
+
+```bash
+cd <project_dir> && <plugin_path>/storyforge cleanup --csv
+```
+
+This writes `working/cleanup-report.csv` with columns:
+`category|type|severity|file|detail|action|command|status`
+
+Read the generated report. Commit it so the report is in git history:
+
+```bash
+git add working/cleanup-report.csv && git commit -m "Cleanup: generate health report" && git push
+```
+
+## Step 3: Present the Summary
+
+Read `working/cleanup-report.csv`. Present a summary to the author:
+
+**Errors** (severity=error) — these break the pipeline and must be fixed:
+- List each error with its detail and action
+
+**Warnings** (severity=warning, status=pending) — these should be fixed:
+- List each warning with its detail and action
+
+**Info** (severity=info) — informational, no action needed:
+- Mention the count but don't list them unless asked
+
+If there are no errors or warnings, tell the author the project is clean, delete the report file, commit, and you're done.
+
+## Step 4: Work Through Action Items
+
+Process action items in priority order: errors first, then warnings.
+
+For each action item, determine how to handle it:
+
+### Actions You Execute Directly
+
+These are CSV edits you can make in this session:
+
+| Type | What to Do |
+|------|-----------|
+| `rename_column` | Read the CSV file, rename the column in the header, write it back |
+| `missing_column` | Read the CSV file, add the column to the header and empty values to all rows |
+| `empty_csv` | Copy the header from the plugin's `templates/` directory |
+
+After each fix, update the `status` field in `working/cleanup-report.csv` from `pending` to `done`, then commit:
+
+```bash
+git add <fixed_file> working/cleanup-report.csv && git commit -m "Cleanup: <what was fixed>" && git push
+```
+
+### Actions That Delegate to Scripts
+
+These require running a Storyforge command. Present the command to the author using the Script Delegation Pattern:
+
+| Type | Command |
+|------|---------|
+| `scene_artifacts` | `storyforge cleanup --scenes` |
+| `crlf_line_endings` | `find reference working -name '*.csv' -exec sed -i '' $'s/\r$//' {} +` |
+| `seq_needs_renumber` | `storyforge scenes-setup --renumber` |
+
+After the command runs, update status to `done` and commit.
+
+### Actions That Delegate to Skills
+
+These need interactive work:
+
+| Type | Skill |
+|------|-------|
+| `missing_csv` (reference/) | Invoke `elaborate` to build the missing data |
+| `orphan_file` | Invoke `extract` to extract metadata from the scene |
+| `missing_intent` / `extra_intent` | Invoke `hone --domain gaps` |
+| `unknown_character` | Invoke `hone --domain registries` |
+
+Mark status as `delegated` and note which skill was invoked. The delegated skill will handle the actual fix.
+
+### Actions That Need Author Decision
+
+These can't be automated:
+
+| Type | What to Ask |
+|------|------------|
+| `orphan_meta` | "Scene {id} has metadata but no file. Should I remove the metadata rows, or create the scene file?" |
+| `bad_chapter_ref` | "Chapter map references scene {id} which doesn't exist. Should I remove it from the chapter map?" |
+| `extra_column` | "CSV has unexpected column {col}. Is this intentional?" |
+
+Wait for the author's answer, then act and update status.
+
+## Step 5: Clean Up
+
+When all action items are `done`, `delegated`, or `skipped`:
+
+1. Delete `working/cleanup-report.csv`
+2. Commit: `git add -A && git commit -m "Cleanup: complete — all issues resolved" && git push`
+3. Tell the author what was fixed
+
+## Script Delegation Pattern
+
+When delegating to an autonomous script, offer two options:
+
+> **Option A: Run it here**
+> I'll launch the command in this conversation.
+>
+> **Option B: Run it yourself**
+> Copy this command and run it in a separate terminal:
+> ```bash
+> cd <project_dir> && <plugin_path>/storyforge <command> [flags]
+> ```
+
+Wait for the author's choice.
+
+## Coaching Level Adaptation
+
+Read the coaching level from `storyforge.yaml` (default: `full`).
+
+- **full:** Execute fixes directly, explain what you're doing as you go.
+- **coach:** Present each finding and ask if the author wants you to fix it or wants to do it themselves.
+- **strict:** Present the full report and list of commands. Don't execute anything — let the author run each command.
+
+## Commit After Every Fix
+
+Every individual fix gets its own commit and push. Don't batch fixes — the git history should show each cleanup step clearly.

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -32,6 +32,7 @@ Before doing anything else, orient yourself:
    - `working/plans/revision-plan.csv` (preferred) or `working/plans/revision-plan.yaml` (legacy)
    - `working/scores/structural-latest.csv` (structural scoring results)
    - `working/scores/structural-proposals.csv` (unaddressed structural proposals)
+   - `working/cleanup-report.csv` (pending cleanup action items from a previous session)
    - The `scenes/` directory (any `.md` files = drafted scenes)
 4. **Read the key decisions file** — check the `key_decisions` artifact path in `storyforge.yaml` (typically `reference/key-decisions.md`). If it exists, read it in full. This file contains settled author decisions. **You must never re-ask a question that is already answered in this file.**
 
@@ -171,6 +172,8 @@ If the project doesn't have a `./storyforge` runner script, offer to create one 
 The author said "surprise me," "what should I work on?", or gave no specific direction.
 
 Determine the single highest-value next action based on project state. Work through these priorities in order — stop at the first one that applies:
+
+**0. Pending cleanup:** If `working/cleanup-report.csv` exists with `status=pending` items → "You have unfinished cleanup items from a previous session." → invoke `cleanup` to resume.
 
 **1. Elaboration phase:** If phase is `spine`/`architecture`/`scene-map`/`briefs` → "Continue elaboration" → invoke `elaborate`.
 

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -103,6 +103,9 @@ Run structural scoring — this is a deterministic analysis of the CSV data (no 
 ```
 If scores are below target, review the diagnosis and proposals in `working/scores/structural-proposals.csv`. At coaching level full, the diagnosis includes craft-grounded explanations and specific CSV changes. At coach, it produces guiding questions.
 
+**"Clean up" / "Health check" / "Check my project" / "Fix CSV issues" / "Project cleanup":**
+Invoke the `cleanup` skill. This runs the project health report (CSV schema validation, scene artifact detection, structural checks), then works through action items — fixing what it can directly and delegating to other skills/scripts as needed.
+
 **"Reconcile" / "Normalize my data" / "Build registries" / "Clean up values" / "Hone" / "Improve my briefs" / "Fix abstract language" / "Fill gaps":**
 Invoke the `hone` skill. Hone consolidates all CSV data quality work: registry normalization, brief concretization (rewriting abstract language as concrete physical beats), structural CSV fixes from evaluation findings, and gap filling. It replaces the standalone reconcile command.
 

--- a/tests/test_cleanup_csv.py
+++ b/tests/test_cleanup_csv.py
@@ -1,10 +1,10 @@
 """Tests for storyforge cleanup --csv schema validation and action formatting."""
 
-import json
 import os
 
 from storyforge.cmd_cleanup import (
     EXPECTED_CSV_SCHEMAS,
+    REPORT_COLUMNS,
     report_csv_schema,
     build_cleanup_report,
     _classify_issue,
@@ -218,9 +218,35 @@ class TestBuildCsvReport:
 
 
 class TestWriteReport:
-    """Tests for JSON report file output."""
+    """Tests for CSV report file output."""
 
-    def test_writes_valid_json(self, tmp_path):
+    def test_writes_valid_csv(self, tmp_path):
+        report = {
+            'findings': [{'type': 'test', 'detail': 'x', 'action': 'y',
+                         'severity': 'info', 'category': 'schema',
+                         'file': 'ref.csv', 'command': ''}],
+            'action_items': [],
+            'summary': {'total': 1, 'errors': 0, 'warnings': 0, 'info': 1},
+        }
+        path = _write_report(report, str(tmp_path))
+        assert os.path.isfile(path)
+        with open(path) as f:
+            lines = f.readlines()
+        assert lines[0].strip() == '|'.join(REPORT_COLUMNS)
+        assert len(lines) == 2  # header + 1 finding
+        cols = lines[1].strip().split('|')
+        assert len(cols) == len(REPORT_COLUMNS)
+        assert cols[0] == 'schema'  # category
+        assert cols[1] == 'test'    # type
+
+    def test_report_path(self, tmp_path):
+        report = {'findings': [], 'action_items': [],
+                  'summary': {'total': 0, 'errors': 0, 'warnings': 0, 'info': 0}}
+        path = _write_report(report, str(tmp_path))
+        assert path.endswith('working/cleanup-report.csv')
+
+    def test_missing_fields_default_empty(self, tmp_path):
+        """Findings without optional fields get empty strings."""
         report = {
             'findings': [{'type': 'test', 'detail': 'x', 'action': 'y',
                          'severity': 'info', 'category': 'schema'}],
@@ -228,13 +254,11 @@ class TestWriteReport:
             'summary': {'total': 1, 'errors': 0, 'warnings': 0, 'info': 1},
         }
         path = _write_report(report, str(tmp_path))
-        assert os.path.isfile(path)
         with open(path) as f:
-            loaded = json.load(f)
-        assert loaded['summary']['total'] == 1
-
-    def test_report_path(self, tmp_path):
-        report = {'findings': [], 'action_items': [],
-                  'summary': {'total': 0, 'errors': 0, 'warnings': 0, 'info': 0}}
-        path = _write_report(report, str(tmp_path))
-        assert path.endswith('working/cleanup-report.json')
+            lines = f.readlines()
+        cols = lines[1].strip().split('|')
+        # 'file' and 'command' should be empty
+        file_idx = REPORT_COLUMNS.index('file')
+        cmd_idx = REPORT_COLUMNS.index('command')
+        assert cols[file_idx] == ''
+        assert cols[cmd_idx] == ''

--- a/tests/test_cleanup_csv.py
+++ b/tests/test_cleanup_csv.py
@@ -1,12 +1,15 @@
 """Tests for storyforge cleanup --csv schema validation and action formatting."""
 
+import json
 import os
 
 from storyforge.cmd_cleanup import (
     EXPECTED_CSV_SCHEMAS,
     report_csv_schema,
-    _action_for_issue,
+    build_cleanup_report,
+    _classify_issue,
     _detect_rename_pairs,
+    _write_report,
 )
 
 
@@ -117,53 +120,121 @@ class TestDetectRenamePairs:
         assert _detect_rename_pairs([]) == {}
 
 
-class TestActionForIssue:
-    """Tests for actionable issue descriptions."""
+class TestClassifyIssue:
+    """Tests for structured issue classification."""
 
     def test_missing_reference_csv(self):
-        action = _action_for_issue('MISSING_CSV:reference/motif-taxonomy.csv', {})
-        assert 'storyforge elaborate' in action or 'templates/' in action
+        finding = _classify_issue('MISSING_CSV:reference/motif-taxonomy.csv', {})
+        assert finding['type'] == 'missing_csv'
+        assert finding['severity'] == 'warning'
+        assert 'command' in finding
 
     def test_missing_working_csv(self):
-        action = _action_for_issue('MISSING_CSV:working/pipeline.csv', {})
-        assert 'automatically' in action
+        finding = _classify_issue('MISSING_CSV:working/pipeline.csv', {})
+        assert finding['type'] == 'missing_csv'
+        assert finding['severity'] == 'info'
 
     def test_missing_column_plain(self):
-        action = _action_for_issue(
+        finding = _classify_issue(
             'MISSING_COLUMN:reference/characters.csv:death_scene', {})
-        assert 'add column' in action
-        assert 'death_scene' in action
+        assert finding['type'] == 'missing_column'
+        assert finding['column'] == 'death_scene'
+        assert 'death_scene' in finding['action']
 
     def test_missing_column_as_rename(self):
         pairs = {'reference/chapter-map.csv': [('chapter', 'seq')]}
-        action = _action_for_issue(
+        finding = _classify_issue(
             'MISSING_COLUMN:reference/chapter-map.csv:chapter', pairs)
-        assert 'rename' in action
-        assert '"seq"' in action
-        assert '"chapter"' in action
+        assert finding['type'] == 'rename_column'
+        assert finding['rename_from'] == 'seq'
+        assert finding['rename_to'] == 'chapter'
 
     def test_extra_column_suppressed_by_rename(self):
         pairs = {'reference/chapter-map.csv': [('chapter', 'seq')]}
-        action = _action_for_issue(
+        finding = _classify_issue(
             'EXTRA_COLUMN:reference/chapter-map.csv:seq', pairs)
-        assert action == ''
+        assert finding is None
 
     def test_orphan_file(self):
-        action = _action_for_issue('ORPHAN_FILE:lost-scene', {})
-        assert 'storyforge extract' in action
+        finding = _classify_issue('ORPHAN_FILE:lost-scene', {})
+        assert finding['type'] == 'orphan_file'
+        assert finding['scene_id'] == 'lost-scene'
+        assert 'storyforge extract' in finding['command']
 
     def test_orphan_meta(self):
-        action = _action_for_issue('ORPHAN_META:ghost-row', {})
-        assert 'remove from CSVs' in action
+        finding = _classify_issue('ORPHAN_META:ghost-row', {})
+        assert finding['type'] == 'orphan_meta'
+        assert 'remove' in finding['action'].lower() or 'create' in finding['action'].lower()
 
     def test_unknown_character(self):
-        action = _action_for_issue('UNKNOWN_CHARACTER:Bob', {})
-        assert 'storyforge hone' in action
+        finding = _classify_issue('UNKNOWN_CHARACTER:Bob', {})
+        assert finding['type'] == 'unknown_character'
+        assert finding['character'] == 'Bob'
+        assert 'storyforge hone' in finding['command']
 
     def test_seq_renumber(self):
-        action = _action_for_issue('SEQ_NEEDS_RENUMBER:gaps found', {})
-        assert 'storyforge scenes-setup' in action
+        finding = _classify_issue('SEQ_NEEDS_RENUMBER:gaps found', {})
+        assert finding['type'] == 'seq_needs_renumber'
+        assert 'storyforge scenes-setup' in finding['command']
 
     def test_bad_chapter_ref(self):
-        action = _action_for_issue('BAD_CHAPTER_REF:deleted-scene', {})
-        assert 'chapter map' in action
+        finding = _classify_issue('BAD_CHAPTER_REF:deleted-scene', {})
+        assert finding['type'] == 'bad_chapter_ref'
+        assert finding['severity'] == 'error'
+
+
+class TestBuildCsvReport:
+    """Tests for the full report builder."""
+
+    def test_clean_project_no_actions(self, tmp_path):
+        """A project with all correct CSVs has no action items."""
+        for rel_path, cols in EXPECTED_CSV_SCHEMAS.items():
+            _write_csv(str(tmp_path), rel_path, '|'.join(cols))
+        # Need scenes dir for unexpected files check
+        (tmp_path / 'scenes').mkdir()
+        (tmp_path / 'reference').mkdir(exist_ok=True)
+        (tmp_path / 'working').mkdir(exist_ok=True)
+        (tmp_path / 'manuscript').mkdir()
+        (tmp_path / 'storyforge.yaml').touch()
+        (tmp_path / '.gitignore').touch()
+
+        report = build_cleanup_report(str(tmp_path))
+        assert report['summary']['errors'] == 0
+        assert report['summary']['warnings'] == 0
+        assert len(report['action_items']) == 0
+
+    def test_report_has_action_items(self, tmp_path):
+        """Missing columns show up as action items."""
+        _write_csv(str(tmp_path), 'reference/scenes.csv', 'id|seq|title')
+
+        report = build_cleanup_report(str(tmp_path))
+        assert report['summary']['warnings'] > 0
+        assert len(report['action_items']) > 0
+        # Each action item should have required fields
+        for item in report['action_items']:
+            assert 'type' in item
+            assert 'action' in item
+            assert 'severity' in item
+
+
+class TestWriteReport:
+    """Tests for JSON report file output."""
+
+    def test_writes_valid_json(self, tmp_path):
+        report = {
+            'findings': [{'type': 'test', 'detail': 'x', 'action': 'y',
+                         'severity': 'info', 'category': 'schema'}],
+            'action_items': [],
+            'summary': {'total': 1, 'errors': 0, 'warnings': 0, 'info': 1},
+        }
+        path = _write_report(report, str(tmp_path))
+        assert os.path.isfile(path)
+        with open(path) as f:
+            loaded = json.load(f)
+        assert loaded['summary']['total'] == 1
+
+    def test_report_path(self, tmp_path):
+        report = {'findings': [], 'action_items': [],
+                  'summary': {'total': 0, 'errors': 0, 'warnings': 0, 'info': 0}}
+        path = _write_report(report, str(tmp_path))
+        assert path.endswith('working/cleanup-report.json')


### PR DESCRIPTION
## Summary
- **Structured cleanup report** (`working/cleanup-report.csv`) — pipe-delimited CSV with columns: `category|type|severity|file|detail|action|command|status`
- Covers all checks: project structure, scene artifacts, CRLF, CSV schema validation, CSV row integrity, unexpected files
- Each finding includes severity, actionable description, and command to run where applicable
- Rename pair detection (e.g. `seq` → `chapter` shows as one rename suggestion, not separate missing/extra)
- `status` column tracks progress: `pending` → `done`/`delegated`/`skipped`
- **New cleanup skill** (`skills/cleanup/SKILL.md`) — interactive workflow that:
  - Checks for existing report; generates one if missing
  - Commits report to git history for visibility
  - Works through action items by priority (errors first)
  - Fixes CSV schema issues directly, delegates to scripts/skills for others
  - Updates status per item, commits after each fix
  - Deletes report when all items resolved
- Forge hub routes "cleanup" / "health check" requests to the new skill

## Test plan
- [x] 966 tests pass (10 skipped)
- [x] Schema validation catches missing/extra/renamed columns
- [x] Report writes valid pipe-delimited CSV with all expected columns
- [x] Findings include default status (`pending` for action items, empty for info)
- [x] Fixture CSVs pass schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)