### PR TITLE
Fix positional CSV column access in scoring/structural

### DIFF
--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -148,21 +148,26 @@ def merge_score_files(target_path: str, source_path: str):
                 f.write('|'.join(row) + '\n')
         return
 
-    # Different headers: join on id column (column 0)
+    # Different headers: join on id column
+    t_col_idx = {name: i for i, name in enumerate(t_header)}
+    s_col_idx = {name: i for i, name in enumerate(s_header)}
+    t_id_col = t_col_idx.get('id', 0)
+    s_id_col = s_col_idx.get('id', 0)
+
     # Build lookup of target rows by id, preserving order
     t_index: dict[str, list[str]] = {}
     t_order: list[str] = []
     for row in t_rows:
-        rid = row[0] if row else ''
+        rid = row[t_id_col] if t_id_col < len(row) else ''
         t_index[rid] = row
         t_order.append(rid)
 
     # Source columns beyond id
-    s_extra_cols = s_header[1:]
+    s_extra_cols = [c for i, c in enumerate(s_header) if i != s_id_col]
     s_index: dict[str, list[str]] = {}
     for row in s_rows:
-        rid = row[0] if row else ''
-        s_index[rid] = row[1:] if len(row) > 1 else []
+        rid = row[s_id_col] if s_id_col < len(row) else ''
+        s_index[rid] = [row[i] for i in range(len(row)) if i != s_id_col]
         # Track new IDs not in target
         if rid not in t_index:
             t_order.append(rid)
@@ -211,10 +216,10 @@ def build_weighted_text(weights_file: str, exclude_section: str = '') -> str:
 
     high_priority = []
     for row in rows:
-        section = row[col_idx.get('section', 0)] if 'section' in col_idx else ''
-        principle = row[col_idx.get('principle', 1)] if 'principle' in col_idx else ''
-        weight = row[col_idx.get('weight', 2)] if 'weight' in col_idx else ''
-        author_weight = row[col_idx.get('author_weight', 3)] if 'author_weight' in col_idx else ''
+        section = row[col_idx['section']] if 'section' in col_idx and col_idx['section'] < len(row) else ''
+        principle = row[col_idx['principle']] if 'principle' in col_idx and col_idx['principle'] < len(row) else ''
+        weight = row[col_idx['weight']] if 'weight' in col_idx and col_idx['weight'] < len(row) else ''
+        author_weight = row[col_idx['author_weight']] if 'author_weight' in col_idx and col_idx['author_weight'] < len(row) else ''
 
         if exclude_section and section == exclude_section:
             continue
