### PR TITLE
Fix positional CSV column access in prompts and revision

### DIFF
--- a/scripts/lib/python/storyforge/prompts.py
+++ b/scripts/lib/python/storyforge/prompts.py
@@ -472,10 +472,18 @@ def _get_scene_overrides(scene_id: str, project_dir: str) -> str:
     if not header:
         return ''
 
+    # Build dicts so we access columns by name, not position
+    col_map = {name.strip(): i for i, name in enumerate(header)}
+    id_idx = col_map.get('id')
+    directive_idx = col_map.get('directive')
+    if id_idx is None or directive_idx is None:
+        return ''
+
     lines = []
     for row in rows:
-        if row and row[0] == scene_id and len(row) > 2:
-            lines.append(f'- {row[2]}')
+        if row and len(row) > max(id_idx, directive_idx) \
+                and row[id_idx].strip() == scene_id:
+            lines.append(f'- {row[directive_idx].strip()}')
 
     return '\n'.join(lines)
 

--- a/scripts/lib/python/storyforge/revision.py
+++ b/scripts/lib/python/storyforge/revision.py
@@ -437,17 +437,19 @@ def _build_overrides_section(project_dir: str, pass_config: str) -> str:
     lines = []
     if target_ids:
         for row in rows:
-            scene_id = row.get('id', row.get(list(row.keys())[0], '')).strip()
-            if scene_id in target_ids:
-                # Columns: id, principle, directive (or similar)
-                cols = list(row.values())
-                if len(cols) >= 3:
-                    lines.append(f"- [{cols[0].strip()}] {cols[1].strip()}: {cols[2].strip()}")
+            rid = row.get('id', '').strip()
+            if rid in target_ids:
+                principle = row.get('principle', '').strip()
+                directive = row.get('directive', '').strip()
+                if rid and principle and directive:
+                    lines.append(f"- [{rid}] {principle}: {directive}")
     else:
         for row in rows:
-            cols = list(row.values())
-            if len(cols) >= 3:
-                lines.append(f"- [{cols[0].strip()}] {cols[1].strip()}: {cols[2].strip()}")
+            rid = row.get('id', '').strip()
+            principle = row.get('principle', '').strip()
+            directive = row.get('directive', '').strip()
+            if rid and principle and directive:
+                lines.append(f"- [{rid}] {principle}: {directive}")
 
     if not lines:
         return ''

