### PR TITLE
Add targeted scoring passes (--principles flag)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ Run: `./tests/run-tests.sh` or `python3 -m pytest tests/` or `pytest tests/test_
 | `storyforge write` | `cmd_write.py` | Draft scenes (brief-aware, parallel wave drafting) |
 | `storyforge evaluate` | `cmd_evaluate.py` | Multi-agent evaluation panel (6 evaluators + synthesis) |
 | `storyforge revise` | `cmd_revise.py` | Execute revision passes. `--polish` for craft-only. `--polish --loop` for score→polish convergence. `--naturalness` for AI pattern removal. |
-| `storyforge score` | `cmd_score.py` | Craft scoring (25 principles + fidelity scoring against briefs) |
+| `storyforge score` | `cmd_score.py` | Craft scoring (25 principles + fidelity scoring against briefs). `--principles P1,P2` for targeted scoring; deterministic principles (e.g. `prose_repetition`) skip the LLM pipeline entirely. |
 | `storyforge elaborate` | `cmd_elaborate.py` | Run elaboration stages (spine/architecture/map/briefs) |
 | `storyforge extract` | `cmd_extract.py` | Extract structural data from prose. `--force` overwrites. |
 | `storyforge validate` | `cmd_validate.py` | Structural + schema validation. `--structural` for scoring. |

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -141,6 +141,9 @@ def main(argv=None):
     # Parse --principles / --deterministic filter
     targeted_principles = None
     deterministic_only = False
+    if args.deterministic and args.principles:
+        log('WARNING: --deterministic and --principles both set; '
+            'using --deterministic (ignoring --principles)')
     if args.deterministic:
         targeted_principles = sorted(DETERMINISTIC_PRINCIPLES)
         deterministic_only = True
@@ -418,23 +421,7 @@ def main(argv=None):
                       or 'prose_repetition' in targeted_principles)
 
     if run_repetition:
-        from storyforge.repetition import scan_manuscript, score_scene_repetition
-
-        log('Running repetition scan...')
-        rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
-        rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
-        log(f'Repetition scan: {len(rep_findings)} findings ({rep_high} high-severity)')
-
-        rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
-        with open(rep_scores_path, 'w', encoding='utf-8') as f:
-            f.write('id|prose_repetition\n')
-            for sid in scene_ids:
-                markers = score_scene_repetition(sid, rep_findings)
-                active = sum(markers[k] for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
-                prose_rep_score = max(1, 5 - active)
-                f.write(f'{sid}|{prose_rep_score}\n')
-
-        log(f'Repetition scores: {rep_scores_path}')
+        _score_repetition(scene_ids, project_dir, cycle_dir)
 
     # =========================================================================
     # Improvement cycle
@@ -484,6 +471,28 @@ def main(argv=None):
 # Internal helpers
 # ============================================================================
 
+def _score_repetition(scene_ids, project_dir, cycle_dir):
+    """Run deterministic repetition scoring. Returns path to scores CSV."""
+    from storyforge.repetition import scan_manuscript, score_scene_repetition
+
+    log('Running repetition scan...')
+    rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
+    rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
+    log(f'Repetition scan: {len(rep_findings)} findings ({rep_high} high-severity)')
+
+    rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
+    with open(rep_scores_path, 'w', encoding='utf-8') as f:
+        f.write('id|prose_repetition\n')
+        for sid in scene_ids:
+            markers = score_scene_repetition(sid, rep_findings)
+            active = sum(markers[k] for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
+            prose_rep_score = max(1, 5 - active)
+            f.write(f'{sid}|{prose_rep_score}\n')
+
+    log(f'Repetition scores: {rep_scores_path}')
+    return rep_scores_path
+
+
 def _resolve_filter(args):
     if args.scenes:
         return ('scenes', args.scenes, None)
@@ -504,26 +513,8 @@ def _run_deterministic_only(principles, scene_ids, project_dir, cycle,
 
     for principle in principles:
         if principle == 'prose_repetition':
-            from storyforge.repetition import scan_manuscript, score_scene_repetition
-
-            log('Running repetition scan...')
-            rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
-            rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
-            log(f'Repetition scan: {len(rep_findings)} findings '
-                f'({rep_high} high-severity)')
-
-            rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
-            with open(rep_scores_path, 'w', encoding='utf-8') as f:
-                f.write('id|prose_repetition\n')
-                for sid in scene_ids:
-                    markers = score_scene_repetition(sid, rep_findings)
-                    active = sum(markers[k]
-                                 for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
-                    prose_rep_score = max(1, 5 - active)
-                    f.write(f'{sid}|{prose_rep_score}\n')
-
-            log(f'Repetition scores written: {rep_scores_path}')
-
+            rep_scores_path = _score_repetition(scene_ids, project_dir,
+                                                cycle_dir)
             # Merge into scene-scores.csv for diagnosis compatibility
             scores_path = os.path.join(cycle_dir, 'scene-scores.csv')
             from storyforge.scoring import merge_score_files
@@ -649,6 +640,11 @@ def _build_scene_prompt(scene_id: str, eval_template: str,
     # Number lines
     numbered = '\n'.join(f'{i+1}: {line}' for i, line in enumerate(scene_text.splitlines()))
 
+    # Count principles from the evaluation criteria (each gets a ### heading)
+    principle_count = evaluation_criteria.count('\n### ')
+    if not principle_count:
+        principle_count = 25  # fallback for the default full set
+
     prompt = eval_template
     prompt = prompt.replace('{{SCENE_TITLE}}', scene_title)
     prompt = prompt.replace('{{SCENE_POV}}', scene_pov)
@@ -656,6 +652,7 @@ def _build_scene_prompt(scene_id: str, eval_template: str,
     prompt = prompt.replace('{{SCENE_EMOTIONAL_ARC}}', scene_emotional_arc or 'Not specified')
     prompt = prompt.replace('{{EVALUATION_CRITERIA}}', evaluation_criteria)
     prompt = prompt.replace('{{WEIGHTED_PRINCIPLES}}', weighted_text_str)
+    prompt = prompt.replace('{{PRINCIPLE_COUNT}}', str(principle_count))
     prompt = prompt.replace('{{SCENE_TEXT}}', numbered)
     return prompt
 

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -64,6 +64,8 @@ def parse_args(argv):
     parser.add_argument('--principles', type=str, default=None,
                         help='Comma-separated craft principles to score '
                              '(e.g. prose_repetition,prose_naturalness)')
+    parser.add_argument('--deterministic', action='store_true',
+                        help='Score only deterministic principles (no API calls)')
     parser.add_argument('--parallel', type=int,
                         default=int(os.environ.get('STORYFORGE_SCORE_PARALLEL', '6')),
                         help='Parallel workers for direct mode (default: 6)')
@@ -136,12 +138,16 @@ def main(argv=None):
     scripts_dir = os.path.join(plugin_dir, 'scripts')
     prompts_dir = os.path.join(scripts_dir, 'prompts', 'scoring')
 
-    # Parse --principles filter
+    # Parse --principles / --deterministic filter
     targeted_principles = None
     deterministic_only = False
-    if args.principles:
+    if args.deterministic:
+        targeted_principles = sorted(DETERMINISTIC_PRINCIPLES)
+        deterministic_only = True
+    elif args.principles:
         targeted_principles = _parse_principles(args.principles, plugin_dir)
         deterministic_only = all(p in DETERMINISTIC_PRINCIPLES for p in targeted_principles)
+    if targeted_principles:
         log(f'Targeted principles: {", ".join(targeted_principles)}')
         if deterministic_only:
             log('All requested principles are deterministic — skipping LLM pipeline')

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -61,10 +61,51 @@ def parse_args(argv):
                         help='Score scenes in act/part N')
     parser.add_argument('--from-seq', type=str, default=None,
                         help='Start from sequence number (N or N-M range)')
+    parser.add_argument('--principles', type=str, default=None,
+                        help='Comma-separated craft principles to score '
+                             '(e.g. prose_repetition,prose_naturalness)')
     parser.add_argument('--parallel', type=int,
                         default=int(os.environ.get('STORYFORGE_SCORE_PARALLEL', '6')),
                         help='Parallel workers for direct mode (default: 6)')
     return parser.parse_args(argv)
+
+
+# Principles that can be scored without any API calls.
+DETERMINISTIC_PRINCIPLES = frozenset(['prose_repetition'])
+
+
+def _load_known_principles(plugin_dir: str) -> set[str]:
+    """Load all known principle names from default-craft-weights.csv."""
+    weights_path = os.path.join(plugin_dir, 'references', 'default-craft-weights.csv')
+    if not os.path.isfile(weights_path):
+        return set()
+    principles = set()
+    with open(weights_path) as f:
+        header = f.readline().strip().split('|')
+        p_idx = header.index('principle') if 'principle' in header else 1
+        for line in f:
+            fields = line.strip().split('|')
+            if len(fields) > p_idx and fields[p_idx]:
+                principles.add(fields[p_idx])
+    return principles
+
+
+def _parse_principles(raw: str, plugin_dir: str) -> list[str]:
+    """Parse and validate the --principles flag value.
+
+    Returns a list of validated principle names.
+    Exits with an error message if any principle name is unrecognised.
+    """
+    requested = [p.strip() for p in raw.split(',') if p.strip()]
+    known = _load_known_principles(plugin_dir)
+    if not known:
+        return requested  # graceful fallback when weights file missing
+    unknown = [p for p in requested if p not in known]
+    if unknown:
+        log(f'ERROR: Unknown principle(s): {", ".join(unknown)}')
+        log(f'Known principles: {", ".join(sorted(known))}')
+        sys.exit(1)
+    return requested
 
 
 def main(argv=None):
@@ -94,6 +135,16 @@ def main(argv=None):
     plugin_dir = get_plugin_dir()
     scripts_dir = os.path.join(plugin_dir, 'scripts')
     prompts_dir = os.path.join(scripts_dir, 'prompts', 'scoring')
+
+    # Parse --principles filter
+    targeted_principles = None
+    deterministic_only = False
+    if args.principles:
+        targeted_principles = _parse_principles(args.principles, plugin_dir)
+        deterministic_only = all(p in DETERMINISTIC_PRINCIPLES for p in targeted_principles)
+        log(f'Targeted principles: {", ".join(targeted_principles)}')
+        if deterministic_only:
+            log('All requested principles are deterministic — skipping LLM pipeline')
 
     # Model selection
     sonnet_model = select_model('evaluation')
@@ -156,6 +207,27 @@ def main(argv=None):
 
     log(f'Cycle: {cycle} -> {cycle_dir}')
 
+    # =========================================================================
+    # Deterministic-only fast path
+    # =========================================================================
+    # When --principles requests only deterministic principles (e.g.
+    # prose_repetition), skip the entire LLM pipeline: no API key needed, no
+    # cost, no batch requests, no PR.  Just run the deterministic scorers,
+    # write results, generate diagnosis, commit and exit.
+
+    if deterministic_only:
+        if args.dry_run:
+            _print_dry_run_deterministic(
+                targeted_principles, scene_count, cycle, scene_ids,
+                metadata_csv, cycle_dir,
+            )
+            return
+        _run_deterministic_only(
+            targeted_principles, scene_ids, project_dir, cycle, cycle_dir,
+            plugin_dir, weights_file, title,
+        )
+        return
+
     # Cost forecast
     avg_words = _avg_word_count(metadata_csv, scene_ids, scenes_dir)
     scene_cost = estimate_cost('score', scene_count, avg_words, eval_model)
@@ -200,7 +272,7 @@ def main(argv=None):
     if args.dry_run:
         _print_dry_run(score_mode, scene_count, args.parallel, cycle,
                        eval_model, scene_cost, scene_ids, metadata_csv,
-                       cycle_dir)
+                       cycle_dir, targeted_principles)
         return
 
     # Load evaluation template and criteria
@@ -218,8 +290,16 @@ def main(argv=None):
         eval_template = f.read()
 
     from storyforge.scoring import build_evaluation_criteria, build_weighted_text
-    evaluation_criteria = build_evaluation_criteria(diagnostics_csv, guide_file)
-    weighted_text_str = build_weighted_text(weights_file, exclude_section='narrative')
+    # Filter to only the requested LLM-scored principles (excluding
+    # deterministic ones which are handled separately).
+    llm_principles = None
+    if targeted_principles:
+        llm_principles = [p for p in targeted_principles
+                          if p not in DETERMINISTIC_PRINCIPLES]
+    evaluation_criteria = build_evaluation_criteria(
+        diagnostics_csv, guide_file, principles=llm_principles)
+    weighted_text_str = build_weighted_text(
+        weights_file, exclude_section='narrative', principles=llm_principles)
 
     log(f'Evaluation model: {eval_model} (mode: {score_mode})')
 
@@ -255,51 +335,54 @@ def main(argv=None):
     update_pr_task(f'Scene-level scoring ({scene_count} scenes)', project_dir)
 
     # =========================================================================
-    # Brief fidelity scoring
+    # Brief fidelity scoring (skip when targeting specific principles)
     # =========================================================================
 
-    if has_briefs:
+    if has_briefs and not targeted_principles:
         _run_fidelity_scoring(
             filtered_ids, project_dir, scenes_dir, log_dir, cycle_dir,
             briefs_csv, score_mode, sonnet_model, plugin_dir,
         )
 
     # =========================================================================
-    # Act-level scoring
+    # Act-level scoring (skip when targeting specific principles)
     # =========================================================================
 
-    log('Running act-level scoring...')
-    _run_act_scoring(
-        scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
-        prompts_dir, weights_file, sonnet_model, plugin_dir, args.dry_run,
-    )
-    update_pr_task('Act-level scoring', project_dir)
+    if not targeted_principles:
+        log('Running act-level scoring...')
+        _run_act_scoring(
+            scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
+            prompts_dir, weights_file, sonnet_model, plugin_dir, args.dry_run,
+        )
+        update_pr_task('Act-level scoring', project_dir)
 
     # =========================================================================
-    # Novel-level scoring
+    # Novel-level scoring (skip when targeting specific principles)
     # =========================================================================
 
-    log('Running novel-level scoring...')
-    _run_novel_scoring(
-        scene_count, metadata_csv, intent_csv, project_dir, cycle_dir,
-        log_dir, prompts_dir, weights_file, sonnet_model, plugin_dir,
-        args.dry_run,
-    )
-    update_pr_task('Novel-level scoring', project_dir)
+    if not targeted_principles:
+        log('Running novel-level scoring...')
+        _run_novel_scoring(
+            scene_count, metadata_csv, intent_csv, project_dir, cycle_dir,
+            log_dir, prompts_dir, weights_file, sonnet_model, plugin_dir,
+            args.dry_run,
+        )
+        update_pr_task('Novel-level scoring', project_dir)
 
     # =========================================================================
-    # Narrative framework scoring
+    # Narrative framework scoring (skip when targeting specific principles)
     # =========================================================================
 
-    log('')
-    log('============================================')
-    log('Narrative Framework Scoring')
-    log('============================================')
+    if not targeted_principles:
+        log('')
+        log('============================================')
+        log('Narrative Framework Scoring')
+        log('============================================')
 
-    _run_narrative_scoring(
-        title, metadata_csv, project_dir, cycle_dir, log_dir, prompts_dir,
-        weights_file, args.dry_run,
-    )
+        _run_narrative_scoring(
+            title, metadata_csv, project_dir, cycle_dir, log_dir, prompts_dir,
+            weights_file, args.dry_run,
+        )
 
     # Update latest symlink
     latest_link = os.path.join(project_dir, 'working', 'scores', 'latest')
@@ -323,25 +406,29 @@ def main(argv=None):
     # Repetition scoring (deterministic, no API calls)
     # =========================================================================
 
-    from storyforge.repetition import scan_manuscript, score_scene_repetition
+    # Run repetition when: no --principles filter, or prose_repetition is in
+    # the requested set.
+    run_repetition = (not targeted_principles
+                      or 'prose_repetition' in targeted_principles)
 
-    log('Running repetition scan...')
-    rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
-    rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
-    log(f'Repetition scan: {len(rep_findings)} findings ({rep_high} high-severity)')
+    if run_repetition:
+        from storyforge.repetition import scan_manuscript, score_scene_repetition
 
-    rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
-    with open(rep_scores_path, 'w', encoding='utf-8') as f:
-        f.write('id|prose_repetition\n')
-        for sid in scene_ids:
-            markers = score_scene_repetition(sid, rep_findings)
-            # Aggregate pr-1..pr-4 flags into a single 1-5 score.
-            # Each active marker reduces the score by 1 (0 flags → 5, 4 flags → 1).
-            active = sum(markers[k] for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
-            prose_rep_score = max(1, 5 - active)
-            f.write(f'{sid}|{prose_rep_score}\n')
+        log('Running repetition scan...')
+        rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
+        rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
+        log(f'Repetition scan: {len(rep_findings)} findings ({rep_high} high-severity)')
 
-    log(f'Repetition scores: {rep_scores_path}')
+        rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
+        with open(rep_scores_path, 'w', encoding='utf-8') as f:
+            f.write('id|prose_repetition\n')
+            for sid in scene_ids:
+                markers = score_scene_repetition(sid, rep_findings)
+                active = sum(markers[k] for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
+                prose_rep_score = max(1, 5 - active)
+                f.write(f'{sid}|{prose_rep_score}\n')
+
+        log(f'Repetition scores: {rep_scores_path}')
 
     # =========================================================================
     # Improvement cycle
@@ -399,6 +486,97 @@ def _resolve_filter(args):
     if hasattr(args, 'from_seq') and args.from_seq:
         return ('from_seq', args.from_seq, None)
     return ('all', None, None)
+
+
+def _run_deterministic_only(principles, scene_ids, project_dir, cycle,
+                            cycle_dir, plugin_dir, weights_file, title):
+    """Fast path for scoring only deterministic principles (no API calls)."""
+    log('')
+    log('============================================')
+    log('Deterministic Scoring (no API calls)')
+    log('============================================')
+
+    for principle in principles:
+        if principle == 'prose_repetition':
+            from storyforge.repetition import scan_manuscript, score_scene_repetition
+
+            log('Running repetition scan...')
+            rep_findings = scan_manuscript(project_dir, scene_ids=scene_ids)
+            rep_high = sum(1 for f in rep_findings if f['severity'] == 'high')
+            log(f'Repetition scan: {len(rep_findings)} findings '
+                f'({rep_high} high-severity)')
+
+            rep_scores_path = os.path.join(cycle_dir, 'repetition-latest.csv')
+            with open(rep_scores_path, 'w', encoding='utf-8') as f:
+                f.write('id|prose_repetition\n')
+                for sid in scene_ids:
+                    markers = score_scene_repetition(sid, rep_findings)
+                    active = sum(markers[k]
+                                 for k in ('pr-1', 'pr-2', 'pr-3', 'pr-4'))
+                    prose_rep_score = max(1, 5 - active)
+                    f.write(f'{sid}|{prose_rep_score}\n')
+
+            log(f'Repetition scores written: {rep_scores_path}')
+
+            # Merge into scene-scores.csv for diagnosis compatibility
+            scores_path = os.path.join(cycle_dir, 'scene-scores.csv')
+            from storyforge.scoring import merge_score_files
+            merge_score_files(scores_path, rep_scores_path)
+
+    # Update latest symlink
+    latest_link = os.path.join(project_dir, 'working', 'scores', 'latest')
+    target = f'cycle-{cycle}'
+    if os.path.islink(latest_link):
+        os.remove(latest_link)
+    os.symlink(target, latest_link)
+    log(f'Updated latest symlink -> {target}')
+
+    # Append to score history
+    from storyforge.history import append_cycle
+    history_count = append_cycle(cycle_dir, cycle, project_dir)
+    if history_count:
+        log(f'Score history: appended {history_count} entries (cycle {cycle})')
+
+    # Diagnosis (only for scored principles)
+    from storyforge.scoring import generate_diagnosis
+    prev_cycle = cycle - 1
+    prev_dir = os.path.join(project_dir, 'working', 'scores',
+                            f'cycle-{prev_cycle}')
+    if not os.path.isdir(prev_dir):
+        prev_dir = '-'
+    generate_diagnosis(cycle_dir, prev_dir, weights_file)
+
+    # Commit results
+    commit_and_push(project_dir,
+                    f'Score: {", ".join(principles)} cycle {cycle}, '
+                    f'{len(scene_ids)} scenes (deterministic)',
+                    ['working/scores/', 'working/costs/', 'working/logs/'])
+
+    log('')
+    log('============================================')
+    log(f'Deterministic scoring complete — cycle {cycle}')
+    log(f'Results: {cycle_dir}')
+    log('============================================')
+
+
+def _print_dry_run_deterministic(principles, scene_count, cycle, scene_ids,
+                                 metadata_csv, cycle_dir):
+    """Print dry-run summary for deterministic-only scoring."""
+    log('============================================')
+    log('DRY RUN — Deterministic Scoring (no API calls)')
+    log('============================================')
+    log(f'Principles: {", ".join(principles)}')
+    log(f'Scenes:     {scene_count}')
+    log(f'Cycle:      {cycle}')
+    log(f'Cost:       $0.00 (deterministic)')
+    log('')
+    log('Scenes to score:')
+    for sid in scene_ids:
+        title = get_field(metadata_csv, sid, 'title') or 'untitled'
+        log(f'  - {sid} ({title})')
+    log('')
+    log(f'Output directory: {cycle_dir}')
+    log('============================================')
 
 
 def _determine_cycle(project_dir: str) -> int:
@@ -1235,12 +1413,15 @@ def _read_reference(project_dir: str, candidates: list) -> str:
 
 
 def _print_dry_run(score_mode, scene_count, parallel, cycle, eval_model,
-                   scene_cost, scene_ids, metadata_csv, cycle_dir):
+                   scene_cost, scene_ids, metadata_csv, cycle_dir,
+                   targeted_principles=None):
     """Print dry-run summary."""
     log('============================================')
     log('DRY RUN — Scoring Plan')
     log('============================================')
     log(f'Mode:     {score_mode}')
+    if targeted_principles:
+        log(f'Principles: {", ".join(targeted_principles)}')
     log(f'Scenes:   {scene_count}')
     log(f'Parallel: {parallel}')
     log(f'Cycle:    {cycle}')
@@ -1260,10 +1441,13 @@ def _print_dry_run(score_mode, scene_count, parallel, cycle, eval_model,
     else:
         log(f'Direct+deep mode: {scene_count} Opus calls, real-time, {parallel} parallel')
     log('')
-    log('After scene scoring:')
-    log('  - Act-level scoring')
-    log('  - Novel-level character + genre scoring (1 invocation)')
-    log('  - Novel-level narrative framework scoring (1 invocation)')
+    if targeted_principles:
+        log('Targeted scoring — skipping act/novel/narrative phases')
+    else:
+        log('After scene scoring:')
+        log('  - Act-level scoring')
+        log('  - Novel-level character + genre scoring (1 invocation)')
+        log('  - Novel-level narrative framework scoring (1 invocation)')
     log('')
     log(f'Output directory: {cycle_dir}')
     log('============================================')

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -195,7 +195,8 @@ def merge_score_files(target_path: str, source_path: str):
 # build_weighted_text
 # ============================================================================
 
-def build_weighted_text(weights_file: str, exclude_section: str = '') -> str:
+def build_weighted_text(weights_file: str, exclude_section: str = '',
+                        principles: list[str] | None = None) -> str:
     """Build markdown text listing high-priority craft principles.
 
     Reads craft-weights.csv, filters to effective weight >= 7, optionally
@@ -204,6 +205,7 @@ def build_weighted_text(weights_file: str, exclude_section: str = '') -> str:
     Args:
         weights_file: Path to craft-weights.csv.
         exclude_section: Section name to exclude (e.g. 'narrative').
+        principles: If set, only include these principles. None means all.
 
     Returns:
         Formatted markdown string.
@@ -215,6 +217,7 @@ def build_weighted_text(weights_file: str, exclude_section: str = '') -> str:
     # Expect columns: section|principle|weight|author_weight|notes
     col_idx = {name: i for i, name in enumerate(header)}
 
+    principle_filter = frozenset(principles) if principles is not None else None
     high_priority = []
     for row in rows:
         section = row[col_idx['section']] if 'section' in col_idx and col_idx['section'] < len(row) else ''
@@ -223,6 +226,8 @@ def build_weighted_text(weights_file: str, exclude_section: str = '') -> str:
         author_weight = row[col_idx['author_weight']] if 'author_weight' in col_idx and col_idx['author_weight'] < len(row) else ''
 
         if exclude_section and section == exclude_section:
+            continue
+        if principle_filter is not None and principle not in principle_filter:
             continue
 
         eff_w = author_weight if author_weight else weight
@@ -824,7 +829,8 @@ def _build_principle_guide(principle_name: str, guide_file: str) -> str:
 # build_evaluation_criteria
 # ============================================================================
 
-def build_evaluation_criteria(diagnostics_csv: str, guide_file: str) -> str:
+def build_evaluation_criteria(diagnostics_csv: str, guide_file: str,
+                              principles: list[str] | None = None) -> str:
     """Build combined evaluation criteria from diagnostics CSV and principle guide.
 
     For each principle found in the diagnostics CSV, produces a section with:
@@ -834,6 +840,7 @@ def build_evaluation_criteria(diagnostics_csv: str, guide_file: str) -> str:
     Args:
         diagnostics_csv: Path to the diagnostics CSV file (pipe-delimited).
         guide_file: Path to the principle-guide.md file.
+        principles: If set, only include these principles. None means all.
 
     Returns:
         Formatted markdown text with evaluation criteria per principle.
@@ -854,20 +861,23 @@ def build_evaluation_criteria(diagnostics_csv: str, guide_file: str) -> str:
 
     # Group questions by principle, preserving order
     from collections import OrderedDict
-    principles: OrderedDict[str, list[str]] = OrderedDict()
+    principle_filter = frozenset(principles) if principles is not None else None
+    principle_questions: OrderedDict[str, list[str]] = OrderedDict()
     for row in rows:
         principle = row[principle_idx] if len(row) > principle_idx else ''
         question = row[question_idx] if question_idx is not None and len(row) > question_idx else ''
         if not principle:
             continue
-        if principle not in principles:
-            principles[principle] = []
+        if principle_filter is not None and principle not in principle_filter:
+            continue
+        if principle not in principle_questions:
+            principle_questions[principle] = []
         if question:
-            principles[principle].append(question)
+            principle_questions[principle].append(question)
 
     # Build output
     parts = []
-    for principle, questions in principles.items():
+    for principle, questions in principle_questions.items():
         parts.append('---')
         parts.append('')
         parts.append(f'### {principle}')

--- a/scripts/prompts/scoring/scene-evaluation.md
+++ b/scripts/prompts/scoring/scene-evaluation.md
@@ -1,4 +1,4 @@
-You are a demanding manuscript editor evaluating a single scene against 25 craft principles. Your job is to find what isn't working, not to validate what is.
+You are a demanding manuscript editor evaluating a single scene against {{PRINCIPLE_COUNT}} craft principles. Your job is to find what isn't working, not to validate what is.
 
 ## Scene
 
@@ -21,7 +21,7 @@ For each principle below, the diagnostic checklist tells you what to look for. T
 
 ## Instructions
 
-Evaluate this scene against all 25 principles. For each principle:
+Evaluate this scene against all {{PRINCIPLE_COUNT}} principles listed above. For each principle:
 
 1. Check the diagnostic markers. These are the specific things to look for — go through each one honestly.
 2. Weigh the evidence. How many markers indicate deficits? Are the deficits structural (the principle is missing), execution-level (attempted but weak), or surface (minor polish)?

--- a/skills/score/SKILL.md
+++ b/skills/score/SKILL.md
@@ -170,6 +170,7 @@ When the author says "run scoring" or "score my scenes":
 1. Confirm the mode and scope:
    - **Mode:** default (Haiku screen + Sonnet deep dive for deficits), `--quick` (Haiku screen only, fast), or `--deep` (Haiku screen + Sonnet deep dive for all principles)
    - **Scope:** all scenes (default), `--scenes ID,ID` for specific scenes, `--act N` for a specific act
+   - **Principles:** `--principles NAMES` for targeted scoring of specific craft principles (comma-separated). For deterministic principles like `prose_repetition`, this skips the LLM pipeline entirely — no API calls, no cost, instant results.
 
 2. Present the author with two options:
 

--- a/tests/test_targeted_scoring.py
+++ b/tests/test_targeted_scoring.py
@@ -35,6 +35,13 @@ def test_no_principles_flag_defaults_to_none():
     assert args.principles is None
 
 
+def test_parse_deterministic_flag():
+    from storyforge.cmd_score import parse_args
+    args = parse_args(['--deterministic'])
+    assert args.deterministic is True
+    assert args.principles is None  # --principles not set
+
+
 # ---------------------------------------------------------------------------
 # Principle validation
 # ---------------------------------------------------------------------------
@@ -243,3 +250,26 @@ def test_deterministic_scoring_writes_results(project_dir, plugin_dir, monkeypat
     # latest symlink should exist
     latest = os.path.join(scores_dir, 'latest')
     assert os.path.islink(latest)
+
+
+def test_deterministic_flag_dry_run(project_dir, plugin_dir, monkeypatch):
+    """--deterministic --dry-run should behave like --principles prose_repetition."""
+    from storyforge.cmd_score import main
+
+    monkeypatch.setenv('STORYFORGE_PLUGIN_DIR', plugin_dir)
+    monkeypatch.chdir(project_dir)
+
+    output_lines = []
+
+    def capture_log(msg):
+        output_lines.append(msg)
+
+    monkeypatch.setattr('storyforge.common.log', capture_log)
+    monkeypatch.setattr('storyforge.cmd_score.log', capture_log)
+
+    main(['--deterministic', '--dry-run'])
+
+    combined = '\n'.join(output_lines)
+    assert 'Deterministic' in combined
+    assert '$0.00' in combined
+    assert 'prose_repetition' in combined

--- a/tests/test_targeted_scoring.py
+++ b/tests/test_targeted_scoring.py
@@ -1,0 +1,245 @@
+"""Tests for targeted scoring (--principles flag)."""
+
+import os
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_principles_flag():
+    from storyforge.cmd_score import parse_args
+    args = parse_args(['--principles', 'prose_repetition'])
+    assert args.principles == 'prose_repetition'
+
+
+def test_parse_multiple_principles():
+    from storyforge.cmd_score import parse_args
+    args = parse_args(['--principles', 'prose_repetition,prose_naturalness'])
+    assert args.principles == 'prose_repetition,prose_naturalness'
+
+
+def test_parse_principles_with_scenes():
+    from storyforge.cmd_score import parse_args
+    args = parse_args(['--principles', 'prose_repetition', '--scenes', 'a,b'])
+    assert args.principles == 'prose_repetition'
+    assert args.scenes == 'a,b'
+
+
+def test_no_principles_flag_defaults_to_none():
+    from storyforge.cmd_score import parse_args
+    args = parse_args([])
+    assert args.principles is None
+
+
+# ---------------------------------------------------------------------------
+# Principle validation
+# ---------------------------------------------------------------------------
+
+def test_load_known_principles(plugin_dir):
+    from storyforge.cmd_score import _load_known_principles
+    known = _load_known_principles(plugin_dir)
+    assert 'prose_repetition' in known
+    assert 'prose_naturalness' in known
+    assert 'economy_clarity' in known
+    assert len(known) >= 25
+
+
+def test_parse_principles_valid(plugin_dir):
+    from storyforge.cmd_score import _parse_principles
+    result = _parse_principles('prose_repetition,prose_naturalness', plugin_dir)
+    assert result == ['prose_repetition', 'prose_naturalness']
+
+
+def test_parse_principles_unknown_exits(plugin_dir):
+    from storyforge.cmd_score import _parse_principles
+    with pytest.raises(SystemExit):
+        _parse_principles('nonexistent_principle', plugin_dir)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic detection
+# ---------------------------------------------------------------------------
+
+def test_deterministic_only_single():
+    from storyforge.cmd_score import DETERMINISTIC_PRINCIPLES
+    assert 'prose_repetition' in DETERMINISTIC_PRINCIPLES
+
+
+def test_deterministic_only_detection():
+    from storyforge.cmd_score import DETERMINISTIC_PRINCIPLES
+    targeted = ['prose_repetition']
+    assert all(p in DETERMINISTIC_PRINCIPLES for p in targeted)
+
+
+def test_mixed_not_deterministic_only():
+    from storyforge.cmd_score import DETERMINISTIC_PRINCIPLES
+    targeted = ['prose_repetition', 'prose_naturalness']
+    assert not all(p in DETERMINISTIC_PRINCIPLES for p in targeted)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation criteria filtering
+# ---------------------------------------------------------------------------
+
+def _write_diagnostics(path, principles):
+    """Write a minimal diagnostics CSV with given principles."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        f.write('principle|question\n')
+        for p in principles:
+            f.write(f'{p}|Is {p} maintained?\n')
+
+
+def _write_guide(path):
+    """Write a minimal principle guide."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        f.write('# Principle Guide\n')
+
+
+def test_build_criteria_no_filter(tmp_path):
+    from storyforge.scoring import build_evaluation_criteria
+    diag = str(tmp_path / 'diagnostics.csv')
+    guide = str(tmp_path / 'guide.md')
+    _write_diagnostics(diag, ['economy_clarity', 'prose_naturalness', 'fictive_dream'])
+    _write_guide(guide)
+
+    result = build_evaluation_criteria(diag, guide)
+    assert 'economy_clarity' in result
+    assert 'prose_naturalness' in result
+    assert 'fictive_dream' in result
+
+
+def test_build_criteria_with_filter(tmp_path):
+    from storyforge.scoring import build_evaluation_criteria
+    diag = str(tmp_path / 'diagnostics.csv')
+    guide = str(tmp_path / 'guide.md')
+    _write_diagnostics(diag, ['economy_clarity', 'prose_naturalness', 'fictive_dream'])
+    _write_guide(guide)
+
+    result = build_evaluation_criteria(diag, guide, principles=['prose_naturalness'])
+    assert 'prose_naturalness' in result
+    assert 'economy_clarity' not in result
+    assert 'fictive_dream' not in result
+
+
+def test_build_criteria_filter_empty_list(tmp_path):
+    from storyforge.scoring import build_evaluation_criteria
+    diag = str(tmp_path / 'diagnostics.csv')
+    guide = str(tmp_path / 'guide.md')
+    _write_diagnostics(diag, ['economy_clarity', 'prose_naturalness'])
+    _write_guide(guide)
+
+    # Empty list should return nothing (no principles match)
+    result = build_evaluation_criteria(diag, guide, principles=[])
+    assert 'economy_clarity' not in result
+    assert 'prose_naturalness' not in result
+
+
+# ---------------------------------------------------------------------------
+# Weighted text filtering
+# ---------------------------------------------------------------------------
+
+def _write_weights(path, rows):
+    """Write a craft-weights CSV."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        f.write('section|principle|weight|author_weight|notes\n')
+        for section, principle, weight in rows:
+            f.write(f'{section}|{principle}|{weight}||\n')
+
+
+def test_weighted_text_no_filter(tmp_path):
+    from storyforge.scoring import build_weighted_text
+    wf = str(tmp_path / 'weights.csv')
+    _write_weights(wf, [
+        ('prose_craft', 'economy_clarity', '8'),
+        ('prose_craft', 'prose_naturalness', '5'),
+    ])
+    result = build_weighted_text(wf)
+    assert 'economy_clarity' in result
+    assert 'prose_naturalness' not in result  # weight < 7
+
+
+def test_weighted_text_with_filter(tmp_path):
+    from storyforge.scoring import build_weighted_text
+    wf = str(tmp_path / 'weights.csv')
+    _write_weights(wf, [
+        ('prose_craft', 'economy_clarity', '8'),
+        ('scene_craft', 'every_scene_must_turn', '9'),
+    ])
+    result = build_weighted_text(wf, principles=['economy_clarity'])
+    assert 'economy_clarity' in result
+    assert 'every_scene_must_turn' not in result
+
+
+# ---------------------------------------------------------------------------
+# Deterministic-only fast path (end-to-end)
+# ---------------------------------------------------------------------------
+
+def test_deterministic_dry_run(project_dir, plugin_dir, monkeypatch):
+    """--principles prose_repetition --dry-run should report $0 cost."""
+    from storyforge.cmd_score import main
+
+    monkeypatch.setenv('STORYFORGE_PLUGIN_DIR', plugin_dir)
+    monkeypatch.chdir(project_dir)
+
+    output_lines = []
+    import storyforge.common
+    original_log = storyforge.common.log
+
+    def capture_log(msg):
+        output_lines.append(msg)
+
+    monkeypatch.setattr('storyforge.common.log', capture_log)
+    monkeypatch.setattr('storyforge.cmd_score.log', capture_log)
+
+    main(['--principles', 'prose_repetition', '--dry-run'])
+
+    combined = '\n'.join(output_lines)
+    assert 'Deterministic' in combined
+    assert '$0.00' in combined
+
+
+def test_deterministic_scoring_writes_results(project_dir, plugin_dir, monkeypatch):
+    """--principles prose_repetition should write scores without API calls."""
+    from storyforge.cmd_score import main
+
+    monkeypatch.setenv('STORYFORGE_PLUGIN_DIR', plugin_dir)
+    monkeypatch.chdir(project_dir)
+
+    # Stub out git operations
+    monkeypatch.setattr('storyforge.cmd_score.create_branch', lambda *a, **k: None)
+    monkeypatch.setattr('storyforge.cmd_score.ensure_branch_pushed', lambda *a, **k: None)
+    monkeypatch.setattr('storyforge.cmd_score.commit_and_push', lambda *a, **k: None)
+
+    main(['--principles', 'prose_repetition'])
+
+    # Check that scores were written
+    scores_dir = os.path.join(project_dir, 'working', 'scores')
+    # Find the cycle directory
+    cycle_dirs = [d for d in os.listdir(scores_dir)
+                  if d.startswith('cycle-') and os.path.isdir(os.path.join(scores_dir, d))]
+    assert cycle_dirs, 'No cycle directory created'
+
+    cycle_dir = os.path.join(scores_dir, cycle_dirs[0])
+    rep_path = os.path.join(cycle_dir, 'repetition-latest.csv')
+    assert os.path.isfile(rep_path), 'repetition-latest.csv not created'
+
+    with open(rep_path) as f:
+        lines = f.readlines()
+    assert lines[0].strip() == 'id|prose_repetition'
+    # Should have scores for scenes that exist as files
+    assert len(lines) > 1
+
+    # Should also have scene-scores.csv (merged)
+    scene_scores = os.path.join(cycle_dir, 'scene-scores.csv')
+    assert os.path.isfile(scene_scores), 'scene-scores.csv not created'
+
+    # latest symlink should exist
+    latest = os.path.join(scores_dir, 'latest')
+    assert os.path.islink(latest)


### PR DESCRIPTION
## Summary
- Adds `--principles` flag to `storyforge score` for scoring specific craft principles instead of all 25+
- Deterministic principles (currently `prose_repetition`) skip the entire LLM pipeline — no API calls, no cost, instant results
- LLM-scored principles filter evaluation criteria and skip act/novel/narrative phases

## Usage
```bash
# Score just one deterministic principle (instant, $0)
storyforge score --principles prose_repetition

# Score a few LLM principles
storyforge score --principles prose_repetition,prose_naturalness

# Combine with existing flags
storyforge score --principles prose_repetition --scenes before,seeing,crew

# Dry run to preview
storyforge score --principles prose_repetition --dry-run
```

## Changes
- `cmd_score.py`: New `--principles` CLI arg, deterministic-only fast path, LLM-filtered path, principle validation against craft-weights.csv
- `scoring.py`: `build_evaluation_criteria()` and `build_weighted_text()` accept optional `principles` filter
- `skills/score/SKILL.md`: Document `--principles` flag in Run Mode
- `CLAUDE.md`: Update command table
- 17 new tests covering CLI parsing, principle validation, deterministic detection, criteria filtering, and end-to-end fast path

## Test plan
- [x] All 1133 tests pass (17 new + 1116 existing, 0 failures)
- [ ] `storyforge score --principles prose_repetition --dry-run` shows $0.00 cost and deterministic path
- [ ] `storyforge score --principles prose_repetition` writes scores without API calls
- [ ] `storyforge score --principles prose_naturalness --dry-run` shows LLM path with filtered principles
- [ ] Unknown principle names produce a clear error message

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)