### PR TITLE
Add test infrastructure: coverage ratchet and conftest organization (#144)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,20 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--tb=short"
+addopts = "--tb=short --cov=scripts/lib/python/storyforge --cov-report=term-missing:skip-covered --cov-fail-under=26"
 
 [tool.coverage.run]
 source = ["scripts/lib/python/storyforge"]
+omit = [
+    "scripts/lib/python/storyforge/__main__.py",
+]
 
 [tool.coverage.report]
 fail_under = 26
-show_missing = false
+show_missing = true
+skip_covered = true
 skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -11,6 +11,7 @@ Fixtures are composable -- a test can use mock_api without mock_git
 or vice versa.
 """
 
+import importlib
 import json
 import os
 import shutil
@@ -26,6 +27,30 @@ import pytest
 TESTS_DIR = os.path.dirname(os.path.dirname(__file__))
 FIXTURE_DIR = os.path.join(TESTS_DIR, 'fixtures', 'test-project')
 API_RESPONSES_DIR = os.path.join(TESTS_DIR, 'fixtures', 'api-responses')
+
+
+# ---------------------------------------------------------------------------
+# Command modules that import api/git/costs at top level.
+# Defined once so all mock fixtures patch the same set.
+# ---------------------------------------------------------------------------
+
+_CMD_MODULES = [
+    'storyforge.cmd_write',
+    'storyforge.cmd_score',
+    'storyforge.cmd_extract',
+    'storyforge.cmd_elaborate',
+    'storyforge.cmd_evaluate',
+    'storyforge.cmd_revise',
+    'storyforge.cmd_hone',
+    'storyforge.cmd_enrich',
+    'storyforge.cmd_review',
+    'storyforge.cmd_cleanup',
+    'storyforge.cmd_assemble',
+    'storyforge.cmd_timeline',
+    'storyforge.cmd_scenes_setup',
+    'storyforge.cmd_migrate',
+    'storyforge.cmd_visualize',
+]
 
 
 # ---------------------------------------------------------------------------
@@ -50,13 +75,14 @@ def load_api_response(name: str) -> dict:
 def load_api_response_text(name: str) -> str:
     """Load just the text content from a canned API response.
 
-    Convenience wrapper that extracts the text from the first text block.
+    Joins all text blocks with newlines, matching production extract_text behavior.
     """
     response = load_api_response(name)
+    texts = []
     for block in response.get('content', []):
         if block.get('type') == 'text':
-            return block.get('text', '')
-    return ''
+            texts.append(block.get('text', ''))
+    return '\n'.join(texts)
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +145,7 @@ def mock_api(monkeypatch):
             self._response_dict = None
             self._response_fn = None
             self._responses_queue = []
+            self._batch_results = []
 
         def set_response(self, text: str):
             """Set a static text response for all API calls."""
@@ -206,10 +233,12 @@ def mock_api(monkeypatch):
                 return ''
             with open(path) as f:
                 data = json.load(f)
+            # Join all text blocks — matches production extract_text behavior
+            texts = []
             for item in data.get('content', []):
                 if item.get('type') == 'text':
-                    return item.get('text', '')
-            return ''
+                    texts.append(item.get('text', ''))
+            return '\n'.join(texts)
 
         def _submit_batch(self, batch_file):
             self.calls.append({'fn': 'submit_batch', 'batch_file': batch_file})
@@ -226,7 +255,7 @@ def mock_api(monkeypatch):
                 'output_dir': output_dir,
                 'log_dir': log_dir,
             })
-            return []
+            return self._batch_results
 
         @property
         def call_count(self) -> int:
@@ -252,34 +281,23 @@ def mock_api(monkeypatch):
     monkeypatch.setattr('storyforge.api.poll_batch', mock._poll_batch)
     monkeypatch.setattr('storyforge.api.download_batch_results', mock._download_batch_results)
 
-    # Also patch where command modules import these at top level
-    _CMD_MODULES = [
-        'storyforge.cmd_write',
-        'storyforge.cmd_score',
-        'storyforge.cmd_extract',
-        'storyforge.cmd_elaborate',
-        'storyforge.cmd_evaluate',
-        'storyforge.cmd_revise',
-        'storyforge.cmd_hone',
-        'storyforge.cmd_enrich',
-        'storyforge.cmd_review',
-        'storyforge.cmd_cleanup',
-        'storyforge.cmd_assemble',
+    # Also patch where command modules import these at top level.
+    # Use importlib+hasattr so typos and broken modules fail loudly
+    # while genuinely absent imports are skipped silently.
+    _api_attrs = [
+        ('invoke', mock._invoke),
+        ('invoke_to_file', mock._invoke_to_file),
+        ('invoke_api', mock._invoke_api),
+        ('extract_text_from_file', mock._extract_text_from_file),
+        ('submit_batch', mock._submit_batch),
+        ('poll_batch', mock._poll_batch),
+        ('download_batch_results', mock._download_batch_results),
     ]
-    for mod in _CMD_MODULES:
-        for attr, fn in [
-            ('invoke', mock._invoke),
-            ('invoke_to_file', mock._invoke_to_file),
-            ('invoke_api', mock._invoke_api),
-            ('extract_text_from_file', mock._extract_text_from_file),
-            ('submit_batch', mock._submit_batch),
-            ('poll_batch', mock._poll_batch),
-            ('download_batch_results', mock._download_batch_results),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{attr}', fn)
-            except AttributeError:
-                pass
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _api_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock
 
@@ -376,38 +394,25 @@ def mock_git(monkeypatch):
     monkeypatch.setattr('storyforge.git.run_review_phase', mock._run_review_phase)
     monkeypatch.setattr('storyforge.git.commit_partial_work', mock._commit_partial_work)
 
-    # Also patch where command modules import git functions at top level
-    _CMD_MODULES = [
-        'storyforge.cmd_write',
-        'storyforge.cmd_score',
-        'storyforge.cmd_extract',
-        'storyforge.cmd_elaborate',
-        'storyforge.cmd_evaluate',
-        'storyforge.cmd_assemble',
-        'storyforge.cmd_hone',
-        'storyforge.cmd_revise',
-        'storyforge.cmd_enrich',
-        'storyforge.cmd_review',
-        'storyforge.cmd_cleanup',
+    # Also patch where command modules import git functions at top level.
+    _git_attrs = [
+        ('create_branch', mock._create_branch),
+        ('ensure_branch_pushed', mock._ensure_branch_pushed),
+        ('ensure_on_branch', mock._ensure_on_branch),
+        ('create_draft_pr', mock._create_draft_pr),
+        ('commit_and_push', mock._commit_and_push),
+        ('update_pr_task', mock._update_pr_task),
+        ('run_review_phase', mock._run_review_phase),
+        ('commit_partial_work', mock._commit_partial_work),
+        ('_git', mock._git),
+        ('has_gh', mock._has_gh),
+        ('current_branch', mock._current_branch),
     ]
-    for mod in _CMD_MODULES:
-        for fn_name, fn in [
-            ('create_branch', mock._create_branch),
-            ('ensure_branch_pushed', mock._ensure_branch_pushed),
-            ('ensure_on_branch', mock._ensure_on_branch),
-            ('create_draft_pr', mock._create_draft_pr),
-            ('commit_and_push', mock._commit_and_push),
-            ('update_pr_task', mock._update_pr_task),
-            ('run_review_phase', mock._run_review_phase),
-            ('commit_partial_work', mock._commit_partial_work),
-            ('_git', mock._git),
-            ('has_gh', mock._has_gh),
-            ('current_branch', mock._current_branch),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{fn_name}', fn)
-            except AttributeError:
-                pass
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _git_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock
 
@@ -427,26 +432,33 @@ def mock_costs(monkeypatch):
         def __init__(self):
             self.operations = []
             self.estimates = []
+            self.threshold_ok = True
 
         def _log_operation(self, project_dir, operation, model,
-                          input_tokens, output_tokens, cost, duration=0):
+                          input_tokens, output_tokens, cost,
+                          duration_s=0, target='',
+                          cache_read=0, cache_create=0):
             self.operations.append({
                 'operation': operation, 'model': model,
                 'input_tokens': input_tokens, 'output_tokens': output_tokens,
-                'cost': cost, 'duration': duration,
+                'cost': cost, 'duration_s': duration_s, 'target': target,
+                'cache_read': cache_read, 'cache_create': cache_create,
             })
 
-        def _estimate_cost(self, operation, scope_count, avg_words=0, model=''):
+        def _estimate_cost(self, operation, scope_count, avg_words, model):
             self.estimates.append({
                 'operation': operation, 'scope_count': scope_count,
+                'avg_words': avg_words, 'model': model,
             })
             return 0.10  # Nominal cost
 
         def _check_threshold(self, estimated_cost):
-            return True  # Always under threshold
+            return self.threshold_ok
 
-        def _print_summary(self, project_dir, operation):
-            pass
+        def _print_summary(self, project_dir, operation=None):
+            self.operations.append({
+                'fn': 'print_summary', 'operation': operation,
+            })
 
     mock = CostsMock()
     monkeypatch.setattr('storyforge.costs.log_operation', mock._log_operation)
@@ -455,21 +467,16 @@ def mock_costs(monkeypatch):
     monkeypatch.setattr('storyforge.costs.print_summary', mock._print_summary)
 
     # Patch in command modules
-    for mod in [
-        'storyforge.cmd_write', 'storyforge.cmd_score',
-        'storyforge.cmd_evaluate', 'storyforge.cmd_revise',
-        'storyforge.cmd_elaborate', 'storyforge.cmd_extract',
-        'storyforge.cmd_enrich', 'storyforge.cmd_hone',
-    ]:
-        for attr, fn in [
-            ('log_operation', mock._log_operation),
-            ('estimate_cost', mock._estimate_cost),
-            ('check_threshold', mock._check_threshold),
-            ('print_summary', mock._print_summary),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{attr}', fn)
-            except AttributeError:
-                pass
+    _cost_attrs = [
+        ('log_operation', mock._log_operation),
+        ('estimate_cost', mock._estimate_cost),
+        ('check_threshold', mock._check_threshold),
+        ('print_summary', mock._print_summary),
+    ]
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _cost_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -3,12 +3,91 @@
 Provides mock_api and mock_git fixtures that patch the API and git
 boundaries so command orchestration logic can be tested without
 real API calls or git operations.
+
+Also provides a canned response loader, project_dir fixture for
+write-safe tests, and mock_costs for cost tracking isolation.
+
+Fixtures are composable -- a test can use mock_api without mock_git
+or vice versa.
 """
 
 import json
 import os
+import shutil
+import subprocess
+
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+TESTS_DIR = os.path.dirname(os.path.dirname(__file__))
+FIXTURE_DIR = os.path.join(TESTS_DIR, 'fixtures', 'test-project')
+API_RESPONSES_DIR = os.path.join(TESTS_DIR, 'fixtures', 'api-responses')
+
+
+# ---------------------------------------------------------------------------
+# Canned response loader
+# ---------------------------------------------------------------------------
+
+def load_api_response(name: str) -> dict:
+    """Load a canned API response from tests/fixtures/api-responses/.
+
+    Args:
+        name: Response filename without .json extension (e.g. 'drafting',
+              'scoring', 'evaluation/synthesis').
+
+    Returns:
+        Parsed JSON dict in Anthropic Messages API response format.
+    """
+    path = os.path.join(API_RESPONSES_DIR, f'{name}.json')
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_api_response_text(name: str) -> str:
+    """Load just the text content from a canned API response.
+
+    Convenience wrapper that extracts the text from the first text block.
+    """
+    response = load_api_response(name)
+    for block in response.get('content', []):
+        if block.get('type') == 'text':
+            return block.get('text', '')
+    return ''
+
+
+# ---------------------------------------------------------------------------
+# project_dir fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """A fresh copy of the test-project fixture in a temp directory.
+
+    Use this when tests modify files. Each test gets its own copy
+    so mutations don't leak between tests.
+
+    Sets up the working/ subdirectories that command modules expect.
+    """
+    dest = tmp_path / 'test-project'
+    shutil.copytree(FIXTURE_DIR, dest)
+
+    # Ensure working directories that commands expect
+    for subdir in [
+        'working/logs', 'working/scores', 'working/costs',
+        'working/evaluations', 'working/reviews', 'working/coaching',
+    ]:
+        os.makedirs(os.path.join(str(dest), subdir), exist_ok=True)
+
+    return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# mock_api fixture
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def mock_api(monkeypatch):
@@ -20,6 +99,17 @@ def mock_api(monkeypatch):
         def test_something(mock_api):
             mock_api.set_response('Hello world')
             # Now invoke_api/invoke/invoke_to_file return this text
+
+        def test_with_canned(mock_api):
+            data = load_api_response('scoring')
+            mock_api.set_response_dict(data)
+
+        def test_sequence(mock_api):
+            mock_api.set_responses(['first call', 'second call'])
+            # Returns them in order, then repeats the last one
+
+        def test_pattern(mock_api):
+            mock_api.set_response_fn(lambda prompt: 'score' if 'score' in prompt else 'other')
     """
 
     class ApiMock:
@@ -27,10 +117,60 @@ def mock_api(monkeypatch):
             self.calls = []
             self._response_text = 'mock response'
             self._response_dict = None
+            self._response_fn = None
+            self._responses_queue = []
 
-        def set_response(self, text):
+        def set_response(self, text: str):
+            """Set a static text response for all API calls."""
             self._response_text = text
             self._response_dict = {
+                'content': [{'type': 'text', 'text': text}],
+                'usage': {'input_tokens': 100, 'output_tokens': 50},
+            }
+            self._response_fn = None
+            self._responses_queue = []
+
+        def set_response_dict(self, response: dict):
+            """Set a full API response dict (e.g. from load_api_response)."""
+            self._response_dict = response
+            # Extract text for invoke_api convenience
+            for block in response.get('content', []):
+                if block.get('type') == 'text':
+                    self._response_text = block.get('text', '')
+                    break
+            self._response_fn = None
+            self._responses_queue = []
+
+        def set_responses(self, texts: list[str]):
+            """Set a sequence of responses. Returns them in order,
+            repeating the last one once exhausted."""
+            self._responses_queue = list(texts)
+            self._response_fn = None
+
+        def set_response_fn(self, fn):
+            """Set a function that receives the prompt and returns response text.
+
+            Useful for tests that need different responses based on prompt content.
+            """
+            self._response_fn = fn
+            self._responses_queue = []
+
+        def _get_response_text(self, prompt: str) -> str:
+            if self._response_fn:
+                return self._response_fn(prompt)
+            if self._responses_queue:
+                text = self._responses_queue.pop(0)
+                if not self._responses_queue:
+                    # Keep last response for subsequent calls
+                    self._responses_queue.append(text)
+                return text
+            return self._response_text
+
+        def _get_response_dict(self, prompt: str) -> dict:
+            text = self._get_response_text(prompt)
+            if self._response_dict and not self._response_fn and not self._responses_queue:
+                return self._response_dict
+            return {
                 'content': [{'type': 'text', 'text': text}],
                 'usage': {'input_tokens': 100, 'output_tokens': 50},
             }
@@ -40,10 +180,7 @@ def mock_api(monkeypatch):
                 'fn': 'invoke', 'prompt': prompt, 'model': model,
                 'max_tokens': max_tokens, 'label': label, 'timeout': timeout,
             })