--- a/tests/test_csv_positional.py
+++ b/tests/test_csv_positional.py
@@ -1,0 +1,171 @@
+"""Regression tests for positional CSV column access bugs.
+
+Verifies that prompts._get_scene_overrides and revision._build_overrides_section
+work correctly when CSV columns are reordered, rather than relying on column
+position.
+"""
+
+import os
+
+
+def _write_csv(tmp_path, filename, content):
+    """Write text content to a file, returning the path."""
+    path = str(tmp_path / filename)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    return path
+
+
+# ============================================================================
+# prompts._get_scene_overrides
+# ============================================================================
+
+class TestGetSceneOverridesColumnOrder:
+    """prompts._get_scene_overrides accesses columns by name, not position."""
+
+    def _setup_project(self, tmp_path, csv_content):
+        """Create a minimal project dir with an overrides.csv."""
+        project_dir = str(tmp_path / 'project')
+        scores_dir = os.path.join(project_dir, 'working', 'scores', 'latest')
+        os.makedirs(scores_dir)
+        overrides_path = os.path.join(scores_dir, 'overrides.csv')
+        with open(overrides_path, 'w', encoding='utf-8') as f:
+            f.write(csv_content)
+        return project_dir
+
+    def test_standard_column_order(self, tmp_path):
+        """Works with the standard id|principle|directive|source order."""
+        from storyforge.prompts import _get_scene_overrides
+
+        project_dir = self._setup_project(tmp_path,
+            'id|principle|directive|source\n'
+            'sc-01|pacing|Slow the opening|evaluator\n'
+            'sc-01|voice|Add more interiority|evaluator\n'
+            'sc-02|pacing|Speed up the chase|evaluator\n'
+        )
+        result = _get_scene_overrides('sc-01', project_dir)
+        assert '- Slow the opening' in result
+        assert '- Add more interiority' in result
+        assert 'Speed up the chase' not in result
+
+    def test_reordered_columns(self, tmp_path):
+        """Works when columns are reordered (directive before id)."""
+        from storyforge.prompts import _get_scene_overrides
+
+        project_dir = self._setup_project(tmp_path,
+            'source|directive|principle|id\n'
+            'evaluator|Slow the opening|pacing|sc-01\n'
+            'evaluator|Speed up the chase|pacing|sc-02\n'
+        )
+        result = _get_scene_overrides('sc-01', project_dir)
+        assert '- Slow the opening' in result
+        assert 'Speed up the chase' not in result
+
+    def test_extra_columns(self, tmp_path):
+        """Works when extra columns are present."""
+        from storyforge.prompts import _get_scene_overrides
+
+        project_dir = self._setup_project(tmp_path,
+            'id|principle|directive|source|notes|priority\n'
+            'sc-01|pacing|Slow the opening|evaluator|important|high\n'
+        )
+        result = _get_scene_overrides('sc-01', project_dir)
+        assert '- Slow the opening' in result
+
+    def test_missing_directive_column(self, tmp_path):
+        """Returns empty string when directive column is missing."""
+        from storyforge.prompts import _get_scene_overrides
+
+        project_dir = self._setup_project(tmp_path,
+            'id|principle|source\n'
+            'sc-01|pacing|evaluator\n'
+        )
+        result = _get_scene_overrides('sc-01', project_dir)
+        assert result == ''
+
+    def test_no_file(self, tmp_path):
+        """Returns empty string when overrides file does not exist."""
+        from storyforge.prompts import _get_scene_overrides
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(project_dir, exist_ok=True)
+        result = _get_scene_overrides('sc-01', project_dir)
+        assert result == ''
+
+
+# ============================================================================
+# revision._build_overrides_section
+# ============================================================================
+
+class TestBuildOverridesSectionColumnOrder:
+    """revision._build_overrides_section accesses columns by name, not position."""
+
+    def _setup_project(self, tmp_path, csv_content):
+        """Create a minimal project dir with an overrides.csv."""
+        project_dir = str(tmp_path / 'project')
+        scores_dir = os.path.join(project_dir, 'working', 'scores', 'latest')
+        os.makedirs(scores_dir)
+        overrides_path = os.path.join(scores_dir, 'overrides.csv')
+        with open(overrides_path, 'w', encoding='utf-8') as f:
+            f.write(csv_content)
+        return project_dir
+
+    def test_standard_column_order(self, tmp_path):
+        """Works with the standard id|principle|directive|source order."""
+        from storyforge.revision import _build_overrides_section
+
+        project_dir = self._setup_project(tmp_path,
+            'id|principle|directive|source\n'
+            'sc-01|pacing|Slow the opening|evaluator\n'
+            'sc-02|voice|Add more interiority|evaluator\n'
+        )
+        result = _build_overrides_section(project_dir, pass_config='')
+        assert '- [sc-01] pacing: Slow the opening' in result
+        assert '- [sc-02] voice: Add more interiority' in result
+
+    def test_reordered_columns(self, tmp_path):
+        """Works when columns are reordered (directive before id)."""
+        from storyforge.revision import _build_overrides_section
+
+        project_dir = self._setup_project(tmp_path,
+            'source|directive|principle|id\n'
+            'evaluator|Slow the opening|pacing|sc-01\n'
+            'evaluator|Add more interiority|voice|sc-02\n'
+        )
+        result = _build_overrides_section(project_dir, pass_config='')
+        assert '- [sc-01] pacing: Slow the opening' in result
+        assert '- [sc-02] voice: Add more interiority' in result
+
+    def test_reordered_columns_with_targets(self, tmp_path):
+        """Works when columns are reordered and targets filter is applied."""
+        from storyforge.revision import _build_overrides_section
+
+        project_dir = self._setup_project(tmp_path,
+            'source|directive|principle|id\n'
+            'evaluator|Slow the opening|pacing|sc-01\n'
+            'evaluator|Add more interiority|voice|sc-02\n'
+        )
+        result = _build_overrides_section(
+            project_dir, pass_config='targets: sc-01')
+        assert '- [sc-01] pacing: Slow the opening' in result
+        assert 'sc-02' not in result
+
+    def test_extra_columns(self, tmp_path):
+        """Works when extra columns are present."""
+        from storyforge.revision import _build_overrides_section
+
+        project_dir = self._setup_project(tmp_path,
+            'id|principle|directive|source|notes|priority\n'
+            'sc-01|pacing|Slow the opening|evaluator|important|high\n'
+        )
+        result = _build_overrides_section(project_dir, pass_config='')
+        assert '- [sc-01] pacing: Slow the opening' in result
+
+    def test_no_file(self, tmp_path):
+        """Returns empty string when overrides file does not exist."""
+        from storyforge.revision import _build_overrides_section
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(project_dir, exist_ok=True)
+        result = _build_overrides_section(project_dir, pass_config='')
+        assert result == ''


### PR DESCRIPTION
## Summary
- **prompts.py**: `_get_scene_overrides` accessed overrides.csv rows by index (`row[0]`, `row[2]`) instead of by column name. Now builds a column-name-to-index map from the header and looks up `id` and `directive` by name.
- **revision.py**: `_build_overrides_section` converted `DictReader` rows back to lists via `list(row.values())` then accessed `cols[0]`, `cols[1]`, `cols[2]`, losing column names. Now uses `row.get('id')`, `row.get('principle')`, `row.get('directive')` directly.
- Added 10 regression tests in `tests/test_csv_positional.py` that verify both functions work with standard, reordered, and extra columns.

## Test plan
- [x] All 10 new regression tests pass (including reordered-column scenarios)
- [x] Full test suite passes (976 passed, 10 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)