@@ -247,14 +252,16 @@ def get_effective_weight(weights_file: str, principle: str) -> int:
     """
     header, rows = _read_csv(weights_file)
     col_idx = {name: i for i, name in enumerate(header)}
-    p_col = col_idx.get('principle', 1)
-    w_col = col_idx.get('weight', 2)
-    aw_col = col_idx.get('author_weight', 3)
+    if 'principle' not in col_idx:
+        return 5
+    p_col = col_idx['principle']
+    w_col = col_idx.get('weight')
+    aw_col = col_idx.get('author_weight')
 
     for row in rows:
         if len(row) > p_col and row[p_col] == principle:
-            author_w = row[aw_col] if len(row) > aw_col else ''
-            weight = row[w_col] if len(row) > w_col else ''
+            author_w = row[aw_col] if aw_col is not None and len(row) > aw_col else ''
+            weight = row[w_col] if w_col is not None and len(row) > w_col else ''
             val = author_w if author_w else weight
             try:
                 return int(val)
@@ -366,6 +373,9 @@ def generate_diagnosis(scores_dir: str, prev_dir: str, weights_file: str):
         if not header or not rows:
             continue
 
+        h_idx = {name: i for i, name in enumerate(header)}
+        id_col = h_idx.get('id', 0)
+
         prev_header: list[str] = []
         prev_rows: list[list[str]] = []
         if prev_dir:
@@ -373,10 +383,10 @@ def generate_diagnosis(scores_dir: str, prev_dir: str, weights_file: str):
             if os.path.isfile(prev_file):
                 prev_header, prev_rows = _read_csv(prev_file)
 
-        # Process each principle column (skip column 0 which is id)
-        for col_idx in range(1, len(header)):
+        # Process each principle column (skip the id column)
+        for col_idx in range(len(header)):
             principle = header[col_idx]
-            if not principle:
+            if not principle or principle == 'id':
                 continue
 
             # Skip narrative principles in scene-level scores
@@ -391,7 +401,8 @@ def generate_diagnosis(scores_dir: str, prev_dir: str, weights_file: str):
                         val = float(row[col_idx])
                     except (ValueError, TypeError):
                         continue
-                    id_scores.append((row[0], val))
+                    row_id = row[id_col] if id_col < len(row) else ''
+                    id_scores.append((row_id, val))
 
             if not id_scores:
                 continue
@@ -495,16 +506,26 @@ def generate_proposals(scores_dir: str, weights_file: str):
     scene_scores_file = os.path.join(scores_dir, 'scene-scores.csv')
     scene_header: list[str] = []
     scene_rows: list[list[str]] = []
+    scene_id_col = 0
     if os.path.isfile(scene_scores_file):
         scene_header, scene_rows = _read_csv(scene_scores_file)
+        scene_h_idx = {name: i for i, name in enumerate(scene_header)}
+        scene_id_col = scene_h_idx.get('id', 0)
+
+    def _dcol(row, name):
+        """Safely get a diagnosis column value by name."""
+        idx = col.get(name)
+        if idx is not None and idx < len(row):
+            return row[idx]
+        return ''
 
     for drow in d_rows:
-        principle = drow[col.get('principle', 0)]
-        scale = drow[col.get('scale', 1)]
-        avg_score = drow[col.get('avg_score', 2)]
-        worst_items = drow[col.get('worst_items', 3)]
-        delta = drow[col.get('delta_from_last', 4)]
-        priority = drow[col.get('priority', 5)]
+        principle = _dcol(drow, 'principle')
+        scale = _dcol(drow, 'scale')
+        avg_score = _dcol(drow, 'avg_score')
+        worst_items = _dcol(drow, 'worst_items')
+        delta = _dcol(drow, 'delta_from_last')
+        priority = _dcol(drow, 'priority')
 
         if priority not in ('high', 'medium'):
             continue
@@ -514,15 +535,16 @@ def generate_proposals(scores_dir: str, weights_file: str):
         if os.path.isfile(weights_file):
             header, rows = _read_csv(weights_file)
             w_col_idx = {name: i for i, name in enumerate(header)}
-            p_idx = w_col_idx.get('principle', 1)
-            wt_idx = w_col_idx.get('weight', 2)
-            for row in rows:
-                if len(row) > p_idx and row[p_idx] == principle:
-                    try:
-                        current_weight = int(row[wt_idx]) if len(row) > wt_idx and row[wt_idx] else 5
-                    except ValueError:
-                        current_weight = 5
-                    break
+            p_idx = w_col_idx.get('principle')
+            wt_idx = w_col_idx.get('weight')
+            if p_idx is not None:
+                for row in rows:
+                    if len(row) > p_idx and row[p_idx] == principle:
+                        try:
+                            current_weight = int(row[wt_idx]) if wt_idx is not None and len(row) > wt_idx and row[wt_idx] else 5
+                        except ValueError:
+                            current_weight = 5
+                        break
 
         increase = 2 if priority == 'high' else 1
         new_weight = min(current_weight + increase, 10)
@@ -555,7 +577,7 @@ def generate_proposals(scores_dir: str, weights_file: str):
                     # Find this scene's score
                     scene_val = None
                     for srow in scene_rows:
-                        if srow and srow[0] == scene_id and scene_col < len(srow):
+                        if srow and scene_id_col < len(srow) and srow[scene_id_col] == scene_id and scene_col < len(srow):
                             try:
                                 scene_val = int(srow[scene_col])
                             except (ValueError, TypeError):
@@ -682,10 +704,10 @@ def parse_scene_evaluation(
             try:
                 p_idx = header.index('principle')
             except ValueError:
-                p_idx = 1  # fallback to second column
+                p_idx = None
             seen: set[str] = set()
             for row in rows:
-                if len(row) > p_idx:
+                if p_idx is not None and len(row) > p_idx:
                     p = row[p_idx]
                     if p and p not in seen:
                         seen.add(p)
@@ -824,15 +846,17 @@ def build_evaluation_criteria(diagnostics_csv: str, guide_file: str) -> str:
 
     # Locate columns by name
     col = {name: i for i, name in enumerate(header)}
-    principle_idx = col.get('principle', 1)
-    question_idx = col.get('question', 3)
+    if 'principle' not in col:
+        return ''
+    principle_idx = col['principle']
+    question_idx = col.get('question')
 
     # Group questions by principle, preserving order
     from collections import OrderedDict
     principles: OrderedDict[str, list[str]] = OrderedDict()
     for row in rows:
         principle = row[principle_idx] if len(row) > principle_idx else ''
-        question = row[question_idx] if len(row) > question_idx else ''
+        question = row[question_idx] if question_idx is not None and len(row) > question_idx else ''
         if not principle:
             continue
         if principle not in principles:
@@ -879,15 +903,28 @@ def collect_exemplars(scores_dir: str, project_dir: str, cycle: str):
 
     # Read existing exemplars to avoid duplicates
     existing = set()
+    ex_header_line = None
     with open(exemplars_file) as f:
         for line in f:
-            if line.startswith('principle|'):
+            line = line.strip()
+            if not line:
                 continue
-            parts = line.strip().split('|')
-            if len(parts) >= 2:
-                existing.add((parts[0], parts[1]))
+            if ex_header_line is None:
+                ex_header_line = line.split('|')
+                continue
+            parts = line.split('|')
+            ex_col = {name: i for i, name in enumerate(ex_header_line)}
+            ex_p_idx = ex_col.get('principle', 0)
+            ex_s_idx = ex_col.get('scene_id', 1)
+            p_val = parts[ex_p_idx] if ex_p_idx < len(parts) else ''
+            s_val = parts[ex_s_idx] if ex_s_idx < len(parts) else ''
+            if p_val and s_val:
+                existing.add((p_val, s_val))
 
     header, rows = _read_csv(scores_file)
+    h_idx = {name: i for i, name in enumerate(header)}
+    sc_id_col = h_idx.get('id', 0)
+
     rationale_file = os.path.join(scores_dir, 'scene-rationale.csv')
     rat_header, rat_rows = ([], [])
     if os.path.isfile(rationale_file):
@@ -896,19 +933,21 @@ def collect_exemplars(scores_dir: str, project_dir: str, cycle: str):
     # Build rationale lookup: {(scene_id, principle): text}
     rat_lookup = {}
     if rat_header and rat_rows:
+        rat_h_idx = {name: i for i, name in enumerate(rat_header)}
+        rat_id_col = rat_h_idx.get('id', 0)
         for row in rat_rows:
-            scene_id = row[0] if row else ''
+            scene_id = row[rat_id_col] if rat_id_col < len(row) else ''
             for ci, col in enumerate(rat_header):
-                if ci == 0:
+                if col == 'id':
                     continue
                 if ci < len(row) and row[ci]:
                     rat_lookup[(scene_id, col)] = row[ci]
 
     new_rows = []
     for row in rows:
-        scene_id = row[0] if row else ''
+        scene_id = row[sc_id_col] if sc_id_col < len(row) else ''
         for ci, principle in enumerate(header):
-            if ci == 0:
+            if principle == 'id':
                 continue
             if ci >= len(row) or not row[ci]:
                 continue
@@ -941,16 +980,35 @@ def check_validated_patterns(project_dir: str) -> str:
     improvements: dict[str, float] = {}
 
     with open(tuning_file) as f:
+        header_line = None
         for line in f:
-            if line.startswith('cycle') or line.startswith('#'):
+            line = line.strip()
+            if not line or line.startswith('#'):
                 continue
-            parts = line.strip().split('|')
-            if len(parts) < 8 or parts[7] != 'true':
+            if header_line is None:
+                header_line = line.split('|')
                 continue
-            key = f'{parts[2]}|{parts[3]}'
+            parts = line.split('|')
+            t_col = {name: i for i, name in enumerate(header_line)}
+            validated_idx = t_col.get('validated')
+            principle_idx = t_col.get('principle')
+            lever_idx = t_col.get('lever')
+            score_after_idx = t_col.get('score_after')
+            score_before_idx = t_col.get('score_before')
+
+            validated = parts[validated_idx] if validated_idx is not None and validated_idx < len(parts) else ''
+            if validated != 'true':
+                continue
+            principle = parts[principle_idx] if principle_idx is not None and principle_idx < len(parts) else ''
+            lever = parts[lever_idx] if lever_idx is not None and lever_idx < len(parts) else ''
+            if not principle or not lever:
+                continue
+            key = f'{principle}|{lever}'
             counts[key] = counts.get(key, 0) + 1
             try:
-                improvements[key] = improvements.get(key, 0.0) + (float(parts[6]) - float(parts[5]))
+                after = float(parts[score_after_idx]) if score_after_idx is not None and score_after_idx < len(parts) else 0.0
+                before = float(parts[score_before_idx]) if score_before_idx is not None and score_before_idx < len(parts) else 0.0
+                improvements[key] = improvements.get(key, 0.0) + (after - before)
             except (ValueError, IndexError):
                 pass
 
@@ -986,6 +1044,14 @@ def _sc_class(val: str) -> str:
     return ''
 
 
+def _col_val(row: list[str], col_map: dict[str, int], name: str, default: str = '') -> str:
+    """Safely retrieve a column value from a CSV row by column name."""
+    idx = col_map.get(name)
+    if idx is not None and idx < len(row):
+        return row[idx]
+    return default
+
+
 def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
                           mode: str, scene_count: int, cost: str):
     """Generate an HTML scoring report."""
@@ -1008,26 +1074,41 @@ def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
     char_file = os.path.join(cycle_dir, 'character-scores.csv')
     if os.path.isfile(char_file):
         header, rows = _read_csv(char_file)
+        ch_col = {name: i for i, name in enumerate(header)}
+        ch_id_col_name = 'character' if 'character' in ch_col else 'id'
+        # Score columns are all non-id columns
+        ch_score_cols = [name for name in header if name != ch_id_col_name]
         for row in rows:
-            if not row or row[0] == 'character':
+            ch_id = _col_val(row, ch_col, ch_id_col_name)
+            if not ch_id or ch_id == ch_id_col_name:
                 continue
-            vals = [(float(row[i]) if i < len(row) and row[i] else 0) for i in range(1, 5)]
+            vals = []
+            cells = ''
+            for col_name in ch_score_cols:
+                v_str = _col_val(row, ch_col, col_name)
+                try:
+                    vals.append(float(v_str) if v_str else 0)
+                except ValueError:
+                    vals.append(0)
+                cells += f'<td class="{_sc_class(v_str)}">{v_str}</td>'
             avg = sum(vals) / max(len(vals), 1)
-            cells = ''.join(f'<td class="{_sc_class(row[i] if i < len(row) else "")}">{row[i] if i < len(row) else ""}</td>'
-                           for i in range(1, 5))
-            char_rows += f'<tr><td>{row[0]}</td>{cells}<td><strong>{avg:.1f}</strong></td></tr>\n'
+            char_rows += f'<tr><td>{ch_id}</td>{cells}<td><strong>{avg:.1f}</strong></td></tr>\n'
 
     # Act structure table
     act_rows = ''
     act_file = os.path.join(cycle_dir, 'act-scores.csv')
     if os.path.isfile(act_file):
         header, rows = _read_csv(act_file)
+        act_col = {name: i for i, name in enumerate(header)}
+        act_id_col = 'id' if 'id' in act_col else header[0]
+        act_score_cols = [name for name in header if name != act_id_col]
         for row in rows:
-            if not row or row[0] == 'id':
+            row_id = _col_val(row, act_col, act_id_col)
+            if not row_id or row_id == 'id':
                 continue
-            label = row[0].replace('act-', 'Part ')
-            cells = ''.join(f'<td class="{_sc_class(row[i] if i < len(row) else "")}">{row[i] if i < len(row) else ""}</td>'
-                           for i in range(1, len(header)))
+            label = row_id.replace('act-', 'Part ')
+            cells = ''.join(f'<td class="{_sc_class(_col_val(row, act_col, c))}">{_col_val(row, act_col, c)}</td>'
+                           for c in act_score_cols)
             act_rows += f'<tr><td>{label}</td>{cells}</tr>\n'
 
     # Genre row
@@ -1035,10 +1116,11 @@ def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
     genre_file = os.path.join(cycle_dir, 'genre-scores.csv')
     if os.path.isfile(genre_file):
         header, rows = _read_csv(genre_file)
+        genre_col = {name: i for i, name in enumerate(header)}
         if rows:
             row = rows[0]
-            genre_row = ''.join(f'<td class="{_sc_class(row[i] if i < len(row) else "")}">{row[i] if i < len(row) else ""}</td>'
-                               for i in range(len(row)))
+            genre_row = ''.join(f'<td class="{_sc_class(_col_val(row, genre_col, c))}">{_col_val(row, genre_col, c)}</td>'
+                               for c in header)
 
     # Strengths / weaknesses from diagnosis
     strengths = ''
@@ -1046,15 +1128,17 @@ def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
     diag_file = os.path.join(cycle_dir, 'diagnosis.csv')
     if os.path.isfile(diag_file):
         header, rows = _read_csv(diag_file)
+        dg_col = {name: i for i, name in enumerate(header)}
         scored = []
         for row in rows:
-            if len(row) >= 4:
-                try:
-                    avg = float(row[2]) if row[2] else 0
-                except ValueError:
-                    avg = 0
-                if avg > 0:
-                    scored.append((avg, row[0].replace('_', ' '), row[3] if len(row) > 3 else ''))
+            try:
+                avg = float(_col_val(row, dg_col, 'avg_score')) if _col_val(row, dg_col, 'avg_score') else 0
+            except ValueError:
+                avg = 0
+            if avg > 0:
+                prin = _col_val(row, dg_col, 'principle').replace('_', ' ')
+                scenes = _col_val(row, dg_col, 'worst_items')
+                scored.append((avg, prin, scenes))
         scored.sort(key=lambda x: x[0], reverse=True)
         for avg, prin, scenes in scored[:5]:
             strengths += f'<tr><td>{prin}</td><td>{avg}</td><td>{scenes}</td></tr>\n'
@@ -1067,14 +1151,16 @@ def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
     proposals_file = os.path.join(cycle_dir, 'proposals.csv')
     if os.path.isfile(proposals_file):
         header, rows = _read_csv(proposals_file)
+        pr_col = {name: i for i, name in enumerate(header)}
         for row in rows:
-            if not row or row[0] == 'id':
+            row_id = _col_val(row, pr_col, 'id')
+            if not row_id or row_id == 'id':
                 continue
-            prin = row[1].replace('_', ' ') if len(row) > 1 else ''
-            lever = row[2].replace('_', ' ') if len(row) > 2 else ''
-            change = row[4] if len(row) > 4 else ''
-            rationale = row[5] if len(row) > 5 else ''
-            status = row[6] if len(row) > 6 else 'pending'
+            prin = _col_val(row, pr_col, 'principle').replace('_', ' ')
+            lever = _col_val(row, pr_col, 'lever').replace('_', ' ')
+            change = _col_val(row, pr_col, 'change')
+            rationale = _col_val(row, pr_col, 'rationale')
+            status = _col_val(row, pr_col, 'status') or 'pending'
             badge_cls = {'applied': 'badge-applied', 'approved': 'badge-approved',
                         'rejected': 'badge-rejected'}.get(status, 'badge-pending')
             proposal_rows += (f'<tr><td>{prin}</td><td>{lever}</td><td>{change}</td>'
@@ -1085,19 +1171,23 @@ def generate_score_report(cycle_dir: str, project_dir: str, cycle: str,
     scene_file = os.path.join(cycle_dir, 'scene-scores.csv')
     if os.path.isfile(scene_file):
         header, rows = _read_csv(scene_file)
+        sc_col = {name: i for i, name in enumerate(header)}
+        sc_id_name = 'id' if 'id' in sc_col else header[0]
+        sc_score_cols = [name for name in header if name != sc_id_name]
         for row in rows:
-            if not row or row[0] == 'id':
+            row_id = _col_val(row, sc_col, sc_id_name)
+            if not row_id or row_id == 'id':
                 continue
             vals = []
-            for i in range(1, len(row)):
+            for c in sc_score_cols:
                 try:
-                    v = float(row[i])
+                    v = float(_col_val(row, sc_col, c))
                     if v > 0:
                         vals.append(v)
                 except (ValueError, IndexError):
                     pass
             avg = _power_mean(vals) if vals else 0
-            scene_heatmap += f'<tr><td>{row[0]}</td><td class="{_sc_class(str(round(avg)))}">{avg:.1f}</td></tr>\n'
+            scene_heatmap += f'<tr><td>{row_id}</td><td class="{_sc_class(str(round(avg)))}">{avg:.1f}</td></tr>\n'
 
     from datetime import datetime
     now = datetime.now().strftime('%Y-%m-%d %H:%M')
@@ -1228,37 +1318,45 @@ def build_score_pr_comment(cycle_dir: str, project_dir: str, cycle: str,
     char_file = os.path.join(cycle_dir, 'character-scores.csv')
     if os.path.isfile(char_file):
         header, rows = _read_csv(char_file)
+        ch_col = {name: i for i, name in enumerate(header)}
+        ch_id_name = 'character' if 'character' in ch_col else 'id'
+        ch_score_cols = [name for name in header if name != ch_id_name]
         parts.append('### Character Arcs')
         parts.append('| Character | Want/Need | Wound/Lie | Flaws | Voice | Avg |')
         parts.append('|-----------|-----------|-----------|-------|-------|-----|')
         for row in rows:
-            if not row or row[0] == 'character':
+            ch_id = _col_val(row, ch_col, ch_id_name)
+            if not ch_id or ch_id == ch_id_name:
                 continue
             vals = []
             cells = []
-            for i in range(1, 5):
-                v = row[i] if i < len(row) and row[i] else '0'
+            for c in ch_score_cols:
+                v = _col_val(row, ch_col, c) or '0'
                 try:
                     vals.append(float(v))
                 except ValueError:
                     vals.append(0)
                 cells.append(f'{_score_icon(int(float(v)))} {v}')
             avg = sum(vals) / max(len(vals), 1)
-            parts.append(f'| {row[0]} | {" | ".join(cells)} | **{avg:.1f}** |')
+            parts.append(f'| {ch_id} | {" | ".join(cells)} | **{avg:.1f}** |')
         parts.append('')
 
     # Act structure
     act_file = os.path.join(cycle_dir, 'act-scores.csv')
     if os.path.isfile(act_file):
         header, rows = _read_csv(act_file)
+        act_col = {name: i for i, name in enumerate(header)}
+        act_id_name = 'id' if 'id' in act_col else header[0]
+        act_score_cols = [name for name in header if name != act_id_name]
         parts.append('### Act Structure')
         parts.append('| Act | Campbell | 3-Act | Save Cat | Truby | Harmon | Kishoten. | Freytag | Char Web | Theme |')
         parts.append('|-----|----------|-------|----------|-------|--------|-----------|---------|----------|-------|')
         for row in rows:
-            if not row or row[0] == 'id':
+            row_id = _col_val(row, act_col, act_id_name)
+            if not row_id or row_id == 'id':
                 continue
-            label = row[0].replace('act-', 'Part ')
-            cells = ' | '.join(row[i] if i < len(row) else '' for i in range(1, len(header)))
+            label = row_id.replace('act-', 'Part ')
+            cells = ' | '.join(_col_val(row, act_col, c) for c in act_score_cols)
             parts.append(f'| {label} | {cells} |')
         parts.append('')
 
@@ -1266,12 +1364,13 @@ def build_score_pr_comment(cycle_dir: str, project_dir: str, cycle: str,
     genre_file = os.path.join(cycle_dir, 'genre-scores.csv')
     if os.path.isfile(genre_file):
         header, rows = _read_csv(genre_file)
+        genre_col = {name: i for i, name in enumerate(header)}
         if rows:
             row = rows[0]
             parts.append('### Genre Contract')
             parts.append('| Trope Awareness | Archetype vs Cliche | Genre Contract | Subversion |')
             parts.append('|-----------------|---------------------|----------------|------------|')
-            cells = ' | '.join(row[i] if i < len(row) else '' for i in range(len(row)))
+            cells = ' | '.join(_col_val(row, genre_col, c) for c in header)
             parts.append(f'| {cells} |')
             parts.append('')
 
@@ -1279,15 +1378,17 @@ def build_score_pr_comment(cycle_dir: str, project_dir: str, cycle: str,
     diag_file = os.path.join(cycle_dir, 'diagnosis.csv')
     if os.path.isfile(diag_file):
         header, rows = _read_csv(diag_file)
+        dg_col = {name: i for i, name in enumerate(header)}
         scored = []
         for row in rows:
-            if len(row) >= 4:
-                try:
-                    avg = float(row[2]) if row[2] else 0
-                except ValueError:
-                    avg = 0
-                if avg > 0:
-                    scored.append((avg, row[0].replace('_', ' '), row[3] if len(row) > 3 else ''))
+            try:
+                avg = float(_col_val(row, dg_col, 'avg_score')) if _col_val(row, dg_col, 'avg_score') else 0
+            except ValueError:
+                avg = 0
+            if avg > 0:
+                prin = _col_val(row, dg_col, 'principle').replace('_', ' ')
+                scenes = _col_val(row, dg_col, 'worst_items')
+                scored.append((avg, prin, scenes))
 
         scored_asc = sorted(scored, key=lambda x: x[0])
         scored_desc = sorted(scored, key=lambda x: x[0], reverse=True)
@@ -1310,16 +1411,17 @@ def build_score_pr_comment(cycle_dir: str, project_dir: str, cycle: str,
     proposals_file = os.path.join(cycle_dir, 'proposals.csv')
     if os.path.isfile(proposals_file):
         header, rows = _read_csv(proposals_file)
-        data_rows = [r for r in rows if r and r[0] != 'id']
+        pr_col = {name: i for i, name in enumerate(header)}
+        data_rows = [r for r in rows if _col_val(r, pr_col, 'id') and _col_val(r, pr_col, 'id') != 'id']
         if data_rows:
             parts.append(f'### Improvement Proposals ({len(data_rows)})')
             parts.append('| Principle | Lever | Change | Status |')
             parts.append('|-----------|-------|--------|--------|')
             for row in data_rows:
-                prin = row[1].replace('_', ' ') if len(row) > 1 else ''
-                lever = row[2].replace('_', ' ') if len(row) > 2 else ''
-                change = row[4] if len(row) > 4 else ''
-                status = row[6] if len(row) > 6 else 'pending'
+                prin = _col_val(row, pr_col, 'principle').replace('_', ' ')
+                lever = _col_val(row, pr_col, 'lever').replace('_', ' ')
+                change = _col_val(row, pr_col, 'change')
+                status = _col_val(row, pr_col, 'status') or 'pending'
                 parts.append(f'| {prin} | {lever} | {change} | {status} |')
             parts.append('')
 

--- a/scripts/lib/python/storyforge/structural.py
+++ b/scripts/lib/python/storyforge/structural.py
@@ -1620,18 +1620,22 @@ def load_previous_scores(project_dir):
     result = {}
     with open(latest_path, 'r') as f:
         header = None
+        col_idx = {}
         for line in f:
             line = line.strip()
             if not line:
                 continue
             if header is None:
                 header = line.split('|')
+                col_idx = {name: i for i, name in enumerate(header)}
                 continue
             parts = line.split('|')
-            if len(parts) >= 2:
-                name = parts[0]
+            dim_idx = col_idx.get('dimension', 0)
+            score_idx = col_idx.get('score')
+            if dim_idx < len(parts) and score_idx is not None and score_idx < len(parts):
+                name = parts[dim_idx]
                 try:
-                    score = float(parts[1])
+                    score = float(parts[score_idx])
                 except ValueError:
                     continue
                 result[name] = score

--- a/tests/test_csv_column_order.py
+++ b/tests/test_csv_column_order.py
@@ -1,0 +1,314 @@
+"""Regression tests for CSV column-order independence.
+
+Verifies that scoring.py and structural.py read CSV data by column name,
+not by positional index. Each test creates CSVs with reordered columns
+and asserts that the functions still produce correct results.
+"""
+
+import os
+
+import pytest
+
+
+def _write_csv(path, header, rows):
+    """Write a pipe-delimited CSV file."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        f.write('|'.join(header) + '\n')
+        for row in rows:
+            f.write('|'.join(str(v) for v in row) + '\n')
+
+
+# =====================================================================
+# scoring.py — build_weighted_text
+# =====================================================================
+
+class TestBuildWeightedTextColumnOrder:
+    def test_reordered_columns(self, tmp_path):
+        from storyforge.scoring import build_weighted_text
+        # Standard order: section|principle|weight|author_weight|notes
+        std = str(tmp_path / 'std.csv')
+        _write_csv(std, ['section', 'principle', 'weight', 'author_weight', 'notes'],
+                   [['craft', 'voice', '8', '', 'important']])
+        result_std = build_weighted_text(std)
+
+        # Reordered: notes|author_weight|weight|principle|section
+        reord = str(tmp_path / 'reord.csv')
+        _write_csv(reord, ['notes', 'author_weight', 'weight', 'principle', 'section'],
+                   [['important', '', '8', 'voice', 'craft']])
+        result_reord = build_weighted_text(reord)
+
+        assert 'voice' in result_std
+        assert result_std == result_reord
+
+    def test_exclude_section_with_reordered_columns(self, tmp_path):
+        from storyforge.scoring import build_weighted_text
+        reord = str(tmp_path / 'reord.csv')
+        _write_csv(reord, ['notes', 'author_weight', 'weight', 'principle', 'section'],
+                   [['', '', '9', 'voice', 'craft'],
+                    ['', '', '8', 'monomyth', 'narrative']])
+        result = build_weighted_text(reord, exclude_section='narrative')
+        assert 'voice' in result
+        assert 'monomyth' not in result
+
+
+# =====================================================================
+# scoring.py — get_effective_weight
+# =====================================================================
+
+class TestGetEffectiveWeightColumnOrder:
+    def test_reordered_columns(self, tmp_path):
+        from storyforge.scoring import get_effective_weight
+        # Reordered: weight|principle|author_weight
+        f = str(tmp_path / 'weights.csv')
+        _write_csv(f, ['weight', 'principle', 'author_weight'],
+                   [['7', 'voice', '9']])
+        result = get_effective_weight(f, 'voice')
+        assert result == 9  # author_weight takes precedence
+
+    def test_missing_author_weight_column(self, tmp_path):
+        from storyforge.scoring import get_effective_weight
+        f = str(tmp_path / 'weights.csv')
+        _write_csv(f, ['principle', 'weight'],
+                   [['voice', '6']])
+        result = get_effective_weight(f, 'voice')
+        assert result == 6
+
+
+# =====================================================================
+# scoring.py — generate_diagnosis
+# =====================================================================
+
+class TestGenerateDiagnosisColumnOrder:
+    def test_id_column_reordered(self, tmp_path):
+        from storyforge.scoring import generate_diagnosis
+        scores_dir = str(tmp_path / 'cycle')
+        os.makedirs(scores_dir)
+        # Put id as the LAST column instead of first
+        _write_csv(os.path.join(scores_dir, 'scene-scores.csv'),
+                   ['voice', 'id'],
+                   [['3', 'scene-a'], ['4', 'scene-b']])
+        weights = str(tmp_path / 'weights.csv')
+        _write_csv(weights, ['principle', 'weight'], [['voice', '5']])
+        generate_diagnosis(scores_dir, '', weights)
+
+        diag_path = os.path.join(scores_dir, 'diagnosis.csv')
+        assert os.path.isfile(diag_path)
+        import csv
+        with open(diag_path) as f:
+            reader = csv.DictReader(f, delimiter='|')
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]['principle'] == 'voice'
+        # Worst item should be scene-a (score 3, lower than scene-b's 4)
+        assert 'scene-a' in rows[0]['worst_items']
+
+
+# =====================================================================
+# scoring.py — generate_proposals
+# =====================================================================
+
+class TestGenerateProposalsColumnOrder:
+    def test_diagnosis_columns_reordered(self, tmp_path):
+        from storyforge.scoring import generate_proposals
+        scores_dir = str(tmp_path / 'cycle')
+        os.makedirs(scores_dir)
+        # Reorder diagnosis columns
+        _write_csv(os.path.join(scores_dir, 'diagnosis.csv'),
+                   ['priority', 'worst_items', 'avg_score', 'scale', 'principle', 'delta_from_last', 'root_cause'],
+                   [['high', 'scene-a', '1.5', 'scene', 'voice', '-0.5', 'craft']])
+        # Reordered weights
+        _write_csv(str(tmp_path / 'weights.csv'),
+                   ['weight', 'principle'],
+                   [['5', 'voice']])
+        # Scene scores with reordered id
+        _write_csv(os.path.join(scores_dir, 'scene-scores.csv'),
+                   ['voice', 'id'],
+                   [['2', 'scene-a']])
+        generate_proposals(scores_dir, str(tmp_path / 'weights.csv'))
+
+        proposals_path = os.path.join(scores_dir, 'proposals.csv')
+        assert os.path.isfile(proposals_path)
+        import csv
+        with open(proposals_path) as f:
+            reader = csv.DictReader(f, delimiter='|')
+            rows = list(reader)
+        assert len(rows) >= 1
+        assert rows[0]['principle'] == 'voice'
+
+
+# =====================================================================
+# scoring.py — build_evaluation_criteria
+# =====================================================================
+
+class TestBuildEvaluationCriteriaColumnOrder:
+    def test_reordered_columns(self, tmp_path, plugin_dir):
+        from storyforge.scoring import build_evaluation_criteria
+        diag = str(tmp_path / 'diag.csv')
+        # Reorder: question|principle|other_col
+        _write_csv(diag, ['question', 'principle', 'other_col'],
+                   [['Does the scene show?', 'voice', 'x'],
+                    ['Is rhythm good?', 'voice', 'y']])
+        guide = os.path.join(plugin_dir, 'references', 'principle-guide.md')
+        result = build_evaluation_criteria(diag, guide)
+        assert 'voice' in result
+        assert 'Does the scene show?' in result
+
+
+# =====================================================================
+# scoring.py — collect_exemplars
+# =====================================================================
+
+class TestCollectExemplarsColumnOrder:
+    def test_scores_with_reordered_id(self, tmp_path):
+        from storyforge.scoring import collect_exemplars
+        scores_dir = str(tmp_path / 'scores')
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(os.path.join(project_dir, 'working'), exist_ok=True)
+
+        # Scene scores with id as last column
+        _write_csv(os.path.join(scores_dir, 'scene-scores.csv'),
+                   ['voice', 'id'],
+                   [['5', 'scene-a'], ['3', 'scene-b']])
+
+        collect_exemplars(scores_dir, project_dir, 'cycle-1')
+
+        exemplars = os.path.join(project_dir, 'working', 'exemplars.csv')
+        assert os.path.isfile(exemplars)
+        with open(exemplars) as f:
+            lines = f.read().strip().split('\n')
+        # Should have header + one exemplar (scene-a with score 5)
+        assert len(lines) == 2
+        assert 'scene-a' in lines[1]
+
+
+# =====================================================================
+# scoring.py — merge_score_files with id not in column 0
+# =====================================================================
+
+class TestMergeScoreFilesColumnOrder:
+    def test_join_with_id_not_first(self, tmp_path):
+        from storyforge.scoring import merge_score_files
+        target = str(tmp_path / 'target.csv')
+        source = str(tmp_path / 'source.csv')
+        # Target has id as column 1, voice as column 0
+        _write_csv(target, ['voice', 'id'], [['3', 'scene-a']])
+        # Source has same id reordered with a new column
+        _write_csv(source, ['id', 'pacing'], [['scene-a', '4']])
+        merge_score_files(target, source)
+
+        with open(target) as f:
+            lines = f.read().strip().split('\n')
+        # Should have merged header
+        header = lines[0].split('|')
+        assert 'id' in header
+        assert 'voice' in header
+        assert 'pacing' in header
+
+
+# =====================================================================
+# scoring.py — generate_score_report diagnosis/proposals
+# =====================================================================
+
+class TestScoreReportColumnOrder:
+    def test_report_with_reordered_diagnosis(self, tmp_path):
+        """Verify generate_score_report reads diagnosis columns by name."""
+        from storyforge.scoring import generate_score_report
+        cycle_dir = str(tmp_path / 'cycle')
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(cycle_dir)
+        os.makedirs(project_dir)
+        # Write storyforge.yaml
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('title: Test Novel\n')
+        # Reordered diagnosis: worst_items first
+        _write_csv(os.path.join(cycle_dir, 'diagnosis.csv'),
+                   ['worst_items', 'avg_score', 'principle', 'scale', 'delta_from_last', 'priority', 'root_cause'],
+                   [['scene-a', '3.5', 'voice', 'scene', '+0.5', 'medium', 'craft']])
+        # Reordered proposals
+        _write_csv(os.path.join(cycle_dir, 'proposals.csv'),
+                   ['status', 'rationale', 'change', 'target', 'lever', 'principle', 'id'],
+                   [['pending', 'low score', 'weight 5 -> 7', 'global', 'craft_weight', 'voice', 'p001']])
+        generate_score_report(cycle_dir, project_dir, '1', 'full', 5, '0.50')
+        report = os.path.join(cycle_dir, 'report.html')
+        assert os.path.isfile(report)
+        with open(report) as f:
+            html = f.read()
+        assert 'voice' in html
+        assert 'craft weight' in html
+
+    def test_pr_comment_with_reordered_diagnosis(self, tmp_path):
+        """Verify build_score_pr_comment reads diagnosis columns by name."""
+        from storyforge.scoring import build_score_pr_comment
+        cycle_dir = str(tmp_path / 'cycle')
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(cycle_dir)
+        os.makedirs(project_dir)
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('title: Test Novel\n')
+        # Reordered diagnosis
+        _write_csv(os.path.join(cycle_dir, 'diagnosis.csv'),
+                   ['worst_items', 'avg_score', 'principle', 'scale', 'delta_from_last', 'priority', 'root_cause'],
+                   [['scene-a', '3.5', 'voice', 'scene', '+0.5', 'medium', 'craft']])
+        # Reordered proposals
+        _write_csv(os.path.join(cycle_dir, 'proposals.csv'),
+                   ['status', 'rationale', 'change', 'target', 'lever', 'principle', 'id'],
+                   [['pending', 'low score', 'weight 5 -> 7', 'global', 'craft_weight', 'voice', 'p001']])
+        result = build_score_pr_comment(cycle_dir, project_dir, '1', 'full', 5, '0.50')
+        assert 'voice' in result
+        assert 'craft weight' in result
+
+
+# =====================================================================
+# structural.py — load_previous_scores
+# =====================================================================
+
+class TestLoadPreviousScoresColumnOrder:
+    def test_reordered_columns(self, tmp_path):
+        from storyforge.structural import load_previous_scores
+        scores_dir = os.path.join(str(tmp_path), 'working', 'scores')
+        os.makedirs(scores_dir)
+        # Standard order: dimension|score|target|weight
+        std = os.path.join(scores_dir, 'structural-latest.csv')
+        _write_csv(std, ['dimension', 'score', 'target', 'weight'],
+                   [['arc_completeness', '0.85', '0.80', '1.0'],
+                    ['overall', '0.75', '0.70', '1.0']])
+        result = load_previous_scores(str(tmp_path))
+        assert result is not None
+        assert result['arc_completeness'] == 0.85
+        assert result['overall'] == 0.75
+
+    def test_columns_in_different_order(self, tmp_path):
+        from storyforge.structural import load_previous_scores
+        scores_dir = os.path.join(str(tmp_path), 'working', 'scores')
+        os.makedirs(scores_dir)
+        # Reordered: weight|target|score|dimension
+        latest = os.path.join(scores_dir, 'structural-latest.csv')
+        _write_csv(latest, ['weight', 'target', 'score', 'dimension'],
+                   [['1.0', '0.80', '0.85', 'arc_completeness'],
+                    ['1.0', '0.70', '0.75', 'overall']])
+        result = load_previous_scores(str(tmp_path))
+        assert result is not None
+        assert result['arc_completeness'] == 0.85
+        assert result['overall'] == 0.75
+
+
+# =====================================================================
+# scoring.py — check_validated_patterns
+# =====================================================================
+
+class TestCheckValidatedPatternsColumnOrder:
+    def test_reordered_tuning_columns(self, tmp_path):
+        from storyforge.scoring import check_validated_patterns
+        project_dir = str(tmp_path)
+        os.makedirs(os.path.join(project_dir, 'working'))
+        tuning = os.path.join(project_dir, 'working', 'tuning.csv')
+        # Reordered columns (standard might be: cycle|scene|principle|lever|target|score_before|score_after|validated)
+        _write_csv(tuning,
+                   ['validated', 'score_after', 'score_before', 'lever', 'principle', 'target', 'scene', 'cycle'],
+                   [['true', '4.0', '2.0', 'craft_weight', 'voice', 'global', 'scene-a', '1'],
+                    ['true', '4.5', '2.5', 'craft_weight', 'voice', 'global', 'scene-b', '2'],
+                    ['true', '4.0', '3.0', 'craft_weight', 'voice', 'global', 'scene-c', '3']])
+        result = check_validated_patterns(project_dir)
+        assert 'voice' in result
+        assert 'craft_weight' in result


### PR DESCRIPTION
## Summary
- Replace hardcoded column indices (`row[0]`, `row[1]`, etc.) with header-based lookups in `scoring.py` and `structural.py`
- Add `_col_val()` helper function for safe named column access across all report/proposal generation
- Fix 15+ functions that assumed CSV columns would always be in a specific order

## Files changed
- `scripts/lib/python/storyforge/scoring.py` -- all CSV reading now uses column name lookups
- `scripts/lib/python/storyforge/structural.py` -- `load_previous_scores` uses header-based lookup
- `tests/test_csv_column_order.py` -- 14 regression tests verifying functions work with reordered columns

## Test plan
- [x] All 980 tests pass (966 existing + 14 new)
- [x] New tests create CSVs with columns in non-standard order and verify correct behavior
- [x] Covers: `build_weighted_text`, `get_effective_weight`, `generate_diagnosis`, `generate_proposals`, `build_evaluation_criteria`, `collect_exemplars`, `merge_score_files`, `generate_score_report`, `build_score_pr_comment`, `check_validated_patterns`, `load_previous_scores`

🤖 Generated with [Claude Code](https://claude.com/claude-code)