-            return self._response_dict or {
-                'content': [{'type': 'text', 'text': self._response_text}],
-                'usage': {'input_tokens': 100, 'output_tokens': 50},
-            }
+            return self._get_response_dict(prompt)
 
         def _invoke_to_file(self, prompt, model, log_file, max_tokens=4096,
                            label='', timeout=600):
@@ -51,7 +188,7 @@ def mock_api(monkeypatch):
                 'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
                 'log_file': log_file, 'max_tokens': max_tokens,
             })
-            response = self._invoke(prompt, model, max_tokens, label, timeout)
+            response = self._get_response_dict(prompt)
             os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
             with open(log_file, 'w') as f:
                 json.dump(response, f)
@@ -62,14 +199,94 @@ def mock_api(monkeypatch):
             self.calls.append({
                 'fn': 'invoke_api', 'prompt': prompt, 'model': model,
             })
-            return self._response_text
+            return self._get_response_text(prompt)
+
+        def _extract_text_from_file(self, path):
+            if not os.path.isfile(path):
+                return ''
+            with open(path) as f:
+                data = json.load(f)
+            for item in data.get('content', []):
+                if item.get('type') == 'text':
+                    return item.get('text', '')
+            return ''
+
+        def _submit_batch(self, batch_file):
+            self.calls.append({'fn': 'submit_batch', 'batch_file': batch_file})
+            return 'batch-test-123'
+
+        def _poll_batch(self, batch_id, log_fn=None):
+            self.calls.append({'fn': 'poll_batch', 'batch_id': batch_id})
+            return 'https://example.com/batch-results'
+
+        def _download_batch_results(self, results_url, output_dir, log_dir):
+            self.calls.append({
+                'fn': 'download_batch_results',
+                'results_url': results_url,
+                'output_dir': output_dir,
+                'log_dir': log_dir,
+            })
+            return []
+
+        @property
+        def call_count(self) -> int:
+            return len(self.calls)
+
+        def calls_for(self, fn_name: str) -> list[dict]:
+            """Return only calls to a specific function."""
+            return [c for c in self.calls if c.get('fn') == fn_name]
+
+        def last_prompt(self, fn_name: str = None) -> str:
+            """Return the prompt from the most recent call (optionally filtered by fn)."""
+            calls = self.calls_for(fn_name) if fn_name else self.calls
+            if not calls:
+                return ''
+            return calls[-1].get('prompt', '')
 
     mock = ApiMock()
     monkeypatch.setattr('storyforge.api.invoke', mock._invoke)
     monkeypatch.setattr('storyforge.api.invoke_to_file', mock._invoke_to_file)
     monkeypatch.setattr('storyforge.api.invoke_api', mock._invoke_api)
+    monkeypatch.setattr('storyforge.api.extract_text_from_file', mock._extract_text_from_file)
+    monkeypatch.setattr('storyforge.api.submit_batch', mock._submit_batch)
+    monkeypatch.setattr('storyforge.api.poll_batch', mock._poll_batch)
+    monkeypatch.setattr('storyforge.api.download_batch_results', mock._download_batch_results)
+
+    # Also patch where command modules import these at top level
+    _CMD_MODULES = [
+        'storyforge.cmd_write',
+        'storyforge.cmd_score',
+        'storyforge.cmd_extract',
+        'storyforge.cmd_elaborate',
+        'storyforge.cmd_evaluate',
+        'storyforge.cmd_revise',
+        'storyforge.cmd_hone',
+        'storyforge.cmd_enrich',
+        'storyforge.cmd_review',
+        'storyforge.cmd_cleanup',
+        'storyforge.cmd_assemble',
+    ]
+    for mod in _CMD_MODULES:
+        for attr, fn in [
+            ('invoke', mock._invoke),
+            ('invoke_to_file', mock._invoke_to_file),
+            ('invoke_api', mock._invoke_api),
+            ('extract_text_from_file', mock._extract_text_from_file),
+            ('submit_batch', mock._submit_batch),
+            ('poll_batch', mock._poll_batch),
+            ('download_batch_results', mock._download_batch_results),
+        ]:
+            try:
+                monkeypatch.setattr(f'{mod}.{attr}', fn)
+            except AttributeError:
+                pass
+
     return mock
 
+
+# ---------------------------------------------------------------------------
+# mock_git fixture
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def mock_git(monkeypatch):
@@ -81,6 +298,11 @@ def mock_git(monkeypatch):
         def test_something(mock_git):
             mock_git.branch = 'storyforge/test-branch'
             # Now current_branch() returns this
+
+        def test_pr(mock_git):
+            mock_git.has_gh = True
+            mock_git.pr_number = '99'
+            # create_draft_pr now returns '99'
     """
 
     class GitMock:
@@ -88,12 +310,13 @@ def mock_git(monkeypatch):
             self.calls = []
             self.branch = 'storyforge/test-20260407'
             self.has_gh = False
+            self.pr_number = '42'
+            self.commit_success = True
 
         def _current_branch(self, project_dir):
             return self.branch
 
         def _git(self, project_dir, *args, check=True):
-            import subprocess
             self.calls.append(args)
             return subprocess.CompletedProcess(
                 args=['git'] + list(args), returncode=0,
@@ -105,7 +328,7 @@ def mock_git(monkeypatch):
 
         def _commit_and_push(self, project_dir, message, paths=None):
             self.calls.append(('commit_and_push', message, paths))
-            return True
+            return self.commit_success
 
         def _create_branch(self, command_name, project_dir):
             self.calls.append(('create_branch', command_name))
@@ -115,6 +338,31 @@ def mock_git(monkeypatch):
             self.calls.append(('ensure_on_branch', command_name))
             return self.branch
 
+        def _ensure_branch_pushed(self, project_dir, branch=None):
+            self.calls.append(('ensure_branch_pushed',))
+            return True
+
+        def _create_draft_pr(self, title, body, project_dir, work_type=''):
+            self.calls.append(('create_draft_pr', title))
+            return self.pr_number
+
+        def _update_pr_task(self, task_text, project_dir, pr_number=''):
+            self.calls.append(('update_pr_task', task_text))
+
+        def _run_review_phase(self, review_type, project_dir, pr_number=''):
+            self.calls.append(('run_review_phase', review_type))
+
+        def _commit_partial_work(self, project_dir):
+            self.calls.append(('commit_partial_work',))
+
+        @property
+        def call_count(self) -> int:
+            return len(self.calls)
+
+        def calls_for(self, fn_name: str) -> list:
+            """Return calls whose first element matches fn_name."""
+            return [c for c in self.calls if isinstance(c, tuple) and c[0] == fn_name]
+
     mock = GitMock()
     monkeypatch.setattr('storyforge.git.current_branch', mock._current_branch)
     monkeypatch.setattr('storyforge.git._git', mock._git)
@@ -122,12 +370,106 @@ def mock_git(monkeypatch):
     monkeypatch.setattr('storyforge.git.commit_and_push', mock._commit_and_push)
     monkeypatch.setattr('storyforge.git.create_branch', mock._create_branch)
     monkeypatch.setattr('storyforge.git.ensure_on_branch', mock._ensure_on_branch)
+    monkeypatch.setattr('storyforge.git.ensure_branch_pushed', mock._ensure_branch_pushed)
+    monkeypatch.setattr('storyforge.git.create_draft_pr', mock._create_draft_pr)
+    monkeypatch.setattr('storyforge.git.update_pr_task', mock._update_pr_task)
+    monkeypatch.setattr('storyforge.git.run_review_phase', mock._run_review_phase)
+    monkeypatch.setattr('storyforge.git.commit_partial_work', mock._commit_partial_work)
+
+    # Also patch where command modules import git functions at top level
+    _CMD_MODULES = [
+        'storyforge.cmd_write',
+        'storyforge.cmd_score',
+        'storyforge.cmd_extract',
+        'storyforge.cmd_elaborate',
+        'storyforge.cmd_evaluate',
+        'storyforge.cmd_assemble',
+        'storyforge.cmd_hone',
+        'storyforge.cmd_revise',
+        'storyforge.cmd_enrich',
+        'storyforge.cmd_review',
+        'storyforge.cmd_cleanup',
+    ]
+    for mod in _CMD_MODULES:
+        for fn_name, fn in [
+            ('create_branch', mock._create_branch),
+            ('ensure_branch_pushed', mock._ensure_branch_pushed),
+            ('ensure_on_branch', mock._ensure_on_branch),
+            ('create_draft_pr', mock._create_draft_pr),
+            ('commit_and_push', mock._commit_and_push),
+            ('update_pr_task', mock._update_pr_task),
+            ('run_review_phase', mock._run_review_phase),
+            ('commit_partial_work', mock._commit_partial_work),
+            ('_git', mock._git),
+            ('has_gh', mock._has_gh),
+            ('current_branch', mock._current_branch),
+        ]:
+            try:
+                monkeypatch.setattr(f'{mod}.{fn_name}', fn)
+            except AttributeError:
+                pass
+
     return mock
 
 
-def load_api_response(name):
-    """Load a canned API response from tests/fixtures/api-responses/."""
-    path = os.path.join(os.path.dirname(__file__), '..', 'fixtures',
-                        'api-responses', f'{name}.json')
-    with open(path) as f:
-        return json.load(f)
+# ---------------------------------------------------------------------------
+# mock_costs fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_costs(monkeypatch):
+    """Patch cost tracking functions to avoid file I/O.
+
+    Returns a controller to inspect logged operations.
+    """
+
+    class CostsMock:
+        def __init__(self):
+            self.operations = []
+            self.estimates = []
+
+        def _log_operation(self, project_dir, operation, model,
+                          input_tokens, output_tokens, cost, duration=0):
+            self.operations.append({
+                'operation': operation, 'model': model,
+                'input_tokens': input_tokens, 'output_tokens': output_tokens,
+                'cost': cost, 'duration': duration,
+            })
+
+        def _estimate_cost(self, operation, scope_count, avg_words=0, model=''):
+            self.estimates.append({
+                'operation': operation, 'scope_count': scope_count,
+            })
+            return 0.10  # Nominal cost
+
+        def _check_threshold(self, estimated_cost):
+            return True  # Always under threshold
+
+        def _print_summary(self, project_dir, operation):
+            pass
+
+    mock = CostsMock()
+    monkeypatch.setattr('storyforge.costs.log_operation', mock._log_operation)
+    monkeypatch.setattr('storyforge.costs.estimate_cost', mock._estimate_cost)
+    monkeypatch.setattr('storyforge.costs.check_threshold', mock._check_threshold)
+    monkeypatch.setattr('storyforge.costs.print_summary', mock._print_summary)
+
+    # Patch in command modules
+    for mod in [
+        'storyforge.cmd_write', 'storyforge.cmd_score',
+        'storyforge.cmd_evaluate', 'storyforge.cmd_revise',
+        'storyforge.cmd_elaborate', 'storyforge.cmd_extract',
+        'storyforge.cmd_enrich', 'storyforge.cmd_hone',
+    ]:
+        for attr, fn in [
+            ('log_operation', mock._log_operation),
+            ('estimate_cost', mock._estimate_cost),
+            ('check_threshold', mock._check_threshold),
+            ('print_summary', mock._print_summary),
+        ]:
+            try:
+                monkeypatch.setattr(f'{mod}.{attr}', fn)
+            except AttributeError:
+                pass
+
+    return mock

--- a/tests/fixtures/api-responses/drafting.json
+++ b/tests/fixtures/api-responses/drafting.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_drafting_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "The morning light filtered through the curtains. She sat at the desk, pen in hand, staring at the blank page."}],
   "usage": {"input_tokens": 2000, "output_tokens": 500}
 }

--- a/tests/fixtures/api-responses/elaboration.json
+++ b/tests/fixtures/api-responses/elaboration.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_elaboration_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow\nact1-sc01|Establish protagonist's world and routine|External pressure from deadline vs internal desire for perfection|Protagonist commits to the project despite doubts|Discovery that the map must be finished by week's end|Choose speed over precision for the first time|None|Protagonist knows the deadline|Reviews old maps; receives the commission letter|\"The king's cartographer does not make mistakes.\"|Anxiety; determination; quiet pride|Maps; precision; ink stains|none|no"}],
   "usage": {"input_tokens": 6000, "output_tokens": 400}
 }

--- a/tests/fixtures/api-responses/elaboration.json
+++ b/tests/fixtures/api-responses/elaboration.json
@@ -1,0 +1,4 @@
+{
+  "content": [{"type": "text", "text": "id|goal|conflict|outcome|crisis|decision|knowledge_in|knowledge_out|key_actions|key_dialogue|emotions|motifs|continuity_deps|has_overflow\nact1-sc01|Establish protagonist's world and routine|External pressure from deadline vs internal desire for perfection|Protagonist commits to the project despite doubts|Discovery that the map must be finished by week's end|Choose speed over precision for the first time|None|Protagonist knows the deadline|Reviews old maps; receives the commission letter|\"The king's cartographer does not make mistakes.\"|Anxiety; determination; quiet pride|Maps; precision; ink stains|none|no"}],
+  "usage": {"input_tokens": 6000, "output_tokens": 400}
+}

--- a/tests/fixtures/api-responses/evaluation.json
+++ b/tests/fixtures/api-responses/evaluation.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_evaluation_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "## Structure\nThe scene achieves its stated goal. The turning point is effective.\n\n## Recommendations\n- Strengthen the opening hook\n- Tighten dialogue in the middle section"}],
   "usage": {"input_tokens": 4000, "output_tokens": 800}
 }

--- a/tests/fixtures/api-responses/extraction.json
+++ b/tests/fixtures/api-responses/extraction.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_extraction_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "id|seq|title|part|pov|location|timeline_day|time_of_day|duration|type|status|word_count|target_words\nact1-sc01|1|The Commission|1|Maren|Cartography workshop|1|morning|2 hours|scene|drafted|2400|2500\nact1-sc02|2|The First Line|1|Maren|Cartography workshop|1|afternoon|1 hour|scene|drafted|1800|2000"}],
   "usage": {"input_tokens": 4000, "output_tokens": 300}
 }

--- a/tests/fixtures/api-responses/extraction.json
+++ b/tests/fixtures/api-responses/extraction.json
@@ -1,0 +1,4 @@
+{
+  "content": [{"type": "text", "text": "id|seq|title|part|pov|location|timeline_day|time_of_day|duration|type|status|word_count|target_words\nact1-sc01|1|The Commission|1|Maren|Cartography workshop|1|morning|2 hours|scene|drafted|2400|2500\nact1-sc02|2|The First Line|1|Maren|Cartography workshop|1|afternoon|1 hour|scene|drafted|1800|2000"}],
+  "usage": {"input_tokens": 4000, "output_tokens": 300}
+}

--- a/tests/fixtures/api-responses/hone.json
+++ b/tests/fixtures/api-responses/hone.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_hone_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "## Diagnosis Report\n\n### Brief Quality\n- act1-sc01: goal field uses abstract language (\"establish\" — prefer concrete visible action)\n- act1-sc02: conflict field is overspecified (3 beats crammed into one field)\n\n### Intent Quality\n- act1-sc01: emotional_arc uses vague descriptor (\"grows\" — specify start and end states)\n- act2-sc01: value_shift is missing\n\n### Registry Gaps\n- characters.csv: missing entry for \"Minister Hale\" (referenced in act2-sc01 on_stage)\n\n### Recommended Fixes\n1. act1-sc01 goal: \"Maren reviews the commission letter and decides to accept despite the impossible deadline\" \n2. act1-sc01 emotional_arc: \"anxiety → reluctant determination\"\n3. act1-sc02 conflict: keep only the primary conflict, move secondary to key_actions\n4. Add Minister Hale to characters.csv with basic fields"}],
   "usage": {"input_tokens": 5000, "output_tokens": 600}
 }

--- a/tests/fixtures/api-responses/hone.json
+++ b/tests/fixtures/api-responses/hone.json
@@ -1,0 +1,4 @@
+{
+  "content": [{"type": "text", "text": "## Diagnosis Report\n\n### Brief Quality\n- act1-sc01: goal field uses abstract language (\"establish\" — prefer concrete visible action)\n- act1-sc02: conflict field is overspecified (3 beats crammed into one field)\n\n### Intent Quality\n- act1-sc01: emotional_arc uses vague descriptor (\"grows\" — specify start and end states)\n- act2-sc01: value_shift is missing\n\n### Registry Gaps\n- characters.csv: missing entry for \"Minister Hale\" (referenced in act2-sc01 on_stage)\n\n### Recommended Fixes\n1. act1-sc01 goal: \"Maren reviews the commission letter and decides to accept despite the impossible deadline\" \n2. act1-sc01 emotional_arc: \"anxiety → reluctant determination\"\n3. act1-sc02 conflict: keep only the primary conflict, move secondary to key_actions\n4. Add Minister Hale to characters.csv with basic fields"}],
+  "usage": {"input_tokens": 5000, "output_tokens": 600}
+}

--- a/tests/fixtures/api-responses/review.json
+++ b/tests/fixtures/api-responses/review.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_review_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "## Summary\nRevision pass completed successfully. Three scenes revised with focus on prose tightening and dialogue naturalization.\n\n## Quality Signals\n- Word count reductions achieved (avg 8% per scene)\n- Voice consistency maintained across all revised scenes\n- Dialogue tags simplified effectively\n\n## Concerns\n- act1-sc02: One continuity reference to \"the letter\" may need checking against act1-sc01 changes\n- act2-sc01: Metaphor in paragraph 3 may clash with established motif taxonomy\n\n## Recommendation\nReady to merge. Minor continuity check recommended but not blocking.\n\n## Fixable Items\n- [ ] reference/scenes.csv: update word_count for act1-sc01 (was 2400, now ~2200)\n- [ ] reference/scenes.csv: update word_count for act1-sc02 (was 1800, now ~1650)"}],
   "usage": {"input_tokens": 6000, "output_tokens": 500}
 }

--- a/tests/fixtures/api-responses/review.json
+++ b/tests/fixtures/api-responses/review.json
@@ -1,0 +1,4 @@
+{
+  "content": [{"type": "text", "text": "## Summary\nRevision pass completed successfully. Three scenes revised with focus on prose tightening and dialogue naturalization.\n\n## Quality Signals\n- Word count reductions achieved (avg 8% per scene)\n- Voice consistency maintained across all revised scenes\n- Dialogue tags simplified effectively\n\n## Concerns\n- act1-sc02: One continuity reference to \"the letter\" may need checking against act1-sc01 changes\n- act2-sc01: Metaphor in paragraph 3 may clash with established motif taxonomy\n\n## Recommendation\nReady to merge. Minor continuity check recommended but not blocking.\n\n## Fixable Items\n- [ ] reference/scenes.csv: update word_count for act1-sc01 (was 2400, now ~2200)\n- [ ] reference/scenes.csv: update word_count for act1-sc02 (was 1800, now ~1650)"}],
+  "usage": {"input_tokens": 6000, "output_tokens": 500}
+}

--- a/tests/fixtures/api-responses/revision.json
+++ b/tests/fixtures/api-responses/revision.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_revision_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "=== SCENE: test-scene ===\nThe morning light crept through half-drawn curtains. She sat at the desk with her pen hovering over the page, not writing.\n=== END SCENE: test-scene ==="}],
   "usage": {"input_tokens": 5000, "output_tokens": 1000}
 }

--- a/tests/fixtures/api-responses/scoring.json
+++ b/tests/fixtures/api-responses/scoring.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_scoring_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "principle|score|rationale\nprose_naturalness|7|Good variety in sentence structure\nvoice_consistency|8|Strong POV voice maintained\ndialogue_craft|6|Some lines feel generic"}],
   "usage": {"input_tokens": 3000, "output_tokens": 200}
 }

--- a/tests/fixtures/api-responses/synthesis.json
+++ b/tests/fixtures/api-responses/synthesis.json
@@ -1,0 +1,4 @@
+{
+  "content": [{"type": "text", "text": "## Synthesis Report\n\n### Strengths\n- Strong POV voice maintained throughout\n- Effective use of setting details\n- Dialogue carries subtext well\n\n### Areas for Improvement\n- Opening paragraph could be tighter\n- Middle section pacing lags\n- Final beat needs stronger emotional closure\n\n### Priority Recommendations\n1. Tighten the opening hook (first 200 words)\n2. Cut redundant interior monologue in paragraphs 4-6\n3. Strengthen the closing image to mirror the opening motif\n\n### Fix Locations\n- fix_location: craft — prose polish for opening/closing\n- fix_location: brief — conflict needs sharper definition\n- fix_location: intent — emotional arc could use value shift clarification"}],
+  "usage": {"input_tokens": 8000, "output_tokens": 1200}
+}

--- a/tests/fixtures/api-responses/synthesis.json
+++ b/tests/fixtures/api-responses/synthesis.json
@@ -1,4 +1,10 @@
 {
+  "id": "msg_test_synthesis_001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-6-20250514",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "content": [{"type": "text", "text": "## Synthesis Report\n\n### Strengths\n- Strong POV voice maintained throughout\n- Effective use of setting details\n- Dialogue carries subtext well\n\n### Areas for Improvement\n- Opening paragraph could be tighter\n- Middle section pacing lags\n- Final beat needs stronger emotional closure\n\n### Priority Recommendations\n1. Tighten the opening hook (first 200 words)\n2. Cut redundant interior monologue in paragraphs 4-6\n3. Strengthen the closing image to mirror the opening motif\n\n### Fix Locations\n- fix_location: craft — prose polish for opening/closing\n- fix_location: brief — conflict needs sharper definition\n- fix_location: intent — emotional arc could use value shift clarification"}],
   "usage": {"input_tokens": 8000, "output_tokens": 1200}
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ git operations, but still mock the API boundary to avoid costs and
 network dependencies.
 """
 
+import importlib
 import json
 import os
 import re
@@ -18,6 +19,29 @@ import pytest
 TESTS_DIR = os.path.dirname(os.path.dirname(__file__))
 FIXTURE_DIR = os.path.join(TESTS_DIR, 'fixtures', 'test-project')
 API_RESPONSES_DIR = os.path.join(TESTS_DIR, 'fixtures', 'api-responses')
+
+
+# ---------------------------------------------------------------------------
+# Command modules — same list as commands/conftest.py
+# ---------------------------------------------------------------------------
+
+_CMD_MODULES = [
+    'storyforge.cmd_write',
+    'storyforge.cmd_score',
+    'storyforge.cmd_extract',
+    'storyforge.cmd_elaborate',
+    'storyforge.cmd_evaluate',
+    'storyforge.cmd_revise',
+    'storyforge.cmd_hone',
+    'storyforge.cmd_enrich',
+    'storyforge.cmd_review',
+    'storyforge.cmd_cleanup',
+    'storyforge.cmd_assemble',
+    'storyforge.cmd_timeline',
+    'storyforge.cmd_scenes_setup',
+    'storyforge.cmd_migrate',
+    'storyforge.cmd_visualize',
+]
 
 
 # ---------------------------------------------------------------------------
@@ -32,12 +56,16 @@ def load_api_response(name: str) -> dict:
 
 
 def load_api_response_text(name: str) -> str:
-    """Load just the text content from a canned API response."""
+    """Load just the text content from a canned API response.
+
+    Joins all text blocks with newlines, matching production extract_text behavior.
+    """
     response = load_api_response(name)
+    texts = []
     for block in response.get('content', []):
         if block.get('type') == 'text':
-            return block.get('text', '')
-    return ''
+            texts.append(block.get('text', ''))
+    return '\n'.join(texts)
 
 
 # ---------------------------------------------------------------------------
@@ -59,10 +87,10 @@ def git_project(tmp_path):
     dest = tmp_path / 'test-project'
     shutil.copytree(FIXTURE_DIR, dest)
 
-    # Ensure working directories
+    # Ensure working directories (matches commands/conftest.py)
     for subdir in [
         'working/logs', 'working/scores', 'working/costs',
-        'working/evaluations', 'working/reviews',
+        'working/evaluations', 'working/reviews', 'working/coaching',
     ]:
         os.makedirs(os.path.join(str(dest), subdir), exist_ok=True)
 
@@ -73,11 +101,11 @@ def git_project(tmp_path):
         'GIT_COMMITTER_NAME': 'Test',
         'GIT_COMMITTER_EMAIL': 'test@test.com',
     }
-    subprocess.run(['git', 'init', '-b', 'main'], cwd=dest, capture_output=True, env=env)
-    subprocess.run(['git', 'add', '-A'], cwd=dest, capture_output=True, env=env)
+    subprocess.run(['git', 'init', '-b', 'main'], cwd=dest, capture_output=True, env=env, check=True)
+    subprocess.run(['git', 'add', '-A'], cwd=dest, capture_output=True, env=env, check=True)
     subprocess.run(
         ['git', 'commit', '-m', 'Initial test fixture'],
-        cwd=dest, capture_output=True, env=env,
+        cwd=dest, capture_output=True, env=env, check=True,
     )
     return str(dest)
 
@@ -91,10 +119,10 @@ def project_dir(tmp_path):
     dest = tmp_path / 'test-project'
     shutil.copytree(FIXTURE_DIR, dest)
 
-    # Ensure working directories
+    # Ensure working directories (matches commands/conftest.py)
     for subdir in [
         'working/logs', 'working/scores', 'working/costs',
-        'working/evaluations', 'working/reviews',
+        'working/evaluations', 'working/reviews', 'working/coaching',
     ]:
         os.makedirs(os.path.join(str(dest), subdir), exist_ok=True)
 
@@ -110,8 +138,9 @@ def mock_api(monkeypatch):
     """Patch all API functions to return canned responses.
 
     Returns a controller to configure per-call responses.
-    Identical to commands/conftest mock_api but also patches
-    extract_text_from_file and batch API functions.
+    Simpler variant of commands/conftest mock_api — supports set_response
+    and set_response_fn but not set_response_dict, set_responses, or
+    call introspection helpers (call_count, calls_for, last_prompt).
     """
 
     class ApiMock:
@@ -177,10 +206,12 @@ def mock_api(monkeypatch):
                 return ''
             with open(path) as f:
                 data = json.load(f)
+            # Join all text blocks — matches production extract_text behavior
+            texts = []
             for item in data.get('content', []):
                 if item.get('type') == 'text':
-                    return item.get('text', '')
-            return ''
+                    texts.append(item.get('text', ''))
+            return '\n'.join(texts)
 
         def _submit_batch(self, batch_file):
             self.calls.append({'fn': 'submit_batch', 'batch_file': batch_file})
@@ -204,32 +235,20 @@ def mock_api(monkeypatch):
     monkeypatch.setattr('storyforge.api.download_batch_results', mock._download_batch_results)
 
     # Also patch where modules import these at top level
-    for mod in [
-        'storyforge.cmd_write',
-        'storyforge.cmd_score',
-        'storyforge.cmd_extract',
-        'storyforge.cmd_elaborate',
-        'storyforge.cmd_evaluate',
-        'storyforge.cmd_revise',
-        'storyforge.cmd_hone',
-        'storyforge.cmd_enrich',
-        'storyforge.cmd_review',
-        'storyforge.cmd_cleanup',
-        'storyforge.cmd_assemble',
-    ]:
-        for attr, fn in [
-            ('invoke', mock._invoke),
-            ('invoke_to_file', mock._invoke_to_file),
-            ('invoke_api', mock._invoke_api),
-            ('extract_text_from_file', mock._extract_text_from_file),
-            ('submit_batch', mock._submit_batch),
-            ('poll_batch', mock._poll_batch),
-            ('download_batch_results', mock._download_batch_results),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{attr}', fn)
-            except AttributeError:
-                pass
+    _api_attrs = [
+        ('invoke', mock._invoke),
+        ('invoke_to_file', mock._invoke_to_file),
+        ('invoke_api', mock._invoke_api),
+        ('extract_text_from_file', mock._extract_text_from_file),
+        ('submit_batch', mock._submit_batch),
+        ('poll_batch', mock._poll_batch),
+        ('download_batch_results', mock._download_batch_results),
+    ]
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _api_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock
 
@@ -259,8 +278,10 @@ def mock_api_rich(monkeypatch):
     class RichApiMock:
         def __init__(self):
             self.calls = []
+            self.unmatched_calls = []
             self._patterns = []  # list of (compiled_regex, response_text)
             self.default = 'mock response'
+            self.strict = False  # Set True to fail on unmatched patterns
 
         def register(self, pattern: str, response_text: str, flags=re.IGNORECASE):
             """Register a regex pattern -> response mapping.
@@ -286,6 +307,14 @@ def mock_api_rich(monkeypatch):
             for regex, text in self._patterns:
                 if regex.search(prompt):
                     return text
+            self.unmatched_calls.append(prompt[:200])
+            if self.strict:
+                registered = [p.pattern for p, _ in self._patterns]
+                raise ValueError(
+                    f'mock_api_rich: no pattern matched prompt '
+                    f'(first 200 chars): {prompt[:200]!r}\n'
+                    f'Registered patterns: {registered}'
+                )
             return self.default
 
         def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600):
@@ -305,7 +334,12 @@ def mock_api_rich(monkeypatch):
                 'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
                 'log_file': log_file, 'max_tokens': max_tokens,
             })
-            response = self._invoke(prompt, model, max_tokens)
+            # Resolve directly — don't call _invoke to avoid double-counting
+            text = self._resolve(prompt)
+            response = {
+                'content': [{'type': 'text', 'text': text}],
+                'usage': {'input_tokens': 100, 'output_tokens': 50},
+            }
             os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
             with open(log_file, 'w') as f:
                 json.dump(response, f)
@@ -323,10 +357,12 @@ def mock_api_rich(monkeypatch):
                 return ''
             with open(path) as f:
                 data = json.load(f)
+            # Join all text blocks — matches production extract_text behavior
+            texts = []
             for item in data.get('content', []):
                 if item.get('type') == 'text':
-                    return item.get('text', '')
-            return ''
+                    texts.append(item.get('text', ''))
+            return '\n'.join(texts)
 
         def _submit_batch(self, batch_file):
             self.calls.append({'fn': 'submit_batch', 'batch_file': batch_file})
@@ -357,27 +393,20 @@ def mock_api_rich(monkeypatch):
     monkeypatch.setattr('storyforge.api.download_batch_results', mock._download_batch_results)
 
     # Also patch command module imports
-    for mod in [
-        'storyforge.cmd_write', 'storyforge.cmd_score',
-        'storyforge.cmd_extract', 'storyforge.cmd_elaborate',
-        'storyforge.cmd_evaluate', 'storyforge.cmd_revise',
-        'storyforge.cmd_hone', 'storyforge.cmd_enrich',
-        'storyforge.cmd_review', 'storyforge.cmd_cleanup',
-        'storyforge.cmd_assemble',
-    ]:
-        for attr, fn in [
-            ('invoke', mock._invoke),
-            ('invoke_to_file', mock._invoke_to_file),
-            ('invoke_api', mock._invoke_api),
-            ('extract_text_from_file', mock._extract_text_from_file),
-            ('submit_batch', mock._submit_batch),
-            ('poll_batch', mock._poll_batch),
-            ('download_batch_results', mock._download_batch_results),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{attr}', fn)
-            except AttributeError:
-                pass
+    _api_attrs = [
+        ('invoke', mock._invoke),
+        ('invoke_to_file', mock._invoke_to_file),
+        ('invoke_api', mock._invoke_api),
+        ('extract_text_from_file', mock._extract_text_from_file),
+        ('submit_batch', mock._submit_batch),
+        ('poll_batch', mock._poll_batch),
+        ('download_batch_results', mock._download_batch_results),
+    ]
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _api_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock
 
@@ -456,30 +485,23 @@ def mock_git(monkeypatch):
     monkeypatch.setattr('storyforge.git.commit_partial_work', mock._commit_partial_work)
 
     # Patch command module imports
-    for mod in [
-        'storyforge.cmd_write', 'storyforge.cmd_score',
-        'storyforge.cmd_extract', 'storyforge.cmd_elaborate',
-        'storyforge.cmd_evaluate', 'storyforge.cmd_assemble',
-        'storyforge.cmd_hone', 'storyforge.cmd_revise',
-        'storyforge.cmd_enrich', 'storyforge.cmd_review',
-        'storyforge.cmd_cleanup',
-    ]:
-        for fn_name, fn in [
-            ('create_branch', mock._create_branch),
-            ('ensure_branch_pushed', mock._ensure_branch_pushed),
-            ('ensure_on_branch', mock._ensure_on_branch),
-            ('create_draft_pr', mock._create_draft_pr),
-            ('commit_and_push', mock._commit_and_push),
-            ('update_pr_task', mock._update_pr_task),
-            ('run_review_phase', mock._run_review_phase),
-            ('commit_partial_work', mock._commit_partial_work),
-            ('_git', mock._git),
-            ('has_gh', mock._has_gh),
-            ('current_branch', mock._current_branch),
-        ]:
-            try:
-                monkeypatch.setattr(f'{mod}.{fn_name}', fn)
-            except AttributeError:
-                pass
+    _git_attrs = [
+        ('create_branch', mock._create_branch),
+        ('ensure_branch_pushed', mock._ensure_branch_pushed),
+        ('ensure_on_branch', mock._ensure_on_branch),
+        ('create_draft_pr', mock._create_draft_pr),
+        ('commit_and_push', mock._commit_and_push),
+        ('update_pr_task', mock._update_pr_task),
+        ('run_review_phase', mock._run_review_phase),
+        ('commit_partial_work', mock._commit_partial_work),
+        ('_git', mock._git),
+        ('has_gh', mock._has_gh),
+        ('current_branch', mock._current_branch),
+    ]
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        for attr, fn in _git_attrs:
+            if hasattr(mod, attr):
+                monkeypatch.setattr(f'{mod_name}.{attr}', fn)
 
     return mock

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,51 +2,116 @@
 
 Provides git_project (real git repo in tmp) and mock_api/mock_git
 fixtures that patch API and git boundaries for end-to-end command tests.
+
+Integration tests exercise real file I/O and (with git_project) real
+git operations, but still mock the API boundary to avoid costs and
+network dependencies.
 """
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import pytest
 
-FIXTURE_DIR = os.path.join(os.path.dirname(__file__), '..', 'fixtures', 'test-project')
+TESTS_DIR = os.path.dirname(os.path.dirname(__file__))
+FIXTURE_DIR = os.path.join(TESTS_DIR, 'fixtures', 'test-project')
+API_RESPONSES_DIR = os.path.join(TESTS_DIR, 'fixtures', 'api-responses')
 
+
+# ---------------------------------------------------------------------------
+# Canned response loader (same as commands/conftest for independence)
+# ---------------------------------------------------------------------------
+
+def load_api_response(name: str) -> dict:
+    """Load a canned API response from tests/fixtures/api-responses/."""
+    path = os.path.join(API_RESPONSES_DIR, f'{name}.json')
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_api_response_text(name: str) -> str:
+    """Load just the text content from a canned API response."""
+    response = load_api_response(name)
+    for block in response.get('content', []):
+        if block.get('type') == 'text':
+            return block.get('text', '')
+    return ''
+
+
+# ---------------------------------------------------------------------------
+# git_project fixture
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def git_project(tmp_path):
-    """A real git repo with test-project fixture, initialized and committed."""
+    """A real git repo with test-project fixture, initialized and committed.
+
+    This creates a genuine git repository so integration tests can exercise
+    real git operations (branching, committing, diffing). The repo has:
+    - An initial commit with all fixture files
+    - A 'main' branch set as the default
+    - Git user configured for the test environment
+
+    Returns the path to the project directory (str).
+    """
     dest = tmp_path / 'test-project'
     shutil.copytree(FIXTURE_DIR, dest)
-    subprocess.run(['git', 'init'], cwd=dest, capture_output=True)
-    subprocess.run(['git', 'add', '-A'], cwd=dest, capture_output=True)
+
+    # Ensure working directories
+    for subdir in [
+        'working/logs', 'working/scores', 'working/costs',
+        'working/evaluations', 'working/reviews',
+    ]:
+        os.makedirs(os.path.join(str(dest), subdir), exist_ok=True)
+
+    env = {
+        **os.environ,
+        'GIT_AUTHOR_NAME': 'Test',
+        'GIT_AUTHOR_EMAIL': 'test@test.com',
+        'GIT_COMMITTER_NAME': 'Test',
+        'GIT_COMMITTER_EMAIL': 'test@test.com',
+    }
+    subprocess.run(['git', 'init', '-b', 'main'], cwd=dest, capture_output=True, env=env)
+    subprocess.run(['git', 'add', '-A'], cwd=dest, capture_output=True, env=env)
     subprocess.run(
         ['git', 'commit', '-m', 'Initial test fixture'],
-        cwd=dest, capture_output=True,
-        env={**os.environ, 'GIT_AUTHOR_NAME': 'Test', 'GIT_AUTHOR_EMAIL': 'test@test.com',
-             'GIT_COMMITTER_NAME': 'Test', 'GIT_COMMITTER_EMAIL': 'test@test.com'},
+        cwd=dest, capture_output=True, env=env,
     )
     return str(dest)
 
 
 @pytest.fixture
 def project_dir(tmp_path):
-    """A fresh copy of the test-project fixture in a temp directory (no git)."""
+    """A fresh copy of the test-project fixture in a temp directory (no git).
+
+    Use this when tests need file I/O but not git operations.
+    """
     dest = tmp_path / 'test-project'
     shutil.copytree(FIXTURE_DIR, dest)
+
+    # Ensure working directories
+    for subdir in [
+        'working/logs', 'working/scores', 'working/costs',
+        'working/evaluations', 'working/reviews',
+    ]:
+        os.makedirs(os.path.join(str(dest), subdir), exist_ok=True)
+
     return str(dest)
 
+
+# ---------------------------------------------------------------------------
+# mock_api fixture (standard)
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def mock_api(monkeypatch):
     """Patch all API functions to return canned responses.
 
     Returns a controller to configure per-call responses.
-
-    Usage:
-        def test_something(mock_api):
-            mock_api.set_response('Hello world')
-            # Now invoke_api/invoke/invoke_to_file return this text
+    Identical to commands/conftest mock_api but also patches
+    extract_text_from_file and batch API functions.
     """
 
     class ApiMock:
@@ -127,7 +192,7 @@ def mock_api(monkeypatch):
 
         def _download_batch_results(self, results_url, output_dir, log_dir):
             self.calls.append({'fn': 'download_batch_results', 'results_url': results_url})
-            return 0
+            return []
 
     mock = ApiMock()
     monkeypatch.setattr('storyforge.api.invoke', mock._invoke)
@@ -144,40 +209,189 @@ def mock_api(monkeypatch):
         'storyforge.cmd_score',
         'storyforge.cmd_extract',
         'storyforge.cmd_elaborate',
+        'storyforge.cmd_evaluate',
+        'storyforge.cmd_revise',
+        'storyforge.cmd_hone',
+        'storyforge.cmd_enrich',
+        'storyforge.cmd_review',
+        'storyforge.cmd_cleanup',
+        'storyforge.cmd_assemble',
     ]:
-        try:
-            monkeypatch.setattr(f'{mod}.invoke_to_file', mock._invoke_to_file)
-        except AttributeError:
-            pass
-        try:
-            monkeypatch.setattr(f'{mod}.extract_text_from_file', mock._extract_text_from_file)
-        except AttributeError:
-            pass
-        try:
-            monkeypatch.setattr(f'{mod}.invoke_api', mock._invoke_api)
-        except AttributeError:
-            pass
-        try:
-            monkeypatch.setattr(f'{mod}.submit_batch', mock._submit_batch)
-        except AttributeError:
-            pass
-        try:
-            monkeypatch.setattr(f'{mod}.poll_batch', mock._poll_batch)
-        except AttributeError:
-            pass
-        try:
-            monkeypatch.setattr(f'{mod}.download_batch_results', mock._download_batch_results)
-        except AttributeError:
-            pass
+        for attr, fn in [
+            ('invoke', mock._invoke),
+            ('invoke_to_file', mock._invoke_to_file),
+            ('invoke_api', mock._invoke_api),
+            ('extract_text_from_file', mock._extract_text_from_file),
+            ('submit_batch', mock._submit_batch),
+            ('poll_batch', mock._poll_batch),
+            ('download_batch_results', mock._download_batch_results),
+        ]:
+            try:
+                monkeypatch.setattr(f'{mod}.{attr}', fn)
+            except AttributeError:
+                pass
 
     return mock
 
+
+# ---------------------------------------------------------------------------
+# mock_api_rich fixture (pattern-matching responses)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_api_rich(monkeypatch):
+    """A sophisticated API mock that matches requests to canned responses
+    based on content patterns in the prompt.
+
+    Returns a controller where you register (pattern, response) pairs.
+    When a prompt is received, patterns are checked in registration order;
+    the first match wins. If no pattern matches, returns the default response.
+
+    Usage:
+        def test_pipeline(mock_api_rich):
+            mock_api_rich.register(r'score.*scene', load_api_response_text('scoring'))
+            mock_api_rich.register(r'draft.*scene', load_api_response_text('drafting'))
+            mock_api_rich.register(r'evaluate', load_api_response_text('evaluation'))
+            mock_api_rich.default = 'fallback response'
+            # API calls now return context-appropriate responses
+    """
+
+    class RichApiMock:
+        def __init__(self):
+            self.calls = []
+            self._patterns = []  # list of (compiled_regex, response_text)
+            self.default = 'mock response'
+
+        def register(self, pattern: str, response_text: str, flags=re.IGNORECASE):
+            """Register a regex pattern -> response mapping.
+
+            Args:
+                pattern: Regex pattern to match against the prompt.
+                response_text: Text to return when pattern matches.
+                flags: Regex flags (default: case-insensitive).
+            """
+            self._patterns.append((re.compile(pattern, flags), response_text))
+
+        def register_canned(self, pattern: str, response_name: str, flags=re.IGNORECASE):
+            """Register a pattern that returns a canned response file.
+
+            Args:
+                pattern: Regex pattern to match against the prompt.
+                response_name: Name of the canned response file (without .json).
+            """
+            text = load_api_response_text(response_name)
+            self.register(pattern, text, flags)
+
+        def _resolve(self, prompt: str) -> str:
+            for regex, text in self._patterns:
+                if regex.search(prompt):
+                    return text
+            return self.default
+
+        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600):
+            self.calls.append({
+                'fn': 'invoke', 'prompt': prompt, 'model': model,
+                'max_tokens': max_tokens,
+            })
+            text = self._resolve(prompt)
+            return {
+                'content': [{'type': 'text', 'text': text}],
+                'usage': {'input_tokens': 100, 'output_tokens': 50},
+            }
+
+        def _invoke_to_file(self, prompt, model, log_file, max_tokens=4096,
+                           label='', timeout=600):
+            self.calls.append({
+                'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
+                'log_file': log_file, 'max_tokens': max_tokens,
+            })
+            response = self._invoke(prompt, model, max_tokens)
+            os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+            with open(log_file, 'w') as f:
+                json.dump(response, f)
+            return response
+
+        def _invoke_api(self, prompt, model, max_tokens=4096, label='',
+                       timeout=600):
+            self.calls.append({
+                'fn': 'invoke_api', 'prompt': prompt, 'model': model,
+            })
+            return self._resolve(prompt)
+
+        def _extract_text_from_file(self, path):
+            if not os.path.isfile(path):
+                return ''
+            with open(path) as f:
+                data = json.load(f)
+            for item in data.get('content', []):
+                if item.get('type') == 'text':
+                    return item.get('text', '')
+            return ''
+
+        def _submit_batch(self, batch_file):
+            self.calls.append({'fn': 'submit_batch', 'batch_file': batch_file})
+            return 'batch-test-123'
+
+        def _poll_batch(self, batch_id, log_fn=None):
+            self.calls.append({'fn': 'poll_batch', 'batch_id': batch_id})
+            return 'https://example.com/batch-results'
+
+        def _download_batch_results(self, results_url, output_dir, log_dir):
+            self.calls.append({'fn': 'download_batch_results', 'results_url': results_url})
+            return []
+
+        @property
+        def call_count(self) -> int:
+            return len(self.calls)
+
+        def calls_for(self, fn_name: str) -> list[dict]:
+            return [c for c in self.calls if c.get('fn') == fn_name]
+
+    mock = RichApiMock()
+    monkeypatch.setattr('storyforge.api.invoke', mock._invoke)
+    monkeypatch.setattr('storyforge.api.invoke_to_file', mock._invoke_to_file)
+    monkeypatch.setattr('storyforge.api.invoke_api', mock._invoke_api)
+    monkeypatch.setattr('storyforge.api.extract_text_from_file', mock._extract_text_from_file)
+    monkeypatch.setattr('storyforge.api.submit_batch', mock._submit_batch)
+    monkeypatch.setattr('storyforge.api.poll_batch', mock._poll_batch)
+    monkeypatch.setattr('storyforge.api.download_batch_results', mock._download_batch_results)
+
+    # Also patch command module imports
+    for mod in [
+        'storyforge.cmd_write', 'storyforge.cmd_score',
+        'storyforge.cmd_extract', 'storyforge.cmd_elaborate',
+        'storyforge.cmd_evaluate', 'storyforge.cmd_revise',
+        'storyforge.cmd_hone', 'storyforge.cmd_enrich',
+        'storyforge.cmd_review', 'storyforge.cmd_cleanup',
+        'storyforge.cmd_assemble',
+    ]:
+        for attr, fn in [
+            ('invoke', mock._invoke),
+            ('invoke_to_file', mock._invoke_to_file),
+            ('invoke_api', mock._invoke_api),
+            ('extract_text_from_file', mock._extract_text_from_file),
+            ('submit_batch', mock._submit_batch),
+            ('poll_batch', mock._poll_batch),
+            ('download_batch_results', mock._download_batch_results),
+        ]:
+            try:
+                monkeypatch.setattr(f'{mod}.{attr}', fn)
+            except AttributeError:
+                pass
+
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# mock_git fixture
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def mock_git(monkeypatch):
     """Patch git operations to avoid real git/gh calls.
 
     Returns a controller to inspect calls and set return values.
+    For tests that need real git, use git_project instead of mock_git.
     """
 
     class GitMock:
@@ -225,6 +439,9 @@ def mock_git(monkeypatch):
         def _run_review_phase(self, review_type, project_dir, pr_number=''):
             self.calls.append(('run_review_phase', review_type))
 
+        def _commit_partial_work(self, project_dir):
+            self.calls.append(('commit_partial_work',))
+
     mock = GitMock()
     monkeypatch.setattr('storyforge.git.current_branch', mock._current_branch)
     monkeypatch.setattr('storyforge.git._git', mock._git)
@@ -236,16 +453,16 @@ def mock_git(monkeypatch):
     monkeypatch.setattr('storyforge.git.create_draft_pr', mock._create_draft_pr)
     monkeypatch.setattr('storyforge.git.update_pr_task', mock._update_pr_task)
     monkeypatch.setattr('storyforge.git.run_review_phase', mock._run_review_phase)
+    monkeypatch.setattr('storyforge.git.commit_partial_work', mock._commit_partial_work)
 
-    # Also patch where command modules import git functions at top level
+    # Patch command module imports
     for mod in [
-        'storyforge.cmd_write',
-        'storyforge.cmd_score',
-        'storyforge.cmd_extract',
-        'storyforge.cmd_elaborate',
-        'storyforge.cmd_assemble',
-        'storyforge.cmd_hone',
-        'storyforge.cmd_revise',
+        'storyforge.cmd_write', 'storyforge.cmd_score',
+        'storyforge.cmd_extract', 'storyforge.cmd_elaborate',
+        'storyforge.cmd_evaluate', 'storyforge.cmd_assemble',
+        'storyforge.cmd_hone', 'storyforge.cmd_revise',
+        'storyforge.cmd_enrich', 'storyforge.cmd_review',
+        'storyforge.cmd_cleanup',
     ]:
         for fn_name, fn in [
             ('create_branch', mock._create_branch),
@@ -255,6 +472,7 @@ def mock_git(monkeypatch):
             ('commit_and_push', mock._commit_and_push),
             ('update_pr_task', mock._update_pr_task),
             ('run_review_phase', mock._run_review_phase),
+            ('commit_partial_work', mock._commit_partial_work),
             ('_git', mock._git),
             ('has_gh', mock._has_gh),
             ('current_branch', mock._current_branch),

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
+# Run Storyforge test suite with coverage.
+#
+# Usage:
+#   ./tests/run-tests.sh              # Run with coverage (default)
+#   ./tests/run-tests.sh --no-cov     # Run without coverage
+#   ./tests/run-tests.sh -k pattern   # Pass args through to pytest
 cd "$(dirname "$0")/.."
-if [ "$1" = "--coverage" ]; then
-    python3 -m pytest tests/ --cov=scripts/lib/python/storyforge --cov-report=term-missing
+
+if [ "$1" = "--no-cov" ]; then
+    shift
+    python3 -m pytest tests/ --no-cov "$@"
 else
     python3 -m pytest tests/ "$@"
 fi

--- a/tests/wiring/conftest.py
+++ b/tests/wiring/conftest.py
@@ -1,1 +1,5 @@
-# Wiring tests need no fixtures — they use only introspection.
+"""Conftest for wiring tests.
+
+Wiring tests verify imports, function signatures, and CLI dispatch
+using introspection only. They need no project fixtures or mocks.
+"""


### PR DESCRIPTION
## Summary

- **pyproject.toml**: Coverage runs by default via `--cov` in pytest addopts with `--cov-fail-under=26` as the coverage floor ratchet. Added `coverage.run` omit list and `coverage.report` exclusion patterns (`pragma: no cover`, `if __name__`, `TYPE_CHECKING`).
- **tests/commands/conftest.py**: Key deliverable. Enhanced `mock_api` with `set_response_dict`, `set_responses` (sequence), `set_response_fn` (pattern), and call introspection (`call_count`, `calls_for`, `last_prompt`). Added `mock_costs` fixture for cost tracking isolation. Added `project_dir` fixture with working subdirectories. Added `load_api_response` and `load_api_response_text` canned response loaders.
- **tests/integration/conftest.py**: Added `mock_api_rich` fixture with regex pattern-matching (`register`/`register_canned`) for multi-step pipeline tests. Enhanced `git_project` fixture with working directories and explicit `main` branch initialization. Added `mock_git` with `commit_partial_work` support.
- **tests/wiring/conftest.py**: Proper docstring (wiring tests need no fixtures).
- **tests/fixtures/api-responses/**: Added 5 new canned response files: `synthesis.json`, `elaboration.json`, `hone.json`, `review.json`, `extraction.json` — now 9 total covering all major API response patterns.
- **tests/run-tests.sh**: Runs coverage by default, added `--no-cov` flag for speed.

All 1159 existing tests pass. Coverage at 44.47% (floor at 26%). Fixtures are composable — tests can use `mock_api` without `mock_git` or vice versa.

Closes #144

## Test plan

- [x] All 1159 existing tests pass with `python3 -m pytest tests/ -q`
- [x] Coverage ratchet enforced: `--cov-fail-under=26` in addopts
- [x] `tests/run-tests.sh` runs coverage by default
- [x] `tests/run-tests.sh --no-cov` skips coverage
- [x] Canned API response files are valid JSON with correct Anthropic Messages API structure
- [ ] Phase B command tests can use `mock_api`, `mock_git`, `mock_costs`, and `project_dir` fixtures independently
- [ ] Phase C integration tests can use `mock_api_rich` with pattern matching and `git_project` with real git ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)