### PR TITLE
Phase B: Command module tests — 504 new tests, 26% → 54% coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--tb=short --cov=scripts/lib/python/storyforge --cov-report=term-missing:skip-covered --cov-fail-under=26"
+addopts = "--tb=short --cov=scripts/lib/python/storyforge --cov-report=term-missing:skip-covered --cov-fail-under=54"
 
 [tool.coverage.run]
 source = ["scripts/lib/python/storyforge"]
@@ -9,7 +9,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 26
+fail_under = 54
 show_missing = true
 skip_covered = true
 skip_empty = true

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -86,6 +86,29 @@ def load_api_response_text(name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Prevent signal handler and log file leaks from main() calls
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolate_global_state(monkeypatch):
+    """Prevent command main() calls from leaking global state.
+
+    - install_signal_handlers: no-op to prevent SIGINT/SIGTERM handler changes
+    - _log_file: reset after each test so log output doesn't go to stale paths
+    """
+    noop = lambda: None
+    monkeypatch.setattr('storyforge.common.install_signal_handlers', noop)
+    # Also patch where cmd modules import it at top level
+    for mod_name in _CMD_MODULES:
+        mod = importlib.import_module(mod_name)
+        if hasattr(mod, 'install_signal_handlers'):
+            monkeypatch.setattr(f'{mod_name}.install_signal_handlers', noop)
+    yield
+    import storyforge.common
+    storyforge.common._log_file = None
+
+
+# ---------------------------------------------------------------------------
 # project_dir fixture
 # ---------------------------------------------------------------------------
 

--- a/tests/commands/test_api.py
+++ b/tests/commands/test_api.py
@@ -1,0 +1,699 @@
+"""Tests for storyforge.api infrastructure module.
+
+Tests the API layer itself (invoke, extract, batch) by mocking urllib
+at the transport layer. Does NOT use the mock_api fixture — that fixture
+is for testing command modules that *call* the API.
+"""
+
+import io
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# extract_text
+# ---------------------------------------------------------------------------
+
+class TestExtractText:
+    def test_single_text_block(self):
+        from storyforge.api import extract_text
+        response = {
+            'content': [{'type': 'text', 'text': 'Hello world'}],
+        }
+        assert extract_text(response) == 'Hello world'
+
+    def test_multiple_text_blocks_joined_with_newline(self):
+        from storyforge.api import extract_text
+        response = {
+            'content': [
+                {'type': 'text', 'text': 'Part A'},
+                {'type': 'text', 'text': 'Part B'},
+                {'type': 'text', 'text': 'Part C'},
+            ],
+        }
+        assert extract_text(response) == 'Part A\nPart B\nPart C'
+
+    def test_empty_content_list(self):
+        from storyforge.api import extract_text
+        response = {'content': []}
+        assert extract_text(response) == ''
+
+    def test_no_text_blocks(self):
+        """Content blocks exist but none are type 'text'."""
+        from storyforge.api import extract_text
+        response = {
+            'content': [{'type': 'tool_use', 'name': 'foo', 'input': {}}],
+        }
+        assert extract_text(response) == ''
+
+    def test_missing_content_key(self):
+        from storyforge.api import extract_text
+        response = {'usage': {'input_tokens': 10, 'output_tokens': 5}}
+        assert extract_text(response) == ''
+
+    def test_mixed_block_types(self):
+        """Only text blocks are extracted, others ignored."""
+        from storyforge.api import extract_text
+        response = {
+            'content': [
+                {'type': 'text', 'text': 'prose'},
+                {'type': 'tool_use', 'name': 'foo', 'input': {}},
+                {'type': 'text', 'text': 'more prose'},
+            ],
+        }
+        assert extract_text(response) == 'prose\nmore prose'
+
+    def test_text_block_with_empty_string(self):
+        from storyforge.api import extract_text
+        response = {
+            'content': [{'type': 'text', 'text': ''}],
+        }
+        assert extract_text(response) == ''
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_file
+# ---------------------------------------------------------------------------
+
+class TestExtractTextFromFile:
+    def test_reads_valid_json(self, tmp_path):
+        from storyforge.api import extract_text_from_file
+        f = tmp_path / 'response.json'
+        f.write_text(json.dumps({
+            'content': [{'type': 'text', 'text': 'Hello from file'}],
+        }))
+        assert extract_text_from_file(str(f)) == 'Hello from file'
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        from storyforge.api import extract_text_from_file
+        result = extract_text_from_file(str(tmp_path / 'nonexistent.json'))
+        assert result == ''
+
+    def test_handles_malformed_json(self, tmp_path):
+        from storyforge.api import extract_text_from_file
+        f = tmp_path / 'bad.json'
+        f.write_text('not valid json {{{')
+        assert extract_text_from_file(str(f)) == ''
+
+    def test_multi_block_from_file(self, tmp_path):
+        from storyforge.api import extract_text_from_file
+        f = tmp_path / 'multi.json'
+        f.write_text(json.dumps({
+            'content': [
+                {'type': 'text', 'text': 'First'},
+                {'type': 'text', 'text': 'Second'},
+            ],
+        }))
+        result = extract_text_from_file(str(f))
+        assert 'First' in result
+        assert 'Second' in result
+
+
+# ---------------------------------------------------------------------------
+# extract_usage
+# ---------------------------------------------------------------------------
+
+class TestExtractUsage:
+    def test_all_fields(self):
+        from storyforge.api import extract_usage
+        response = {
+            'usage': {
+                'input_tokens': 200,
+                'output_tokens': 100,
+                'cache_read_input_tokens': 50,
+                'cache_creation_input_tokens': 25,
+            },
+        }
+        u = extract_usage(response)
+        assert u['input_tokens'] == 200
+        assert u['output_tokens'] == 100
+        assert u['cache_read'] == 50
+        assert u['cache_create'] == 25
+
+    def test_defaults_to_zero(self):
+        from storyforge.api import extract_usage
+        response = {'usage': {}}
+        u = extract_usage(response)
+        assert u['input_tokens'] == 0
+        assert u['output_tokens'] == 0
+        assert u['cache_read'] == 0
+        assert u['cache_create'] == 0
+
+    def test_missing_usage_key(self):
+        from storyforge.api import extract_usage
+        response = {}
+        u = extract_usage(response)
+        assert u['input_tokens'] == 0
+
+
+# ---------------------------------------------------------------------------
+# max_output_tokens
+# ---------------------------------------------------------------------------
+
+class TestMaxOutputTokens:
+    def test_known_model(self):
+        from storyforge.api import max_output_tokens
+        assert max_output_tokens('claude-opus-4-6') == 128000
+
+    def test_unknown_model_returns_default(self):
+        from storyforge.api import max_output_tokens, _DEFAULT_MAX_OUTPUT
+        assert max_output_tokens('claude-unknown-99') == _DEFAULT_MAX_OUTPUT
+
+
+# ---------------------------------------------------------------------------
+# invoke (mocking _api_request)
+# ---------------------------------------------------------------------------
+
+class TestInvoke:
+    def test_constructs_correct_body(self, monkeypatch):
+        from storyforge import api
+
+        captured = {}
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            captured['path'] = path
+            captured['body'] = body
+            captured['method'] = method
+            return {
+                'content': [{'type': 'text', 'text': 'response'}],
+                'usage': {'input_tokens': 10, 'output_tokens': 5},
+            }
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+
+        result = api.invoke('Hello', 'claude-sonnet-4-6', max_tokens=2048)
+
+        assert captured['path'] == 'messages'
+        assert captured['method'] == 'POST'
+        assert captured['body']['model'] == 'claude-sonnet-4-6'
+        assert captured['body']['max_tokens'] == 2048
+        assert captured['body']['messages'] == [{'role': 'user', 'content': 'Hello'}]
+        assert result['content'][0]['text'] == 'response'
+
+    def test_passes_timeout_to_api_request(self, monkeypatch):
+        from storyforge import api
+
+        captured = {}
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            captured['timeout'] = timeout
+            return {'content': [], 'usage': {}}
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        api.invoke('test', 'claude-sonnet-4-6', timeout=1200)
+        assert captured['timeout'] == 1200
+
+    def test_propagates_runtime_error(self, monkeypatch):
+        from storyforge import api
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            raise RuntimeError('API returned HTTP 500: server error')
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+
+        with pytest.raises(RuntimeError, match='HTTP 500'):
+            api.invoke('test', 'claude-sonnet-4-6')
+
+
+# ---------------------------------------------------------------------------
+# invoke_api (convenience wrapper)
+# ---------------------------------------------------------------------------
+
+class TestInvokeApi:
+    def test_returns_text_on_success(self, monkeypatch):
+        from storyforge import api
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            return {
+                'content': [{'type': 'text', 'text': 'Success text'}],
+                'usage': {'input_tokens': 10, 'output_tokens': 5},
+            }
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+        result = api.invoke_api('test prompt', 'claude-sonnet-4-6')
+        assert result == 'Success text'
+
+    def test_returns_empty_string_on_failure(self, monkeypatch):
+        from storyforge import api
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            raise RuntimeError('network down')
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+        result = api.invoke_api('test prompt', 'claude-sonnet-4-6')
+        assert result == ''
+
+    def test_passes_label_and_timeout(self, monkeypatch):
+        from storyforge import api
+
+        captured = {}
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            captured['label'] = label
+            captured['timeout'] = timeout
+            return {'content': [{'type': 'text', 'text': 'ok'}], 'usage': {}}
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+        api.invoke_api('test', 'claude-sonnet-4-6', label='scoring', timeout=1800)
+        assert captured['label'] == 'scoring'
+        assert captured['timeout'] == 1800
+
+
+# ---------------------------------------------------------------------------
+# invoke_to_file
+# ---------------------------------------------------------------------------
+
+class TestInvokeToFile:
+    def test_writes_response_to_file(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        fake_response = {
+            'content': [{'type': 'text', 'text': 'file output'}],
+            'usage': {'input_tokens': 10, 'output_tokens': 5},
+        }
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            return fake_response
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+
+        log_file = str(tmp_path / 'output.json')
+        result = api.invoke_to_file('prompt', 'claude-sonnet-4-6', log_file)
+
+        assert result == fake_response
+        assert os.path.isfile(log_file)
+        with open(log_file) as f:
+            written = json.load(f)
+        assert written['content'][0]['text'] == 'file output'
+
+    def test_creates_parent_directories(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            return {'content': [], 'usage': {}}
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+
+        log_file = str(tmp_path / 'deep' / 'nested' / 'dir' / 'output.json')
+        api.invoke_to_file('prompt', 'claude-sonnet-4-6', log_file)
+        assert os.path.isfile(log_file)
+
+    def test_returns_response_dict(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        expected = {
+            'content': [{'type': 'text', 'text': 'hello'}],
+            'usage': {'input_tokens': 5, 'output_tokens': 3},
+        }
+
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+            return expected
+
+        monkeypatch.setattr(api, 'invoke', mock_invoke)
+
+        result = api.invoke_to_file('p', 'm', str(tmp_path / 'out.json'))
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# _api_request (mocking urlopen)
+# ---------------------------------------------------------------------------
+
+class TestApiRequest:
+    def test_successful_request(self, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key-123')
+
+        response_data = {'id': 'msg_1', 'content': [{'type': 'text', 'text': 'hi'}]}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch('storyforge.api.urlopen', return_value=mock_resp) as mock_url:
+            result = api._api_request('messages', {'model': 'test'}, method='POST')
+
+        assert result == response_data
+        call_args = mock_url.call_args
+        req = call_args[0][0]
+        assert req.full_url == f'{api.API_BASE}/messages'
+        assert req.get_header('X-api-key') == 'test-key-123'
+        assert req.get_header('Anthropic-version') == api.API_VERSION
+
+    def test_retries_on_500(self, monkeypatch):
+        from storyforge import api
+        from urllib.error import HTTPError
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        # Patch time.sleep to avoid delays in tests
+        monkeypatch.setattr('storyforge.api.time.sleep', lambda _: None)
+
+        success_resp = MagicMock()
+        success_resp.read.return_value = json.dumps({'ok': True}).encode()
+        success_resp.__enter__ = MagicMock(return_value=success_resp)
+        success_resp.__exit__ = MagicMock(return_value=False)
+
+        error = HTTPError(
+            'http://example.com', 500, 'Server Error',
+            {}, io.BytesIO(b'internal error'),
+        )
+
+        call_count = {'n': 0}
+
+        def mock_urlopen(req, timeout=None):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                raise error
+            return success_resp
+
+        with patch('storyforge.api.urlopen', side_effect=mock_urlopen):
+            result = api._api_request('messages')
+
+        assert result == {'ok': True}
+        assert call_count['n'] == 2
+
+    def test_raises_on_4xx_without_retry(self, monkeypatch):
+        from storyforge import api
+        from urllib.error import HTTPError
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        error = HTTPError(
+            'http://example.com', 400, 'Bad Request',
+            {}, io.BytesIO(b'invalid request'),
+        )
+
+        with patch('storyforge.api.urlopen', side_effect=error):
+            with pytest.raises(RuntimeError, match='HTTP 400'):
+                api._api_request('messages')
+
+    def test_raises_on_connection_error_after_retries(self, monkeypatch):
+        from storyforge import api
+        from urllib.error import URLError
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.api.time.sleep', lambda _: None)
+
+        error = URLError('Connection refused')
+
+        with patch('storyforge.api.urlopen', side_effect=error):
+            with pytest.raises(RuntimeError, match='failed after'):
+                api._api_request('messages')
+
+    def test_timeout_error_retries(self, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.api.time.sleep', lambda _: None)
+
+        success_resp = MagicMock()
+        success_resp.read.return_value = json.dumps({'ok': True}).encode()
+        success_resp.__enter__ = MagicMock(return_value=success_resp)
+        success_resp.__exit__ = MagicMock(return_value=False)
+
+        call_count = {'n': 0}
+
+        def mock_urlopen(req, timeout=None):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                raise TimeoutError('timed out')
+            return success_resp
+
+        with patch('storyforge.api.urlopen', side_effect=mock_urlopen):
+            result = api._api_request('messages')
+
+        assert result == {'ok': True}
+        assert call_count['n'] == 2
+
+
+# ---------------------------------------------------------------------------
+# get_api_key
+# ---------------------------------------------------------------------------
+
+class TestGetApiKey:
+    def test_returns_key_from_env(self, monkeypatch):
+        from storyforge.api import get_api_key
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-test-key')
+        assert get_api_key() == 'sk-test-key'
+
+    def test_raises_when_not_set(self, monkeypatch):
+        from storyforge.api import get_api_key
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        with pytest.raises(RuntimeError, match='ANTHROPIC_API_KEY not set'):
+            get_api_key()
+
+
+# ---------------------------------------------------------------------------
+# Batch API: submit_batch
+# ---------------------------------------------------------------------------
+
+class TestSubmitBatch:
+    def test_returns_batch_id(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        # Write a JSONL batch file
+        batch_file = str(tmp_path / 'batch.jsonl')
+        with open(batch_file, 'w') as f:
+            f.write(json.dumps({'custom_id': 'req-1', 'params': {'model': 'test'}}) + '\n')
+            f.write(json.dumps({'custom_id': 'req-2', 'params': {'model': 'test'}}) + '\n')
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            assert path == 'messages/batches'
+            assert method == 'POST'
+            assert len(body['requests']) == 2
+            return {'id': 'batch_abc123'}
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        batch_id = api.submit_batch(batch_file)
+        assert batch_id == 'batch_abc123'
+
+    def test_raises_when_no_id_returned(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        batch_file = str(tmp_path / 'batch.jsonl')
+        with open(batch_file, 'w') as f:
+            f.write(json.dumps({'custom_id': 'req-1'}) + '\n')
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            return {'error': 'something went wrong'}
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        with pytest.raises(RuntimeError, match='No batch ID returned'):
+            api.submit_batch(batch_file)
+
+    def test_skips_blank_lines(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        batch_file = str(tmp_path / 'batch.jsonl')
+        with open(batch_file, 'w') as f:
+            f.write(json.dumps({'custom_id': 'req-1'}) + '\n')
+            f.write('\n')  # blank line
+            f.write(json.dumps({'custom_id': 'req-2'}) + '\n')
+
+        captured = {}
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            captured['count'] = len(body['requests'])
+            return {'id': 'batch_xyz'}
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        api.submit_batch(batch_file)
+        assert captured['count'] == 2
+
+
+# ---------------------------------------------------------------------------
+# Batch API: poll_batch
+# ---------------------------------------------------------------------------
+
+class TestPollBatch:
+    def test_returns_results_url_when_ended(self, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setattr('storyforge.api.time.sleep', lambda _: None)
+
+        call_count = {'n': 0}
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                return {
+                    'processing_status': 'in_progress',
+                    'request_counts': {'succeeded': 0, 'errored': 0},
+                }
+            return {
+                'processing_status': 'ended',
+                'request_counts': {'succeeded': 5, 'errored': 0},
+                'results_url': 'https://api.anthropic.com/results/batch_123',
+            }
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        url = api.poll_batch('batch_123')
+        assert url == 'https://api.anthropic.com/results/batch_123'
+        assert call_count['n'] == 2
+
+    def test_calls_log_fn(self, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setattr('storyforge.api.time.sleep', lambda _: None)
+
+        logged = []
+
+        def mock_api_request(path, body=None, method='GET', timeout=600):
+            return {
+                'processing_status': 'ended',
+                'request_counts': {'succeeded': 3, 'errored': 0},
+                'results_url': 'https://example.com/results',
+            }
+
+        monkeypatch.setattr(api, '_api_request', mock_api_request)
+        api.poll_batch('batch_abc', log_fn=logged.append)
+        assert len(logged) == 1
+        assert 'ended' in logged[0]
+
+
+# ---------------------------------------------------------------------------
+# Batch API: download_batch_results
+# ---------------------------------------------------------------------------
+
+class TestDownloadBatchResults:
+    def test_processes_succeeded_items(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        output_dir = str(tmp_path / 'output')
+        log_dir = str(tmp_path / 'logs')
+
+        # Build a fake JSONL response
+        lines = [
+            json.dumps({
+                'custom_id': 'scene-alpha',
+                'result': {
+                    'type': 'succeeded',
+                    'message': {
+                        'content': [{'type': 'text', 'text': 'Alpha prose'}],
+                        'usage': {'input_tokens': 100, 'output_tokens': 50},
+                    },
+                },
+            }),
+            json.dumps({
+                'custom_id': 'scene-beta',
+                'result': {
+                    'type': 'errored',
+                    'error': {'message': 'overloaded'},
+                },
+            }),
+        ]
+        body = '\n'.join(lines).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch('storyforge.api.urlopen', return_value=mock_resp):
+            succeeded = api.download_batch_results('https://example.com/results', output_dir, log_dir)
+
+        assert succeeded == ['scene-alpha']
+
+        # Check status files
+        assert open(os.path.join(output_dir, '.status-scene-alpha')).read() == 'ok'
+        assert open(os.path.join(output_dir, '.status-scene-beta')).read() == 'fail'
+
+        # Check text output
+        assert open(os.path.join(log_dir, 'scene-alpha.txt')).read() == 'Alpha prose'
+
+        # Check JSON log
+        with open(os.path.join(log_dir, 'scene-alpha.json')) as f:
+            data = json.load(f)
+        assert data['usage']['input_tokens'] == 100
+
+    def test_creates_output_directories(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        output_dir = str(tmp_path / 'a' / 'b' / 'output')
+        log_dir = str(tmp_path / 'c' / 'd' / 'logs')
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b''
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch('storyforge.api.urlopen', return_value=mock_resp):
+            succeeded = api.download_batch_results('https://example.com/r', output_dir, log_dir)
+
+        assert succeeded == []
+        assert os.path.isdir(output_dir)
+        assert os.path.isdir(log_dir)
+
+    def test_skips_malformed_lines(self, tmp_path, monkeypatch):
+        from storyforge import api
+
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        output_dir = str(tmp_path / 'output')
+        log_dir = str(tmp_path / 'logs')
+
+        lines = [
+            'not json at all',
+            '',
+            json.dumps({
+                'custom_id': 'good-one',
+                'result': {
+                    'type': 'succeeded',
+                    'message': {
+                        'content': [{'type': 'text', 'text': 'Good'}],
+                        'usage': {'input_tokens': 10, 'output_tokens': 5},
+                    },
+                },
+            }),
+        ]
+        body = '\n'.join(lines).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch('storyforge.api.urlopen', return_value=mock_resp):
+            succeeded = api.download_batch_results('https://example.com/r', output_dir, log_dir)
+
+        assert succeeded == ['good-one']
+
+
+# ---------------------------------------------------------------------------
+# extract_response (alias)
+# ---------------------------------------------------------------------------
+
+class TestExtractResponse:
+    def test_is_alias_for_extract_text_from_file(self, tmp_path):
+        from storyforge.api import extract_response
+        f = tmp_path / 'resp.json'
+        f.write_text(json.dumps({
+            'content': [{'type': 'text', 'text': 'alias test'}],
+        }))
+        assert extract_response(str(f)) == 'alias test'
+
+
+# ---------------------------------------------------------------------------
+# calculate_cost_from_usage
+# ---------------------------------------------------------------------------
+
+class TestCalculateCostFromUsage:
+    def test_returns_float(self):
+        from storyforge.api import calculate_cost_from_usage
+        usage = {
+            'input_tokens': 1000,
+            'output_tokens': 500,
+            'cache_read': 0,
+            'cache_create': 0,
+        }
+        cost = calculate_cost_from_usage(usage, 'claude-sonnet-4-6')
+        assert isinstance(cost, float)
+        assert cost > 0

--- a/tests/commands/test_cmd_assemble.py
+++ b/tests/commands/test_cmd_assemble.py
@@ -1,0 +1,652 @@
+"""Tests for storyforge.cmd_assemble — manuscript assembly and book production.
+
+Covers: parse_args, format resolution, dry-run mode, main flow,
+chapter map reading, output directory creation, git workflow, and error handling.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from storyforge.cmd_assemble import (
+    VALID_FORMATS,
+    _resolve_formats,
+    _word_count,
+    parse_args,
+    main,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _ensure_scene_files(project_dir, scene_ids=None):
+    """Ensure scene files exist for testing."""
+    if scene_ids is None:
+        scene_ids = ['act1-sc01', 'act1-sc02', 'act2-sc01']
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    for sid in scene_ids:
+        path = os.path.join(scenes_dir, f'{sid}.md')
+        if not os.path.isfile(path):
+            with open(path, 'w') as f:
+                f.write(f'Scene prose for {sid}. ' * 50 + '\n')
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+class TestParseArgs:
+    """Tests for parse_args."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert args.formats == []
+        assert not args.all_formats
+        assert not args.draft
+        assert args.annotate is True
+        assert not args.interactive
+        assert not args.dry_run
+        assert not args.skip_validation
+        assert not args.no_pr
+
+    def test_format_epub(self):
+        args = parse_args(['--format', 'epub'])
+        assert args.formats == ['epub']
+
+    def test_format_multiple(self):
+        args = parse_args(['--format', 'epub', '--format', 'pdf'])
+        assert args.formats == ['epub', 'pdf']
+
+    def test_all_formats(self):
+        args = parse_args(['--all'])
+        assert args.all_formats
+
+    def test_draft(self):
+        args = parse_args(['--draft'])
+        assert args.draft
+
+    def test_no_annotate(self):
+        args = parse_args(['--no-annotate'])
+        assert args.annotate is False
+
+    def test_interactive(self):
+        args = parse_args(['--interactive'])
+        assert args.interactive
+
+    def test_interactive_short(self):
+        args = parse_args(['-i'])
+        assert args.interactive
+
+    def test_dry_run(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_skip_validation(self):
+        args = parse_args(['--skip-validation'])
+        assert args.skip_validation
+
+    def test_no_pr(self):
+        args = parse_args(['--no-pr'])
+        assert args.no_pr
+
+    def test_combined_flags(self):
+        args = parse_args(['--format', 'epub', '--dry-run', '--skip-validation', '--no-pr'])
+        assert args.formats == ['epub']
+        assert args.dry_run
+        assert args.skip_validation
+        assert args.no_pr
+
+    def test_draft_with_no_annotate(self):
+        args = parse_args(['--draft', '--no-annotate'])
+        assert args.draft
+        assert args.annotate is False
+
+
+# ============================================================================
+# _resolve_formats
+# ============================================================================
+
+class TestResolveFormats:
+    """Tests for _resolve_formats."""
+
+    def test_default_is_markdown(self):
+        args = parse_args([])
+        result = _resolve_formats(args)
+        assert result == ['markdown']
+
+    def test_draft_forces_markdown(self):
+        args = parse_args(['--draft'])
+        result = _resolve_formats(args)
+        assert result == ['markdown']
+
+    def test_all_flag(self):
+        args = parse_args(['--all'])
+        result = _resolve_formats(args)
+        assert result == ['all']
+
+    def test_single_format(self):
+        args = parse_args(['--format', 'epub'])
+        result = _resolve_formats(args)
+        assert result == ['epub']
+
+    def test_multiple_formats(self):
+        args = parse_args(['--format', 'epub', '--format', 'html'])
+        result = _resolve_formats(args)
+        assert result == ['epub', 'html']
+
+    def test_comma_separated_formats(self):
+        args = parse_args(['--format', 'epub,html'])
+        result = _resolve_formats(args)
+        assert result == ['epub', 'html']
+
+    def test_invalid_format_exits(self):
+        args = parse_args(['--format', 'docx'])
+        with pytest.raises(SystemExit):
+            _resolve_formats(args)
+
+    def test_draft_overrides_format(self):
+        """Draft flag should override any explicit format specification."""
+        args = parse_args(['--draft', '--format', 'epub'])
+        result = _resolve_formats(args)
+        assert result == ['markdown']
+
+    def test_all_overrides_format(self):
+        """All flag takes precedence over explicit formats."""
+        args = parse_args(['--all', '--format', 'epub'])
+        result = _resolve_formats(args)
+        assert result == ['all']
+
+
+# ============================================================================
+# VALID_FORMATS
+# ============================================================================
+
+class TestValidFormats:
+    """Tests for the VALID_FORMATS constant."""
+
+    def test_contains_expected_formats(self):
+        assert 'epub' in VALID_FORMATS
+        assert 'pdf' in VALID_FORMATS
+        assert 'html' in VALID_FORMATS
+        assert 'web' in VALID_FORMATS
+        assert 'markdown' in VALID_FORMATS
+        assert 'all' in VALID_FORMATS
+
+    def test_no_unexpected_formats(self):
+        assert len(VALID_FORMATS) == 6
+
+
+# ============================================================================
+# _word_count
+# ============================================================================
+
+class TestWordCount:
+    """Tests for _word_count."""
+
+    def test_counts_words(self, tmp_path):
+        f = tmp_path / 'test.md'
+        f.write_text('one two three four five')
+        assert _word_count(str(f)) == 5
+
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / 'empty.md'
+        f.write_text('')
+        assert _word_count(str(f)) == 0
+
+    def test_multiline(self, tmp_path):
+        f = tmp_path / 'multi.md'
+        f.write_text('line one\nline two\nline three')
+        assert _word_count(str(f)) == 6
+
+
+# ============================================================================
+# main() -- dry-run mode
+# ============================================================================
+
+class TestMainDryRun:
+    """Tests for main() in dry-run mode."""
+
+    def test_dry_run_prints_plan(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        # Mock _run_assembly_cmd for chapter counting and scene listing
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '2'
+            if 'chapter-scenes' in args_str:
+                ch_num = args[1]
+                if ch_num == '1':
+                    return 'act1-sc01\nact1-sc02'
+                elif ch_num == '2':
+                    return 'act2-sc01'
+                return ''
+            if 'read-chapter-field' in args_str:
+                ch_num = args[1]
+                if ch_num == '1':
+                    return 'The Finest Cartographer'
+                elif ch_num == '2':
+                    return 'Into the Blank'
+                return 'Unknown'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        main(['--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert "Cartographer's Silence" in captured.out
+        assert 'Chapters: 2' in captured.out
+        assert 'Markdown' in captured.out or 'markdown' in captured.out
+
+        # No API calls, no git commits
+        assert mock_api.call_count == 0
+        assert mock_git.calls_for('commit_and_push') == []
+
+    def test_dry_run_with_epub_format(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '2'
+            if 'chapter-scenes' in args_str:
+                ch_num = args[1]
+                if ch_num == '1':
+                    return 'act1-sc01\nact1-sc02'
+                return 'act2-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter Title'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        main(['--format', 'epub', '--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'epub3' in captured.out
+
+    def test_dry_run_shows_missing_scenes(self, mock_api, mock_git, mock_costs,
+                                           project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        # Only create some scene files, leaving one missing
+        _ensure_scene_files(project_dir, ['act1-sc01'])
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01\nmissing-scene'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        main(['--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'MISSING' in captured.out
+
+
+# ============================================================================
+# main() -- validation errors
+# ============================================================================
+
+class TestMainValidation:
+    """Tests for main() validation paths."""
+
+    def test_missing_chapter_map_exits(self, mock_api, mock_git, mock_costs,
+                                        project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        # Remove chapter map
+        chapter_map = os.path.join(project_dir, 'reference', 'chapter-map.csv')
+        if os.path.isfile(chapter_map):
+            os.remove(chapter_map)
+
+        with pytest.raises(SystemExit):
+            main([])
+
+    def test_empty_chapter_map_exits(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '0'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        with pytest.raises(SystemExit):
+            main([])
+
+    def test_invalid_format_exits(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        with pytest.raises(SystemExit):
+            main(['--format', 'docx'])
+
+
+# ============================================================================
+# main() -- full assembly flow
+# ============================================================================
+
+class TestMainAssembly:
+    """Tests for main() full assembly execution."""
+
+    def test_draft_mode(self, mock_api, mock_git, mock_costs, project_dir,
+                         monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        # Track subprocess calls
+        calls = []
+        original_run = subprocess.run
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '2'
+            if 'chapter-scenes' in args_str:
+                ch_num = args[1]
+                if ch_num == '1':
+                    return 'act1-sc01\nact1-sc02'
+                return 'act2-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter Title'
+            if 'assemble' in args_str and args_str.startswith('assemble'):
+                return '5000'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            calls.append(cmd_str)
+            if 'storyforge.assembly' in cmd_str and 'chapter' in cmd_str:
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout='Chapter content here with some words in it.',
+                    stderr='',
+                )
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+
+        main(['--draft', '--no-pr'])
+
+        captured = capsys.readouterr()
+        combined = captured.out
+        assert 'draft' in combined.lower() or 'Draft' in combined
+
+        # Draft mode should create chapter files
+        chapters_dir = os.path.join(project_dir, 'manuscript', 'chapters')
+        assert os.path.isdir(chapters_dir)
+
+
+# ============================================================================
+# main() -- git workflow
+# ============================================================================
+
+class TestMainGitWorkflow:
+    """Tests for git workflow in assembly."""
+
+    def test_creates_branch(self, mock_api, mock_git, mock_costs, project_dir,
+                             monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            if 'assemble' in args_str and args_str.startswith('assemble'):
+                return '1000'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.assembly' in cmd_str:
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout='Assembly content.',
+                    stderr='',
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout='', stderr='')
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+
+        main(['--draft', '--no-pr'])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+        assert branch_calls[0][1] == 'assemble'
+
+    def test_no_pr_flag_skips_pr(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            if 'assemble' in args_str and args_str.startswith('assemble'):
+                return '1000'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        def mock_subprocess_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout='Content.', stderr='')
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+
+        main(['--draft', '--no-pr'])
+
+        pr_calls = mock_git.calls_for('create_draft_pr')
+        assert len(pr_calls) == 0
+
+    def test_dry_run_skips_git(self, mock_api, mock_git, mock_costs,
+                                project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        main(['--dry-run'])
+
+        # Dry run should not create branch or commit
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) == 0
+        commit_calls = mock_git.calls_for('commit_and_push')
+        assert len(commit_calls) == 0
+
+
+# ============================================================================
+# main() -- chapter map freshness check
+# ============================================================================
+
+class TestChapterMapFreshness:
+    """Tests for chapter map freshness warning in main."""
+
+    def test_warns_about_stale_chapter_map(self, mock_api, mock_git, mock_costs,
+                                            project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        # The fixture has scenes not in chapter map (new-x1, act2-sc02, act2-sc03)
+        # This should trigger a freshness warning
+        main(['--dry-run'])
+
+        captured = capsys.readouterr()
+        # The warning is logged, which goes to stdout
+        assert 'chapter map' in captured.out.lower() or 'Chapter map' in captured.out
+
+
+# ============================================================================
+# main() -- all-formats dry run
+# ============================================================================
+
+class TestMainAllFormats:
+    """Tests for --all flag behavior."""
+
+    def test_all_formats_dry_run(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_assemble.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_assemble.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        _ensure_scene_files(project_dir)
+
+        def mock_assembly_cmd(*args):
+            args_str = ' '.join(str(a) for a in args)
+            if 'count-chapters' in args_str:
+                return '1'
+            if 'chapter-scenes' in args_str:
+                return 'act1-sc01'
+            if 'read-chapter-field' in args_str:
+                return 'Chapter One'
+            return ''
+
+        monkeypatch.setattr('storyforge.cmd_assemble._run_assembly_cmd',
+                            mock_assembly_cmd)
+
+        main(['--all', '--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        # All formats should be listed
+        assert 'Markdown' in captured.out
+        assert 'epub3' in captured.out
+        assert 'HTML' in captured.out
+        assert 'Web book' in captured.out
+        assert 'PDF' in captured.out

--- a/tests/commands/test_cmd_assemble.py
+++ b/tests/commands/test_cmd_assemble.py
@@ -403,7 +403,7 @@ class TestMainAssembly:
 
         # Track subprocess calls
         calls = []
-        original_run = subprocess.run
+
 
         def mock_assembly_cmd(*args):
             args_str = ' '.join(str(a) for a in args)
@@ -432,7 +432,7 @@ class TestMainAssembly:
                     stdout='Chapter content here with some words in it.',
                     stderr='',
                 )
-            return original_run(cmd, **kwargs)
+            return subprocess.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
 

--- a/tests/commands/test_cmd_evaluate.py
+++ b/tests/commands/test_cmd_evaluate.py
@@ -1,0 +1,761 @@
+"""Tests for storyforge.cmd_evaluate — Multi-agent evaluation panel.
+
+Covers: parse_args, main, evaluator dispatch, batch vs direct API,
+synthesis, assessment, dry run, scene filtering, cost logging, error handling.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+from storyforge.cmd_evaluate import (
+    parse_args,
+    main,
+    CORE_EVALUATORS,
+    _resolve_filter,
+    _load_custom_evaluators,
+    _resolve_voice_guide,
+    _build_eval_prompt,
+    _build_synthesis_prompt,
+)
+
+from tests.commands.conftest import (
+    load_api_response,
+    load_api_response_text,
+    TESTS_DIR,
+)
+
+# The plugin root is the repo root — one level above tests/
+PLUGIN_DIR = os.path.dirname(TESTS_DIR)
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+class TestParseArgs:
+    """Exhaustive tests for argument parsing."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert not args.manuscript
+        assert args.chapter is None
+        assert args.act is None
+        assert args.scenes is None
+        assert args.scene is None
+        assert args.from_seq is None
+        assert args.evaluator is None
+        assert not args.final
+        assert not args.interactive
+        assert not args.direct
+        assert not args.dry_run
+
+    def test_manuscript_flag(self):
+        args = parse_args(['--manuscript'])
+        assert args.manuscript
+
+    def test_chapter_flag(self):
+        args = parse_args(['--chapter', '5'])
+        assert args.chapter == 5
+
+    def test_act_flag(self):
+        args = parse_args(['--act', '2'])
+        assert args.act == '2'
+
+    def test_part_alias(self):
+        args = parse_args(['--part', '3'])
+        assert args.act == '3'
+
+    def test_scenes_flag(self):
+        args = parse_args(['--scenes', 'act1-sc01,act1-sc02'])
+        assert args.scenes == 'act1-sc01,act1-sc02'
+
+    def test_scene_flag(self):
+        args = parse_args(['--scene', 'act1-sc01'])
+        assert args.scene == 'act1-sc01'
+
+    def test_from_seq_flag(self):
+        args = parse_args(['--from-seq', '5'])
+        assert args.from_seq == '5'
+
+    def test_evaluator_flag(self):
+        args = parse_args(['--evaluator', 'line-editor'])
+        assert args.evaluator == 'line-editor'
+
+    def test_final_flag(self):
+        args = parse_args(['--final'])
+        assert args.final
+
+    def test_interactive_flag(self):
+        args = parse_args(['-i'])
+        assert args.interactive
+
+    def test_interactive_long_flag(self):
+        args = parse_args(['--interactive'])
+        assert args.interactive
+
+    def test_direct_flag(self):
+        args = parse_args(['--direct'])
+        assert args.direct
+
+    def test_dry_run_flag(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_combined_flags(self):
+        args = parse_args(['--act', '1', '--evaluator', 'first-reader', '--dry-run'])
+        assert args.act == '1'
+        assert args.evaluator == 'first-reader'
+        assert args.dry_run
+
+
+# ============================================================================
+# _resolve_filter
+# ============================================================================
+
+class TestResolveFilter:
+    """Tests for filter mode resolution from args."""
+
+    def test_default_returns_all(self):
+        args = parse_args([])
+        mode, *_ = _resolve_filter(args)
+        assert mode == 'all'
+
+    def test_manuscript_mode(self):
+        args = parse_args(['--manuscript'])
+        mode, *_ = _resolve_filter(args)
+        assert mode == 'manuscript'
+
+    def test_chapter_mode(self):
+        args = parse_args(['--chapter', '3'])
+        mode, value, *_ = _resolve_filter(args)
+        assert mode == 'chapter'
+        assert value == '3'
+
+    def test_act_mode(self):
+        args = parse_args(['--act', '2'])
+        mode, value, *_ = _resolve_filter(args)
+        assert mode == 'act'
+        assert value == '2'
+
+    def test_single_scene_mode(self):
+        args = parse_args(['--scene', 'act1-sc01'])
+        mode, value, range_start, *_ = _resolve_filter(args)
+        assert mode == 'single'
+        assert range_start == 'act1-sc01'
+
+    def test_scenes_mode(self):
+        args = parse_args(['--scenes', 'act1-sc01,act1-sc02'])
+        result = _resolve_filter(args)
+        assert result[0] == 'scenes'
+        assert result[4] == 'act1-sc01,act1-sc02'
+
+    def test_scenes_range_mode(self):
+        args = parse_args(['--scenes', 'act1-sc01..act2-sc01'])
+        result = _resolve_filter(args)
+        assert result[0] == 'range'
+        assert result[2] == 'act1-sc01'
+        assert result[3] == 'act2-sc01'
+
+    def test_from_seq_mode(self):
+        args = parse_args(['--from-seq', '5'])
+        result = _resolve_filter(args)
+        assert result[0] == 'from_seq'
+        assert result[5] == '5'
+
+
+# ============================================================================
+# _load_custom_evaluators
+# ============================================================================
+
+class TestLoadCustomEvaluators:
+    """Tests for loading custom evaluators from storyforge.yaml."""
+
+    def test_no_custom_evaluators(self, project_dir):
+        result = _load_custom_evaluators(project_dir)
+        assert result == []
+
+    def test_missing_yaml(self, tmp_path):
+        result = _load_custom_evaluators(str(tmp_path))
+        assert result == []
+
+    def test_with_custom_evaluators(self, tmp_path):
+        yaml_content = """\
+project:
+  title: Test
+custom_evaluators:
+  - name: beta-reader
+    persona_file: reference/beta-reader.md
+  - name: sensitivity-reader
+    persona_file: reference/sensitivity.md
+"""
+        (tmp_path / 'storyforge.yaml').write_text(yaml_content)
+        (tmp_path / 'reference').mkdir(exist_ok=True)
+        (tmp_path / 'reference' / 'beta-reader.md').write_text('Beta reader persona')
+        (tmp_path / 'reference' / 'sensitivity.md').write_text('Sensitivity persona')
+
+        result = _load_custom_evaluators(str(tmp_path))
+        assert len(result) == 2
+        assert result[0][0] == 'beta-reader'
+        assert result[1][0] == 'sensitivity-reader'
+
+
+# ============================================================================
+# _resolve_voice_guide
+# ============================================================================
+
+class TestResolveVoiceGuide:
+    """Tests for voice guide resolution."""
+
+    def test_finds_voice_guide(self, project_dir):
+        path, content = _resolve_voice_guide(project_dir)
+        assert path is not None
+        assert 'Voice Guide' in content
+
+    def test_no_voice_guide(self, tmp_path):
+        (tmp_path / 'storyforge.yaml').write_text('project:\n  title: Test\n')
+        path, content = _resolve_voice_guide(str(tmp_path))
+        assert path is None
+        assert content == ''
+
+
+# ============================================================================
+# CORE_EVALUATORS
+# ============================================================================
+
+class TestCoreEvaluators:
+    """Tests for evaluator constants."""
+
+    def test_six_core_evaluators(self):
+        assert len(CORE_EVALUATORS) == 6
+
+    def test_expected_evaluators(self):
+        expected = {
+            'literary-agent', 'developmental-editor', 'line-editor',
+            'genre-expert', 'first-reader', 'writing-coach',
+        }
+        assert set(CORE_EVALUATORS) == expected
+
+
+# ============================================================================
+# Dry run
+# ============================================================================
+
+class TestDryRun:
+    """Tests for dry run mode."""
+
+    def test_dry_run_no_api_calls(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+
+        # Need scene files to exist
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        for sf in ['act1-sc01.md', 'act1-sc02.md']:
+            with open(os.path.join(scenes_dir, sf), 'w') as f:
+                f.write('Test scene content here.')
+
+        main(['--dry-run', '--scene', 'act1-sc01'])
+
+        assert mock_api.call_count == 0
+        assert len(mock_git.calls_for('create_branch')) == 0
+
+    def test_dry_run_prints_evaluator_prompts(self, mock_api, mock_git, mock_costs,
+                                               project_dir, monkeypatch, capsys):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'act1-sc01.md'), 'w') as f:
+            f.write('Test scene content.')
+
+        main(['--dry-run', '--scene', 'act1-sc01'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert 'synthesis' in captured.out.lower()
+
+
+# ============================================================================
+# Direct mode evaluation
+# ============================================================================
+
+class TestDirectMode:
+    """Tests for direct API evaluation mode."""
+
+    def _setup_project(self, project_dir, monkeypatch):
+        """Common setup for direct mode tests."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        # Patch get_api_key to not raise
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        # Write scene content
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'act1-sc01.md'), 'w') as f:
+            f.write('Dorren studied the map. The eastern sector readings were wrong.')
+
+    def test_direct_single_evaluator(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        """Single evaluator in direct mode should make one API call."""
+        self._setup_project(project_dir, monkeypatch)
+
+        eval_text = load_api_response_text('evaluation')
+        synth_text = load_api_response_text('synthesis')
+        mock_api.set_response(eval_text)
+
+        main(['--direct', '--scene', 'act1-sc01', '--evaluator', 'line-editor'])
+
+        # Single evaluator mode: one evaluator call, no synthesis
+        invoke_calls = mock_api.calls_for('invoke_to_file')
+        assert len(invoke_calls) >= 1
+
+        # Should NOT have created a branch (single evaluator mode)
+        assert len(mock_git.calls_for('create_branch')) == 0
+
+    def test_direct_all_evaluators_creates_branch(self, mock_api, mock_git, mock_costs,
+                                                    project_dir, monkeypatch):
+        """Full evaluation should create a branch and PR."""
+        self._setup_project(project_dir, monkeypatch)
+
+        eval_text = load_api_response_text('evaluation')
+
+        # Build a synthesis response with the expected delimiters
+        synth_response_text = (
+            '--- BEGIN synthesis.md ---\n'
+            '## Consensus Findings\nStrong voice.\n'
+            '--- END synthesis.md ---\n'
+            '--- BEGIN findings.yaml ---\n'
+            'metadata:\n  title: Test\nfindings:\n  - id: F001\n'
+            '    category: prose\n    severity: minor\n'
+            '    summary: "Opening hook"\n    fix_location: craft\n'
+            '--- END findings.yaml ---\n'
+        )
+        mock_api.set_response_fn(
+            lambda prompt: synth_response_text if 'reconciling' in prompt.lower()
+            else eval_text
+        )
+
+        main(['--direct', '--scene', 'act1-sc01'])
+
+        # Should have created a branch
+        assert len(mock_git.calls_for('create_branch')) == 1
+        # Should have created a draft PR
+        assert len(mock_git.calls_for('create_draft_pr')) == 1
+        # Should have committed
+        assert len(mock_git.calls_for('commit_and_push')) >= 1
+
+    def test_direct_calls_six_evaluators(self, mock_api, mock_git, mock_costs,
+                                          project_dir, monkeypatch):
+        """Default evaluation should invoke all 6 core evaluators."""
+        self._setup_project(project_dir, monkeypatch)
+
+        eval_text = load_api_response_text('evaluation')
+        synth_response_text = (
+            '--- BEGIN synthesis.md ---\n'
+            '## Consensus\nGood.\n'
+            '--- END synthesis.md ---\n'
+            '--- BEGIN findings.yaml ---\n'
+            'findings: []\n'
+            '--- END findings.yaml ---\n'
+        )
+        mock_api.set_response_fn(
+            lambda prompt: synth_response_text if 'reconciling' in prompt.lower()
+            else eval_text
+        )
+
+        main(['--direct', '--scene', 'act1-sc01'])
+
+        # Count evaluator invoke_to_file calls (6 evaluators + synthesis + possibly assessment)
+        invoke_calls = mock_api.calls_for('invoke_to_file')
+        # At least 6 (evaluators) + 1 (synthesis)
+        assert len(invoke_calls) >= 7
+
+
+# ============================================================================
+# Batch mode
+# ============================================================================
+
+class TestBatchMode:
+    """Tests for batch API evaluation mode."""
+
+    def _setup_project(self, project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'act1-sc01.md'), 'w') as f:
+            f.write('Dorren studied the map.')
+
+    def test_batch_submits_and_polls(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        """Batch mode should submit_batch, poll_batch, download_batch_results."""
+        self._setup_project(project_dir, monkeypatch)
+
+        # download_batch_results creates report files; simulate that
+        eval_dir_holder = {}
+
+        original_download = mock_api._download_batch_results
+
+        def fake_download(results_url, output_dir, log_dir):
+            original_download(results_url, output_dir, log_dir)
+            # Create evaluator report files and status files so synthesis runs
+            for name in CORE_EVALUATORS:
+                report_path = os.path.join(output_dir, f'{name}.md')
+                status_path = os.path.join(output_dir, f'.status-{name}')
+                txt_path = os.path.join(log_dir, f'{name}.txt')
+                with open(report_path, 'w') as f:
+                    f.write(f'## {name} Report\nGood work.')
+                with open(status_path, 'w') as f:
+                    f.write('ok')
+                with open(txt_path, 'w') as f:
+                    f.write(f'## {name} Report\nGood work.')
+            return list(CORE_EVALUATORS)
+
+        monkeypatch.setattr('storyforge.api.download_batch_results', fake_download)
+        monkeypatch.setattr('storyforge.cmd_evaluate.download_batch_results', fake_download)
+
+        synth_response_text = (
+            '--- BEGIN synthesis.md ---\n'
+            '## Consensus\nGood.\n'
+            '--- END synthesis.md ---\n'
+            '--- BEGIN findings.yaml ---\n'
+            'findings: []\n'
+            '--- END findings.yaml ---\n'
+        )
+        mock_api.set_response(synth_response_text)
+
+        main(['--scene', 'act1-sc01'])
+
+        assert len(mock_api.calls_for('submit_batch')) == 1
+        assert len(mock_api.calls_for('poll_batch')) == 1
+
+
+# ============================================================================
+# Synthesis prompt
+# ============================================================================
+
+class TestSynthesisPrompt:
+    """Tests for synthesis prompt construction."""
+
+    def test_synthesis_includes_evaluator_names(self, project_dir):
+        eval_dir = os.path.join(project_dir, 'working', 'evaluations', 'eval-test')
+        os.makedirs(eval_dir, exist_ok=True)
+
+        for name in ['line-editor', 'first-reader']:
+            with open(os.path.join(eval_dir, f'{name}.md'), 'w') as f:
+                f.write(f'## {name} Report\nFindings here.')
+
+        prompt = _build_synthesis_prompt(
+            project_dir, eval_dir, 'test', 'test scope',
+            'Test Book', 'fantasy', 'A test logline', 'scenes',
+            ['line-editor', 'first-reader'], False, True,
+        )
+
+        assert 'line-editor' in prompt
+        assert 'first-reader' in prompt
+        assert 'Test Book' in prompt
+
+    def test_synthesis_final_includes_readiness(self, project_dir):
+        eval_dir = os.path.join(project_dir, 'working', 'evaluations', 'eval-test')
+        os.makedirs(eval_dir, exist_ok=True)
+
+        prompt = _build_synthesis_prompt(
+            project_dir, eval_dir, 'test', 'test scope',
+            'Test', 'fantasy', '', 'scenes',
+            ['line-editor'], True, True,
+        )
+
+        assert 'Beta Reader Readiness' in prompt
+
+    def test_synthesis_non_final_no_readiness(self, project_dir):
+        eval_dir = os.path.join(project_dir, 'working', 'evaluations', 'eval-test')
+        os.makedirs(eval_dir, exist_ok=True)
+
+        prompt = _build_synthesis_prompt(
+            project_dir, eval_dir, 'test', 'test scope',
+            'Test', 'fantasy', '', 'scenes',
+            ['line-editor'], False, True,
+        )
+
+        assert 'Beta Reader Readiness' not in prompt
+
+    def test_synthesis_includes_fix_location_schema(self, project_dir):
+        eval_dir = os.path.join(project_dir, 'working', 'evaluations', 'eval-test')
+        os.makedirs(eval_dir, exist_ok=True)
+
+        prompt = _build_synthesis_prompt(
+            project_dir, eval_dir, 'test', 'test scope',
+            'Test', 'fantasy', '', 'scenes',
+            ['line-editor'], False, True,
+        )
+
+        assert 'fix_location' in prompt
+        assert 'brief' in prompt
+        assert 'craft' in prompt
+
+
+# ============================================================================
+# Eval prompt building
+# ============================================================================
+
+class TestBuildEvalPrompt:
+    """Tests for evaluator prompt construction."""
+
+    def test_prompt_includes_project_title(self, project_dir):
+        plugin_dir = PLUGIN_DIR
+
+        prompt = _build_eval_prompt(
+            'line-editor', False, True, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test Title', 'fantasy', 'A test logline',
+            'Voice guide content', False, '20260101-000000',
+            [],
+        )
+
+        assert prompt is not None
+        assert 'Test Title' in prompt
+
+    def test_prompt_includes_genre(self, project_dir):
+        plugin_dir = PLUGIN_DIR
+
+        prompt = _build_eval_prompt(
+            'first-reader', False, True, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test Title', 'fantasy (secondary world)', 'logline',
+            '', False, '20260101-000000', [],
+        )
+
+        assert prompt is not None
+        assert 'fantasy' in prompt
+
+    def test_prompt_api_mode_includes_manuscript_inline(self, project_dir):
+        """API mode should inline scene content in prompt."""
+        plugin_dir = PLUGIN_DIR
+
+        # Write scene content
+        scene_path = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        with open(scene_path, 'w') as f:
+            f.write('The cartographer studied her instruments.')
+
+        prompt = _build_eval_prompt(
+            'first-reader', False, True, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test', 'fantasy', '', '', False, '20260101-000000', [],
+        )
+
+        assert 'The cartographer studied her instruments.' in prompt
+
+    def test_prompt_non_api_mode_no_inline(self, project_dir):
+        """Non-API mode should reference files but not inline content."""
+        plugin_dir = PLUGIN_DIR
+
+        prompt = _build_eval_prompt(
+            'first-reader', False, False, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test', 'fantasy', '', '', False, '20260101-000000', [],
+        )
+
+        assert prompt is not None
+        assert 'Read the scene files' in prompt
+        assert 'MANUSCRIPT' not in prompt
+
+    def test_final_eval_adds_context(self, project_dir):
+        """--final should add evaluation context block."""
+        plugin_dir = PLUGIN_DIR
+
+        prompt = _build_eval_prompt(
+            'first-reader', False, True, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test', 'fantasy', '', '', True, '20260101-000000', [],
+        )
+
+        assert 'final evaluation' in prompt.lower()
+        assert 'beta reader' in prompt.lower()
+
+    def test_unknown_evaluator_returns_none(self, project_dir):
+        plugin_dir = PLUGIN_DIR
+
+        prompt = _build_eval_prompt(
+            'nonexistent-evaluator', False, True, project_dir, plugin_dir,
+            ['scenes/act1-sc01.md'], 'test scope', 'scenes',
+            'Test', 'fantasy', '', '', False, '20260101-000000', [],
+        )
+
+        assert prompt is None
+
+
+# ============================================================================
+# Scene filtering in main
+# ============================================================================
+
+class TestSceneFiltering:
+    """Tests for scene filtering through main."""
+
+    def _setup(self, project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        for sf in ['act1-sc01.md', 'act1-sc02.md', 'act2-sc01.md']:
+            with open(os.path.join(scenes_dir, sf), 'w') as f:
+                f.write('Test scene content.')
+
+    def test_act_filter_dry_run(self, mock_api, mock_git, mock_costs,
+                                 project_dir, monkeypatch, capsys):
+        self._setup(project_dir, monkeypatch)
+        main(['--dry-run', '--act', '1'])
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+
+    def test_from_seq_filter_dry_run(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch, capsys):
+        self._setup(project_dir, monkeypatch)
+        main(['--dry-run', '--from-seq', '3'])
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+
+
+# ============================================================================
+# Error handling
+# ============================================================================
+
+class TestErrorHandling:
+    """Tests for error conditions."""
+
+    def test_no_api_key_exits(self, mock_api, mock_git, mock_costs,
+                               project_dir, monkeypatch):
+        """Missing API key should exit in batch/direct mode."""
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_api_key',
+            lambda: (_ for _ in ()).throw(RuntimeError('no key')))
+
+        with pytest.raises(SystemExit):
+            main(['--scene', 'act1-sc01'])
+
+    def test_unknown_evaluator_exits(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        """Unknown --evaluator name should exit."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        with pytest.raises(SystemExit):
+            main(['--direct', '--scene', 'act1-sc01', '--evaluator', 'nonexistent'])
+
+    def test_no_scene_files_exits(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        """If no scene files exist for the filter, should exit."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        # Remove all scene files
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        for f in os.listdir(scenes_dir):
+            os.remove(os.path.join(scenes_dir, f))
+
+        with pytest.raises(SystemExit):
+            main(['--direct'])
+
+
+# ============================================================================
+# Cost logging
+# ============================================================================
+
+class TestCostTracking:
+    """Tests for cost estimation and logging."""
+
+    def test_cost_estimate_called_during_evaluation(self, mock_api, mock_git,
+                                                     mock_costs, project_dir,
+                                                     monkeypatch):
+        """Cost estimation should be called during a real evaluation."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'act1-sc01.md'), 'w') as f:
+            f.write('Test scene content words here.')
+
+        eval_text = load_api_response_text('evaluation')
+        synth_text = (
+            '--- BEGIN synthesis.md ---\n'
+            '## Consensus\nGood.\n'
+            '--- END synthesis.md ---\n'
+            '--- BEGIN findings.yaml ---\n'
+            'findings: []\n'
+            '--- END findings.yaml ---\n'
+        )
+        mock_api.set_response_fn(
+            lambda prompt: synth_text if 'reconciling' in prompt.lower() else eval_text
+        )
+
+        main(['--direct', '--scene', 'act1-sc01', '--evaluator', 'line-editor'])
+
+        # estimate_cost should have been called
+        assert len(mock_costs.estimates) >= 1
+
+    def test_print_summary_called(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        """print_summary should be called at the end."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_evaluate.get_plugin_dir',
+            lambda: PLUGIN_DIR)
+        monkeypatch.setattr('storyforge.cmd_evaluate.get_api_key', lambda: 'test-key')
+
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'act1-sc01.md'), 'w') as f:
+            f.write('Test content.')
+
+        mock_api.set_response(load_api_response_text('evaluation'))
+
+        main(['--direct', '--scene', 'act1-sc01', '--evaluator', 'line-editor'])
+
+        summary_calls = [op for op in mock_costs.operations
+                        if op.get('fn') == 'print_summary']
+        assert len(summary_calls) >= 1

--- a/tests/commands/test_cmd_hone.py
+++ b/tests/commands/test_cmd_hone.py
@@ -1,0 +1,678 @@
+"""Tests for storyforge.cmd_hone — CSV data quality tool.
+
+Covers: parse_args, main, domain resolution, diagnose mode, loop mode,
+findings-driven fixes, coaching level, dry run, scene filtering, error handling.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+from storyforge.cmd_hone import (
+    parse_args,
+    main,
+    ALL_DOMAINS,
+    PHASE1_REGISTRY,
+    PHASE2_REGISTRY,
+    PHASE3_REGISTRY,
+    ALL_REGISTRY_SUBS,
+    _resolve_domains,
+    _resolve_scene_filter,
+)
+
+from tests.commands.conftest import (
+    load_api_response,
+    load_api_response_text,
+)
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+class TestParseArgs:
+    """Exhaustive tests for argument parsing."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert args.domain is None
+        assert args.phase is None
+        assert args.scenes is None
+        assert args.act is None
+        assert args.threshold == 3.5
+        assert args.coaching is None
+        assert not args.diagnose
+        assert not args.dry_run
+        assert not args.loop
+        assert args.max_loops == 5
+        assert args.findings is None
+
+    def test_domain_flag(self):
+        args = parse_args(['--domain', 'briefs'])
+        assert args.domain == 'briefs'
+
+    def test_domain_comma_separated(self):
+        args = parse_args(['--domain', 'briefs,intent'])
+        assert args.domain == 'briefs,intent'
+
+    def test_phase_flag(self):
+        args = parse_args(['--phase', '1'])
+        assert args.phase == 1
+
+    def test_phase_2(self):
+        args = parse_args(['--phase', '2'])
+        assert args.phase == 2
+
+    def test_phase_3(self):
+        args = parse_args(['--phase', '3'])
+        assert args.phase == 3
+
+    def test_scenes_flag(self):
+        args = parse_args(['--scenes', 'act1-sc01,act1-sc02'])
+        assert args.scenes == 'act1-sc01,act1-sc02'
+
+    def test_act_flag(self):
+        args = parse_args(['--act', '2'])
+        assert args.act == '2'
+
+    def test_part_alias(self):
+        args = parse_args(['--part', '1'])
+        assert args.act == '1'
+
+    def test_threshold_flag(self):
+        args = parse_args(['--threshold', '4.0'])
+        assert args.threshold == 4.0
+
+    def test_coaching_full(self):
+        args = parse_args(['--coaching', 'full'])
+        assert args.coaching == 'full'
+
+    def test_coaching_coach(self):
+        args = parse_args(['--coaching', 'coach'])
+        assert args.coaching == 'coach'
+
+    def test_coaching_strict(self):
+        args = parse_args(['--coaching', 'strict'])
+        assert args.coaching == 'strict'
+
+    def test_coaching_invalid_exits(self):
+        with pytest.raises(SystemExit):
+            parse_args(['--coaching', 'invalid'])
+
+    def test_diagnose_flag(self):
+        args = parse_args(['--diagnose'])
+        assert args.diagnose
+
+    def test_dry_run_flag(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_loop_flag(self):
+        args = parse_args(['--loop'])
+        assert args.loop
+
+    def test_max_loops_flag(self):
+        args = parse_args(['--loop', '--max-loops', '10'])
+        assert args.max_loops == 10
+
+    def test_findings_flag(self):
+        args = parse_args(['--findings', '/tmp/findings.csv'])
+        assert args.findings == '/tmp/findings.csv'
+
+    def test_findings_default_none(self):
+        args = parse_args([])
+        assert args.findings is None
+
+    def test_combined_flags(self):
+        args = parse_args([
+            '--domain', 'briefs', '--scenes', 'act1-sc01',
+            '--coaching', 'coach', '--threshold', '4.5', '--dry-run',
+        ])
+        assert args.domain == 'briefs'
+        assert args.scenes == 'act1-sc01'
+        assert args.coaching == 'coach'
+        assert args.threshold == 4.5
+        assert args.dry_run
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+class TestConstants:
+    """Tests for domain constants."""
+
+    def test_all_domains_includes_expected(self):
+        assert 'registries' in ALL_DOMAINS
+        assert 'gaps' in ALL_DOMAINS
+        assert 'structural' in ALL_DOMAINS
+        assert 'briefs' in ALL_DOMAINS
+        assert 'intent' in ALL_DOMAINS
+
+    def test_all_domains_count(self):
+        assert len(ALL_DOMAINS) == 5
+
+    def test_phase1_registry(self):
+        assert 'characters' in PHASE1_REGISTRY
+        assert 'locations' in PHASE1_REGISTRY
+
+    def test_phase2_registry(self):
+        assert 'values' in PHASE2_REGISTRY
+        assert 'mice-threads' in PHASE2_REGISTRY
+
+    def test_phase3_registry(self):
+        assert 'knowledge' in PHASE3_REGISTRY
+        assert 'outcomes' in PHASE3_REGISTRY
+        assert 'physical-states' in PHASE3_REGISTRY
+
+    def test_all_registry_subs_is_complete(self):
+        all_phase = set(PHASE1_REGISTRY + PHASE2_REGISTRY + PHASE3_REGISTRY)
+        assert all_phase == set(ALL_REGISTRY_SUBS)
+
+
+# ============================================================================
+# _resolve_domains
+# ============================================================================
+
+class TestResolveDomains:
+    """Tests for domain resolution logic."""
+
+    def test_default_all_domains(self):
+        args = parse_args([])
+        domains = _resolve_domains(args)
+        assert domains == list(ALL_DOMAINS)
+
+    def test_single_domain(self):
+        args = parse_args(['--domain', 'briefs'])
+        domains = _resolve_domains(args)
+        assert domains == ['briefs']
+
+    def test_comma_separated_domains(self):
+        args = parse_args(['--domain', 'briefs,intent'])
+        domains = _resolve_domains(args)
+        assert domains == ['briefs', 'intent']
+
+    def test_phase_1_returns_registry_subs(self):
+        args = parse_args(['--phase', '1'])
+        domains = _resolve_domains(args)
+        assert domains == PHASE1_REGISTRY
+
+    def test_phase_2_returns_registry_subs(self):
+        args = parse_args(['--phase', '2'])
+        domains = _resolve_domains(args)
+        assert domains == PHASE2_REGISTRY
+
+    def test_phase_3_returns_registry_subs(self):
+        args = parse_args(['--phase', '3'])
+        domains = _resolve_domains(args)
+        assert domains == PHASE3_REGISTRY
+
+    def test_invalid_phase_returns_empty(self):
+        args = parse_args(['--phase', '99'])
+        domains = _resolve_domains(args)
+        assert domains == []
+
+
+# ============================================================================
+# _resolve_scene_filter
+# ============================================================================
+
+class TestResolveSceneFilter:
+    """Tests for scene filter resolution."""
+
+    def test_no_filter_returns_none(self, project_dir):
+        args = parse_args([])
+        ref_dir = os.path.join(project_dir, 'reference')
+        result = _resolve_scene_filter(args, ref_dir)
+        assert result is None
+
+    def test_scenes_flag_returns_list(self, project_dir):
+        args = parse_args(['--scenes', 'act1-sc01,act1-sc02'])
+        ref_dir = os.path.join(project_dir, 'reference')
+        result = _resolve_scene_filter(args, ref_dir)
+        assert result == ['act1-sc01', 'act1-sc02']
+
+    def test_scenes_strips_whitespace(self, project_dir):
+        args = parse_args(['--scenes', 'act1-sc01 , act1-sc02'])
+        ref_dir = os.path.join(project_dir, 'reference')
+        result = _resolve_scene_filter(args, ref_dir)
+        assert result == ['act1-sc01', 'act1-sc02']
+
+    def test_act_filter_returns_matching_scenes(self, project_dir):
+        args = parse_args(['--act', '1'])
+        ref_dir = os.path.join(project_dir, 'reference')
+        result = _resolve_scene_filter(args, ref_dir)
+        # Scenes in part 1: act1-sc01, act1-sc02, new-x1
+        assert 'act1-sc01' in result
+        assert 'act1-sc02' in result
+        assert 'new-x1' in result
+        # act2 scenes should not be included
+        assert 'act2-sc01' not in result
+
+    def test_act_filter_part_2(self, project_dir):
+        args = parse_args(['--act', '2'])
+        ref_dir = os.path.join(project_dir, 'reference')
+        result = _resolve_scene_filter(args, ref_dir)
+        assert 'act2-sc01' in result
+        assert 'act1-sc01' not in result
+
+
+# ============================================================================
+# Dry run
+# ============================================================================
+
+class TestDryRun:
+    """Tests for dry run mode — no file modifications, no API calls."""
+
+    def test_dry_run_no_api_calls(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--dry-run'])
+
+        assert mock_api.call_count == 0
+
+    def test_dry_run_no_git_operations(self, mock_api, mock_git, mock_costs,
+                                        project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--dry-run'])
+
+        assert len(mock_git.calls_for('commit_and_push')) == 0
+        assert len(mock_git.calls_for('ensure_on_branch')) == 0
+
+    def test_dry_run_briefs_shows_issues(self, mock_api, mock_git, mock_costs,
+                                          project_dir, monkeypatch, capsys):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--dry-run', '--domain', 'briefs'])
+
+        # Should complete without error; output goes to log
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# Diagnose mode
+# ============================================================================
+
+class TestDiagnoseMode:
+    """Tests for diagnose mode — read-only assessment."""
+
+    def test_diagnose_no_api_calls(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        assert mock_api.call_count == 0
+
+    def test_diagnose_no_git_operations(self, mock_api, mock_git, mock_costs,
+                                         project_dir, monkeypatch):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        assert len(mock_git.calls_for('commit_and_push')) == 0
+        assert len(mock_git.calls_for('ensure_on_branch')) == 0
+
+    def test_diagnose_outputs_structural_scores(self, mock_api, mock_git, mock_costs,
+                                                 project_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        captured = capsys.readouterr()
+        assert 'Structural Scores' in captured.out
+
+    def test_diagnose_outputs_brief_quality(self, mock_api, mock_git, mock_costs,
+                                             project_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        captured = capsys.readouterr()
+        assert 'Brief Quality' in captured.out
+
+    def test_diagnose_outputs_gaps(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        captured = capsys.readouterr()
+        assert 'Gaps' in captured.out
+
+    def test_diagnose_outputs_summary(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        captured = capsys.readouterr()
+        assert 'Summary' in captured.out
+
+    def test_diagnose_with_scene_filter(self, mock_api, mock_git, mock_costs,
+                                         project_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose', '--scenes', 'act1-sc01'])
+
+        captured = capsys.readouterr()
+        assert 'Structural Scores' in captured.out
+
+
+# ============================================================================
+# Loop mode incompatibilities
+# ============================================================================
+
+class TestLoopIncompatibilities:
+    """Tests for --loop incompatibility checks."""
+
+    def test_loop_and_diagnose_exits(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        with pytest.raises(SystemExit):
+            main(['--loop', '--diagnose'])
+
+    def test_loop_and_dry_run_exits(self, mock_api, mock_git, mock_costs,
+                                     project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        with pytest.raises(SystemExit):
+            main(['--loop', '--dry-run'])
+
+    def test_loop_and_domain_exits(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        with pytest.raises(SystemExit):
+            main(['--loop', '--domain', 'briefs'])
+
+
+# ============================================================================
+# Domain execution
+# ============================================================================
+
+class TestDomainExecution:
+    """Tests for individual domain execution."""
+
+    def test_structural_domain_is_noop(self, mock_api, mock_git, mock_costs,
+                                        project_dir, monkeypatch):
+        """Structural domain should log a message but make no API calls."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--domain', 'structural', '--dry-run'])
+
+        assert mock_api.call_count == 0
+
+    def test_unknown_domain_warns(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        """Unknown domain should log warning and continue."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        # Should not crash
+        main(['--domain', 'nonexistent', '--dry-run'])
+
+    def test_gaps_domain_dry_run(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--domain', 'gaps', '--dry-run'])
+
+        assert mock_api.call_count == 0
+        assert len(mock_git.calls_for('commit_and_push')) == 0
+
+
+# ============================================================================
+# API key requirement
+# ============================================================================
+
+class TestApiKeyCheck:
+    """Tests for API key validation."""
+
+    def test_no_api_key_exits_for_active_domains(self, mock_api, mock_git,
+                                                   mock_costs, project_dir,
+                                                   monkeypatch):
+        """Missing API key should exit when running non-dry, non-diagnose."""
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        with pytest.raises(SystemExit):
+            main(['--domain', 'briefs'])
+
+    def test_diagnose_does_not_need_api_key(self, mock_api, mock_git,
+                                              mock_costs, project_dir,
+                                              monkeypatch):
+        """Diagnose mode should work without API key."""
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        # Should not exit
+        main(['--diagnose'])
+
+    def test_dry_run_does_not_need_api_key(self, mock_api, mock_git,
+                                            mock_costs, project_dir,
+                                            monkeypatch):
+        """Dry run should work without API key."""
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--dry-run'])
+
+
+# ============================================================================
+# Coaching level
+# ============================================================================
+
+class TestCoachingLevel:
+    """Tests for coaching level adaptation."""
+
+    def test_coaching_flag_sets_env(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        # Pre-set via monkeypatch so it gets cleaned up after the test
+        monkeypatch.setenv('STORYFORGE_COACHING', '')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--coaching', 'strict', '--dry-run'])
+
+        assert os.environ.get('STORYFORGE_COACHING') == 'strict'
+
+    def test_strict_coaching_skips_api_key_check(self, mock_api, mock_git,
+                                                   mock_costs, project_dir,
+                                                   monkeypatch):
+        """Strict coaching with no API key should not exit."""
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        # Pre-set via monkeypatch so it gets cleaned up after the test
+        monkeypatch.setenv('STORYFORGE_COACHING', '')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.get_coaching_level', lambda pd: 'strict')
+
+        # strict coaching skips API key check
+        main(['--coaching', 'strict', '--dry-run'])
+
+
+# ============================================================================
+# Findings-driven mode
+# ============================================================================
+
+class TestFindingsMode:
+    """Tests for --findings flag (external findings file)."""
+
+    def test_findings_flag_parsed(self):
+        args = parse_args(['--findings', '/tmp/test-findings.csv'])
+        assert args.findings == '/tmp/test-findings.csv'
+
+    def test_findings_dry_run(self, mock_api, mock_git, mock_costs,
+                               project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        # Create a findings file
+        findings_path = os.path.join(project_dir, 'working', 'findings.csv')
+        with open(findings_path, 'w') as f:
+            f.write('scene_id|target_file|fields|guidance\n')
+            f.write('act1-sc01|scene-briefs.csv|goal|Make goal more concrete\n')
+
+        main(['--domain', 'briefs', '--findings', findings_path, '--dry-run'])
+
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# Effective findings file (annotation merge)
+# ============================================================================
+
+class TestEffectiveFindings:
+    """Tests for _effective_findings_file — annotation merging."""
+
+    def test_no_annotations_returns_findings_file(self, project_dir):
+        from storyforge.cmd_hone import _effective_findings_file
+
+        findings = '/tmp/some-file.csv'
+        result = _effective_findings_file(project_dir, findings, dry_run=False)
+        assert result == findings
+
+    def test_no_annotations_no_findings_returns_none(self, project_dir):
+        from storyforge.cmd_hone import _effective_findings_file
+
+        result = _effective_findings_file(project_dir, None, dry_run=False)
+        assert result is None
+
+
+# ============================================================================
+# Git operations
+# ============================================================================
+
+class TestGitOperations:
+    """Tests for git branch/commit in hone."""
+
+    def test_ensure_on_branch_called_for_active_run(self, mock_api, mock_git,
+                                                      mock_costs, project_dir,
+                                                      monkeypatch):
+        """Active (non-dry, non-diagnose) runs should ensure we're on a branch."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        # Run a domain that's a no-op (structural) to avoid needing real hone logic
+        main(['--domain', 'structural'])
+
+        assert len(mock_git.calls_for('ensure_on_branch')) == 1
+
+    def test_dry_run_skips_branch(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--dry-run'])
+
+        assert len(mock_git.calls_for('ensure_on_branch')) == 0
+
+    def test_diagnose_skips_branch(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--diagnose'])
+
+        assert len(mock_git.calls_for('ensure_on_branch')) == 0
+
+
+# ============================================================================
+# Intent domain
+# ============================================================================
+
+class TestIntentDomain:
+    """Tests for intent domain execution."""
+
+    def test_intent_dry_run_no_crash(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--domain', 'intent', '--dry-run'])
+
+        assert mock_api.call_count == 0
+
+    def test_intent_missing_csv_skips(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch):
+        """If scene-intent.csv is missing, intent domain should skip gracefully."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        # Remove intent CSV
+        intent_path = os.path.join(project_dir, 'reference', 'scene-intent.csv')
+        if os.path.exists(intent_path):
+            os.remove(intent_path)
+
+        main(['--domain', 'intent', '--dry-run'])
+
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# Briefs domain
+# ============================================================================
+
+class TestBriefsDomain:
+    """Tests for briefs domain execution."""
+
+    def test_briefs_dry_run_no_modifications(self, mock_api, mock_git, mock_costs,
+                                              project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--domain', 'briefs', '--dry-run'])
+
+        assert mock_api.call_count == 0
+        assert len(mock_git.calls_for('commit_and_push')) == 0
+
+    def test_briefs_with_scene_filter(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr(
+            'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
+
+        main(['--domain', 'briefs', '--scenes', 'act1-sc01', '--dry-run'])
+
+        assert mock_api.call_count == 0

--- a/tests/commands/test_cmd_hone.py
+++ b/tests/commands/test_cmd_hone.py
@@ -430,14 +430,16 @@ class TestDomainExecution:
         assert mock_api.call_count == 0
 
     def test_unknown_domain_warns(self, mock_api, mock_git, mock_costs,
-                                   project_dir, monkeypatch):
+                                   project_dir, monkeypatch, capsys):
         """Unknown domain should log warning and continue."""
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
         monkeypatch.setattr(
             'storyforge.cmd_hone.detect_project_root', lambda: project_dir)
 
-        # Should not crash
         main(['--domain', 'nonexistent', '--dry-run'])
+
+        # Should not have made any API calls for an unknown domain
+        assert mock_api.call_count == 0
 
     def test_gaps_domain_dry_run(self, mock_api, mock_git, mock_costs,
                                   project_dir, monkeypatch):

--- a/tests/commands/test_cmd_revise.py
+++ b/tests/commands/test_cmd_revise.py
@@ -538,7 +538,6 @@ class TestMainPassExecution:
 
         # Mock the revision module subprocess call
         import subprocess as sp
-        original_run = sp.run
 
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = ' '.join(str(c) for c in cmd)
@@ -550,7 +549,7 @@ class TestMainPassExecution:
                 )
             if 'storyforge.parsing' in cmd_str and 'extract-scenes' in cmd_str:
                 return sp.CompletedProcess(cmd, 0, stdout='Extracted 2 scenes', stderr='')
-            return original_run(cmd, **kwargs)
+            return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
 
@@ -584,7 +583,6 @@ class TestMainPassExecution:
         _ensure_scene_files(project_dir)
 
         import subprocess as sp
-        original_run = sp.run
 
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = ' '.join(str(c) for c in cmd)
@@ -592,7 +590,7 @@ class TestMainPassExecution:
                 return sp.CompletedProcess(cmd, 0, stdout='Prompt text', stderr='')
             if 'storyforge.parsing' in cmd_str:
                 return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
-            return original_run(cmd, **kwargs)
+            return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
         mock_api.set_response('Revised content')
@@ -627,7 +625,6 @@ class TestMainPolishMode:
         _ensure_scene_files(project_dir)
 
         import subprocess as sp
-        original_run = sp.run
 
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = ' '.join(str(c) for c in cmd)
@@ -635,7 +632,7 @@ class TestMainPolishMode:
                 return sp.CompletedProcess(cmd, 0, stdout='Polish prompt', stderr='')
             if 'storyforge.parsing' in cmd_str:
                 return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
-            return original_run(cmd, **kwargs)
+            return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
         mock_api.set_response('Polished prose')
@@ -720,7 +717,6 @@ class TestMainCostEstimation:
         _ensure_scene_files(project_dir)
 
         import subprocess as sp
-        original_run = sp.run
 
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = ' '.join(str(c) for c in cmd)
@@ -728,7 +724,7 @@ class TestMainCostEstimation:
                 return sp.CompletedProcess(cmd, 0, stdout='Prompt', stderr='')
             if 'storyforge.parsing' in cmd_str:
                 return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
-            return original_run(cmd, **kwargs)
+            return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
         mock_api.set_response('Result')
@@ -762,7 +758,6 @@ class TestMainGitWorkflow:
         _ensure_scene_files(project_dir)
 
         import subprocess as sp
-        original_run = sp.run
 
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = ' '.join(str(c) for c in cmd)
@@ -770,7 +765,7 @@ class TestMainGitWorkflow:
                 return sp.CompletedProcess(cmd, 0, stdout='Prompt', stderr='')
             if 'storyforge.parsing' in cmd_str:
                 return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
-            return original_run(cmd, **kwargs)
+            return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
 
         monkeypatch.setattr('subprocess.run', mock_subprocess_run)
         mock_api.set_response('Result')

--- a/tests/commands/test_cmd_revise.py
+++ b/tests/commands/test_cmd_revise.py
@@ -1,0 +1,867 @@
+"""Tests for storyforge.cmd_revise — revision pass execution.
+
+Covers: parse_args, main flow (polish, naturalness, structural, standard),
+dry-run mode, loop mode, scope resolution, plan generation, scene extraction,
+cost estimation, git workflow, and error handling.
+"""
+
+import csv
+import os
+import sys
+
+import pytest
+
+from storyforge.cmd_revise import (
+    CSV_PLAN_FIELDS,
+    _count_passes,
+    _generate_polish_plan,
+    _generate_naturalness_plan,
+    _read_csv_plan,
+    _read_pass_field,
+    _write_csv_plan,
+    _build_revision_config,
+    _summarize_diagnosis,
+    _detect_upstream_scenes,
+    _next_plan_number,
+    parse_args,
+    main,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _write_plan(project_dir, rows):
+    """Write a CSV revision plan into the project's working/plans/ directory."""
+    plans_dir = os.path.join(project_dir, 'working', 'plans')
+    os.makedirs(plans_dir, exist_ok=True)
+    plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+    _write_csv_plan(plan_file, rows)
+    return plan_file
+
+
+def _make_plan_rows(names=('prose-polish',), fix_location='craft', status='pending'):
+    """Create minimal plan rows for testing."""
+    rows = []
+    for i, name in enumerate(names, 1):
+        rows.append({
+            'pass': str(i),
+            'name': name,
+            'purpose': f'Test purpose for {name}',
+            'scope': 'full',
+            'targets': '',
+            'guidance': f'Test guidance for {name}',
+            'protection': '',
+            'findings': '',
+            'status': status,
+            'model_tier': 'opus',
+            'fix_location': fix_location,
+        })
+    return rows
+
+
+def _ensure_scene_files(project_dir, scene_ids=None):
+    """Ensure scene files exist for testing."""
+    if scene_ids is None:
+        scene_ids = ['act1-sc01', 'act1-sc02']
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    for sid in scene_ids:
+        path = os.path.join(scenes_dir, f'{sid}.md')
+        if not os.path.isfile(path):
+            with open(path, 'w') as f:
+                f.write(f'Scene prose for {sid}. ' * 50 + '\n')
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+class TestParseArgs:
+    """Tests for parse_args."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert not args.dry_run
+        assert not args.polish
+        assert not args.naturalness
+        assert not args.structural
+        assert not args.loop
+        assert not args.interactive
+        assert not args.skip_initial_score
+        assert not args.no_annotations
+        assert args.max_loops == 5
+        assert args.pass_num == 0
+        assert args.coaching is None
+
+    def test_dry_run(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_polish(self):
+        args = parse_args(['--polish'])
+        assert args.polish
+
+    def test_naturalness(self):
+        args = parse_args(['--naturalness'])
+        assert args.naturalness
+
+    def test_structural(self):
+        args = parse_args(['--structural'])
+        assert args.structural
+
+    def test_loop(self):
+        args = parse_args(['--polish', '--loop'])
+        assert args.loop
+        assert args.polish
+
+    def test_max_loops(self):
+        args = parse_args(['--max-loops', '10'])
+        assert args.max_loops == 10
+
+    def test_max_loops_default(self):
+        args = parse_args([])
+        assert args.max_loops == 5
+
+    def test_interactive(self):
+        args = parse_args(['--interactive'])
+        assert args.interactive
+
+    def test_interactive_short(self):
+        args = parse_args(['-i'])
+        assert args.interactive
+
+    def test_coaching_full(self):
+        args = parse_args(['--coaching', 'full'])
+        assert args.coaching == 'full'
+
+    def test_coaching_coach(self):
+        args = parse_args(['--coaching', 'coach'])
+        assert args.coaching == 'coach'
+
+    def test_coaching_strict(self):
+        args = parse_args(['--coaching', 'strict'])
+        assert args.coaching == 'strict'
+
+    def test_coaching_invalid(self):
+        with pytest.raises(SystemExit):
+            parse_args(['--coaching', 'invalid'])
+
+    def test_pass_num(self):
+        args = parse_args(['3'])
+        assert args.pass_num == 3
+
+    def test_pass_num_default(self):
+        args = parse_args([])
+        assert args.pass_num == 0
+
+    def test_skip_initial_score(self):
+        args = parse_args(['--skip-initial-score'])
+        assert args.skip_initial_score
+
+    def test_no_annotations(self):
+        args = parse_args(['--no-annotations'])
+        assert args.no_annotations
+
+    def test_polish_loop_combination(self):
+        args = parse_args(['--polish', '--loop', '--max-loops', '3'])
+        assert args.polish
+        assert args.loop
+        assert args.max_loops == 3
+
+    def test_naturalness_with_coaching(self):
+        args = parse_args(['--naturalness', '--coaching', 'strict'])
+        assert args.naturalness
+        assert args.coaching == 'strict'
+
+    def test_polish_dry_run(self):
+        args = parse_args(['--polish', '--dry-run'])
+        assert args.polish
+        assert args.dry_run
+
+
+# ============================================================================
+# CSV plan helpers
+# ============================================================================
+
+class TestCsvPlanHelpers:
+    """Tests for CSV plan reading and writing."""
+
+    def test_write_and_read_plan(self, tmp_path):
+        plan_file = str(tmp_path / 'plan.csv')
+        rows = _make_plan_rows(('pass-a', 'pass-b'))
+        _write_csv_plan(plan_file, rows)
+
+        read_back = _read_csv_plan(plan_file)
+        assert len(read_back) == 2
+        assert read_back[0]['name'] == 'pass-a'
+        assert read_back[1]['name'] == 'pass-b'
+
+    def test_read_nonexistent_plan(self):
+        result = _read_csv_plan('/nonexistent/path/plan.csv')
+        assert result == []
+
+    def test_count_passes(self):
+        rows = _make_plan_rows(('a', 'b', 'c'))
+        assert _count_passes(rows) == 3
+
+    def test_count_passes_empty(self):
+        assert _count_passes([]) == 0
+
+    def test_read_pass_field(self):
+        rows = _make_plan_rows(('pass-a', 'pass-b'))
+        assert _read_pass_field(rows, 1, 'name') == 'pass-a'
+        assert _read_pass_field(rows, 2, 'name') == 'pass-b'
+
+    def test_read_pass_field_out_of_range(self):
+        rows = _make_plan_rows(('pass-a',))
+        assert _read_pass_field(rows, 5, 'name') == ''
+
+    def test_next_plan_number_empty_dir(self, tmp_path):
+        assert _next_plan_number(str(tmp_path)) == 1
+
+    def test_next_plan_number_with_existing(self, tmp_path):
+        (tmp_path / 'revision-plan-1.csv').touch()
+        (tmp_path / 'revision-plan-3.csv').touch()
+        assert _next_plan_number(str(tmp_path)) == 4
+
+    def test_next_plan_number_nonexistent_dir(self, tmp_path):
+        assert _next_plan_number(str(tmp_path / 'does-not-exist')) == 1
+
+
+# ============================================================================
+# Plan generation
+# ============================================================================
+
+class TestPlanGeneration:
+    """Tests for auto-generated revision plans."""
+
+    def test_generate_polish_plan(self, project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+        plans_dir = os.path.join(project_dir, 'working', 'plans')
+        os.makedirs(plans_dir, exist_ok=True)
+        plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+
+        rows = _generate_polish_plan(plan_file, project_dir)
+        assert len(rows) == 1
+        assert rows[0]['name'] == 'prose-polish'
+        assert rows[0]['fix_location'] == 'craft'
+        assert rows[0]['status'] == 'pending'
+        # Plan file should be written
+        assert os.path.isfile(plan_file) or os.path.islink(plan_file)
+
+    def test_generate_naturalness_plan(self, project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+        plans_dir = os.path.join(project_dir, 'working', 'plans')
+        os.makedirs(plans_dir, exist_ok=True)
+        plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+
+        rows = _generate_naturalness_plan(plan_file, project_dir)
+        assert len(rows) == 3
+        assert rows[0]['name'] == 'tricolon-parallelism'
+        assert rows[1]['name'] == 'em-dash-antithesis'
+        assert rows[2]['name'] == 'ai-vocabulary-hedging'
+        for row in rows:
+            assert row['fix_location'] == 'craft'
+            assert row['status'] == 'pending'
+            assert row['model_tier'] == 'opus'
+
+
+# ============================================================================
+# Revision config builder
+# ============================================================================
+
+class TestBuildRevisionConfig:
+    """Tests for _build_revision_config."""
+
+    def test_empty_plan_row(self):
+        row = {f: '' for f in CSV_PLAN_FIELDS}
+        assert _build_revision_config(row) == ''
+
+    def test_with_guidance(self):
+        row = {f: '' for f in CSV_PLAN_FIELDS}
+        row['guidance'] = 'Focus on tightening'
+        result = _build_revision_config(row)
+        assert 'guidance: Focus on tightening' in result
+
+    def test_with_extra(self):
+        row = {f: '' for f in CSV_PLAN_FIELDS}
+        row['guidance'] = 'test guidance'
+        result = _build_revision_config(row, extra={'rationale': 'test rationale'})
+        assert 'guidance: test guidance' in result
+        assert 'rationale: test rationale' in result
+
+    def test_multiline_guidance(self):
+        row = {f: '' for f in CSV_PLAN_FIELDS}
+        row['guidance'] = 'line1\nline2'
+        result = _build_revision_config(row)
+        assert 'guidance: |-' in result
+
+
+# ============================================================================
+# Diagnosis helpers
+# ============================================================================
+
+class TestDiagnosisHelpers:
+    """Tests for diagnosis summarization and upstream detection."""
+
+    def test_summarize_diagnosis_empty(self):
+        summary = _summarize_diagnosis([])
+        assert summary['high_count'] == 0
+        assert summary['medium_count'] == 0
+        assert summary['overall_avg'] == 0.0
+
+    def test_summarize_diagnosis_with_data(self):
+        rows = [
+            {'priority': 'high', 'scale': 'scene', 'principle': 'voice',
+             'avg_score': '3.5', 'worst_items': 'act1-sc01'},
+            {'priority': 'medium', 'scale': 'scene', 'principle': 'pacing',
+             'avg_score': '4.0', 'worst_items': 'act1-sc02'},
+            {'priority': 'low', 'scale': 'manuscript', 'principle': 'structure',
+             'avg_score': '2.0', 'worst_items': ''},
+        ]
+        summary = _summarize_diagnosis(rows)
+        assert summary['high_count'] == 1
+        assert summary['medium_count'] == 1
+        assert summary['high_principles'] == ['voice']
+        assert summary['medium_principles'] == ['pacing']
+        # Only scene-scale rows contribute to average
+        assert summary['overall_avg'] == pytest.approx(3.75)
+
+    def test_detect_upstream_scenes_empty(self):
+        result = _detect_upstream_scenes('/tmp', [])
+        assert result == []
+
+    def test_detect_upstream_scenes_with_brief_cause(self):
+        rows = [
+            {'root_cause': 'brief', 'worst_items': 'act1-sc01;act1-sc02'},
+            {'root_cause': 'craft', 'worst_items': 'act2-sc01'},
+        ]
+        result = _detect_upstream_scenes('/tmp', rows)
+        assert result == ['act1-sc01', 'act1-sc02']
+
+    def test_detect_upstream_scenes_no_brief(self):
+        rows = [
+            {'root_cause': 'craft', 'worst_items': 'act1-sc01'},
+        ]
+        result = _detect_upstream_scenes('/tmp', rows)
+        assert result == []
+
+
+# ============================================================================
+# main() -- dry run mode
+# ============================================================================
+
+class TestMainDryRun:
+    """Tests for main() in dry-run mode."""
+
+    def test_polish_dry_run(self, mock_api, mock_git, mock_costs, project_dir,
+                            monkeypatch, capsys):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        main(['--polish', '--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert 'prose-polish' in captured.out
+        # No API calls in dry run
+        assert mock_api.call_count == 0
+
+    def test_existing_plan_dry_run(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch, capsys):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        # Write a CSV plan
+        rows = _make_plan_rows(('tightening', 'deepening'))
+        _write_plan(project_dir, rows)
+
+        main(['--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert 'tightening' in captured.out
+        assert mock_api.call_count == 0
+
+    def test_naturalness_dry_run(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch, capsys):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        main(['--naturalness', '--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert 'tricolon-parallelism' in captured.out
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# main() -- validation errors
+# ============================================================================
+
+class TestMainValidation:
+    """Tests for main() validation and error paths."""
+
+    def test_mutually_exclusive_modes(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        with pytest.raises(SystemExit):
+            main(['--polish', '--naturalness'])
+
+    def test_loop_requires_polish(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        with pytest.raises(SystemExit):
+            main(['--loop'])
+
+    def test_loop_incompatible_with_dry_run(self, mock_api, mock_git,
+                                             mock_costs, project_dir,
+                                             monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        with pytest.raises(SystemExit):
+            main(['--polish', '--loop', '--dry-run'])
+
+    def test_loop_incompatible_with_interactive(self, mock_api, mock_git,
+                                                 mock_costs, project_dir,
+                                                 monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        with pytest.raises(SystemExit):
+            main(['--polish', '--loop', '--interactive'])
+
+    def test_skip_initial_score_requires_loop(self, mock_api, mock_git,
+                                               mock_costs, project_dir,
+                                               monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        with pytest.raises(SystemExit):
+            main(['--skip-initial-score'])
+
+    def test_no_plan_file_exits(self, mock_api, mock_git, mock_costs,
+                                 project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        # Remove the legacy YAML plan if it exists
+        yaml_plan = os.path.join(project_dir, 'working', 'plans', 'revision-plan.yaml')
+        if os.path.isfile(yaml_plan):
+            os.remove(yaml_plan)
+        with pytest.raises(SystemExit):
+            main([])
+
+    def test_no_api_key_exits(self, mock_api, mock_git, mock_costs,
+                               project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+        # Remove API key
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        # Restore get_api_key to raise on missing key
+        monkeypatch.setattr('storyforge.cmd_revise.get_api_key',
+                            lambda: (_ for _ in ()).throw(RuntimeError('ANTHROPIC_API_KEY not set')))
+
+        # Write a plan so we get past plan validation
+        rows = _make_plan_rows(('test-pass',))
+        _write_plan(project_dir, rows)
+
+        with pytest.raises(SystemExit):
+            main([])
+
+    def test_all_passes_completed_returns(self, mock_api, mock_git, mock_costs,
+                                           project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        # Write a plan with all passes completed
+        rows = _make_plan_rows(('pass-a',), status='completed')
+        _write_plan(project_dir, rows)
+
+        # Should return without error (no more work to do)
+        main([])
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# main() -- pass execution (standard prose revision)
+# ============================================================================
+
+class TestMainPassExecution:
+    """Tests for main() executing revision passes."""
+
+    def test_executes_craft_pass(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        # Write a craft revision plan
+        rows = _make_plan_rows(('prose-polish',), fix_location='craft')
+        plan_file = _write_plan(project_dir, rows)
+
+        _ensure_scene_files(project_dir)
+
+        # Mock the revision module subprocess call
+        import subprocess as sp
+        original_run = sp.run
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.revision' in cmd_str and 'build-prompt' in cmd_str:
+                return sp.CompletedProcess(
+                    cmd, 0,
+                    stdout='Revision prompt for prose-polish pass.',
+                    stderr='',
+                )
+            if 'storyforge.parsing' in cmd_str and 'extract-scenes' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='Extracted 2 scenes', stderr='')
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+
+        # Set up the API response
+        mock_api.set_response(
+            '=== SCENE: act1-sc01 ===\nRevised prose.\n=== END SCENE: act1-sc01 ==='
+        )
+
+        main([])
+
+        # API should have been called for the revision
+        assert mock_api.call_count >= 1
+        # Git should have committed
+        assert mock_git.call_count >= 1
+
+    def test_start_from_pass_num(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        # Two-pass plan: first already completed
+        rows = _make_plan_rows(('pass-a', 'pass-b'), fix_location='craft')
+        rows[0]['status'] = 'completed'
+        _write_plan(project_dir, rows)
+        _ensure_scene_files(project_dir)
+
+        import subprocess as sp
+        original_run = sp.run
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.revision' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='Prompt text', stderr='')
+            if 'storyforge.parsing' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+        mock_api.set_response('Revised content')
+
+        # Start from pass 2 explicitly
+        main(['2'])
+
+        # Only one API call (for pass 2)
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) >= 1
+
+
+# ============================================================================
+# main() -- polish mode (non-dry-run)
+# ============================================================================
+
+class TestMainPolishMode:
+    """Tests for main() in polish mode with API execution."""
+
+    def test_polish_generates_plan_and_executes(self, mock_api, mock_git,
+                                                 mock_costs, project_dir,
+                                                 monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        _ensure_scene_files(project_dir)
+
+        import subprocess as sp
+        original_run = sp.run
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.revision' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='Polish prompt', stderr='')
+            if 'storyforge.parsing' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+        mock_api.set_response('Polished prose')
+
+        main(['--polish'])
+
+        # Plan should have been generated
+        plan_file = os.path.join(project_dir, 'working', 'plans', 'revision-plan.csv')
+        assert os.path.isfile(plan_file) or os.path.islink(plan_file)
+
+        # API should have been called
+        assert mock_api.call_count >= 1
+
+        # Git branch created and commits made
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+
+
+# ============================================================================
+# main() -- structural mode dry run
+# ============================================================================
+
+class TestMainStructuralMode:
+    """Tests for structural mode (CSV-only revision)."""
+
+    def test_structural_requires_proposals_file(self, mock_api, mock_git,
+                                                 mock_costs, project_dir,
+                                                 monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        # No structural-proposals.csv exists
+        with pytest.raises(SystemExit):
+            main(['--structural'])
+
+    def test_structural_dry_run_with_proposals(self, mock_api, mock_git,
+                                                mock_costs, project_dir,
+                                                monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+        # Create proposals file
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        os.makedirs(scores_dir, exist_ok=True)
+        proposals_file = os.path.join(scores_dir, 'structural-proposals.csv')
+        with open(proposals_file, 'w') as f:
+            f.write('dimension|target|fix_location|rationale|change|status\n')
+            f.write('pacing|act1-sc01|structural|Needs faster pacing|Speed up|pending\n')
+
+        main(['--structural', '--dry-run'])
+
+        captured = capsys.readouterr()
+        assert 'DRY RUN' in captured.out
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# main() -- cost estimation
+# ============================================================================
+
+class TestMainCostEstimation:
+    """Tests for cost estimation during revision."""
+
+    def test_cost_estimate_called(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        rows = _make_plan_rows(('test-pass',))
+        _write_plan(project_dir, rows)
+        _ensure_scene_files(project_dir)
+
+        import subprocess as sp
+        original_run = sp.run
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.revision' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='Prompt', stderr='')
+            if 'storyforge.parsing' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+        mock_api.set_response('Result')
+
+        main([])
+
+        # Cost estimation should have been called
+        assert len(mock_costs.estimates) >= 1
+
+
+# ============================================================================
+# main() -- git workflow
+# ============================================================================
+
+class TestMainGitWorkflow:
+    """Tests for git branch/PR creation during revision."""
+
+    def test_creates_branch_and_pr(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        plugin_dir = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.dirname(
+                os.path.dirname(__file__)))))
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: plugin_dir)
+
+        rows = _make_plan_rows(('test-pass',))
+        _write_plan(project_dir, rows)
+        _ensure_scene_files(project_dir)
+
+        import subprocess as sp
+        original_run = sp.run
+
+        def mock_subprocess_run(cmd, **kwargs):
+            cmd_str = ' '.join(str(c) for c in cmd)
+            if 'storyforge.revision' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='Prompt', stderr='')
+            if 'storyforge.parsing' in cmd_str:
+                return sp.CompletedProcess(cmd, 0, stdout='', stderr='')
+            return original_run(cmd, **kwargs)
+
+        monkeypatch.setattr('subprocess.run', mock_subprocess_run)
+        mock_api.set_response('Result')
+
+        main([])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+        assert branch_calls[0][1] == 'revise'
+
+        pr_calls = mock_git.calls_for('create_draft_pr')
+        assert len(pr_calls) >= 1
+
+    def test_no_branch_in_dry_run(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_revise.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.setattr('storyforge.cmd_revise.get_plugin_dir',
+                            lambda: os.path.dirname(os.path.dirname(
+                                os.path.dirname(os.path.dirname(
+                                    os.path.dirname(__file__))))))
+
+        rows = _make_plan_rows(('test-pass',))
+        _write_plan(project_dir, rows)
+
+        main(['--dry-run'])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) == 0
+
+
+# ============================================================================
+# _estimate_avg_words
+# ============================================================================
+
+class TestEstimateAvgWords:
+    """Tests for _estimate_avg_words."""
+
+    def test_from_metadata_csv(self, project_dir):
+        from storyforge.cmd_revise import _estimate_avg_words
+        # Update metadata to have word counts
+        meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        with open(meta_csv) as f:
+            content = f.read()
+        # Replace all '0' word counts with real values
+        content = content.replace('|0|2500', '|2500|2500')
+        content = content.replace('|0|3000', '|3000|3000')
+        content = content.replace('|0|1500', '|1500|1500')
+        content = content.replace('|0|2800', '|2800|2800')
+        content = content.replace('|0|2000', '|2000|2000')
+        content = content.replace('|0|2200', '|2200|2200')
+        with open(meta_csv, 'w') as f:
+            f.write(content)
+
+        avg, count = _estimate_avg_words(project_dir)
+        assert avg > 0
+        assert count > 0
+
+    def test_fallback_to_scene_files(self, project_dir):
+        from storyforge.cmd_revise import _estimate_avg_words
+        _ensure_scene_files(project_dir)
+        avg, count = _estimate_avg_words(project_dir)
+        assert avg > 0
+        assert count > 0
+
+
+# ============================================================================
+# _register_new_scenes
+# ============================================================================
+
+class TestRegisterNewScenes:
+    """Tests for new scene registration during revision."""
+
+    def test_registers_new_scene(self, project_dir):
+        from storyforge.cmd_revise import _register_new_scenes
+
+        # Create a new scene file
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        with open(os.path.join(scenes_dir, 'new-scene-x.md'), 'w') as f:
+            f.write('New scene prose here.\n')
+
+        _register_new_scenes(project_dir, 'NEW:new-scene-x;act1-sc01', 'test-pass')
+
+        # Check the scene was registered in metadata
+        meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        with open(meta_csv) as f:
+            content = f.read()
+        assert 'new-scene-x' in content
+
+    def test_no_new_prefix_skips(self, project_dir):
+        from storyforge.cmd_revise import _register_new_scenes
+        _register_new_scenes(project_dir, 'act1-sc01;act1-sc02', 'test-pass')
+        # Should not error and not change anything significant

--- a/tests/commands/test_cmd_score.py
+++ b/tests/commands/test_cmd_score.py
@@ -1,0 +1,661 @@
+"""Tests for storyforge score — principled craft scoring.
+
+Covers parse_args, main orchestration with mocked API/git/costs,
+score parsing, targeted principles, deterministic scoring,
+fidelity scoring, dry-run mode, and batch vs direct API paths.
+"""
+
+import json
+import os
+
+import pytest
+
+from storyforge.cmd_score import (
+    parse_args,
+    main,
+    DETERMINISTIC_PRINCIPLES,
+    _resolve_filter,
+    _determine_cycle,
+    _avg_word_count,
+    _build_scene_prompt,
+)
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+
+class TestParseArgs:
+    """Test CLI argument parsing for the score command."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert not args.dry_run
+        assert not args.interactive
+        assert not args.direct
+        assert not args.deep
+        assert args.scenes is None
+        assert args.act is None
+        assert args.from_seq is None
+        assert args.principles is None
+        assert not args.deterministic
+        assert args.parallel == 6  # default
+
+    def test_dry_run(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_interactive_long(self):
+        args = parse_args(['--interactive'])
+        assert args.interactive
+
+    def test_interactive_short(self):
+        args = parse_args(['-i'])
+        assert args.interactive
+
+    def test_direct(self):
+        args = parse_args(['--direct'])
+        assert args.direct
+
+    def test_deep(self):
+        args = parse_args(['--deep'])
+        assert args.deep
+
+    def test_direct_deep(self):
+        args = parse_args(['--direct', '--deep'])
+        assert args.direct
+        assert args.deep
+
+    def test_scenes_flag(self):
+        args = parse_args(['--scenes', 'scene-1,scene-2'])
+        assert args.scenes == 'scene-1,scene-2'
+
+    def test_act_flag(self):
+        args = parse_args(['--act', '2'])
+        assert args.act == '2'
+
+    def test_from_seq_flag(self):
+        args = parse_args(['--from-seq', '5'])
+        assert args.from_seq == '5'
+
+    def test_from_seq_range(self):
+        args = parse_args(['--from-seq', '3-7'])
+        assert args.from_seq == '3-7'
+
+    def test_principles_single(self):
+        args = parse_args(['--principles', 'prose_naturalness'])
+        assert args.principles == 'prose_naturalness'
+
+    def test_principles_comma_separated(self):
+        args = parse_args(['--principles', 'prose_naturalness,voice_consistency'])
+        assert args.principles == 'prose_naturalness,voice_consistency'
+
+    def test_deterministic_flag(self):
+        args = parse_args(['--deterministic'])
+        assert args.deterministic
+
+    def test_parallel_flag(self):
+        args = parse_args(['--parallel', '4'])
+        assert args.parallel == 4
+
+    def test_parallel_env_default(self, monkeypatch):
+        monkeypatch.setenv('STORYFORGE_SCORE_PARALLEL', '12')
+        # The default reads from env at parse time, but since the module
+        # already loaded the default, we test with explicit flag instead
+        args = parse_args(['--parallel', '12'])
+        assert args.parallel == 12
+
+    def test_combined_flags(self):
+        args = parse_args(['--dry-run', '--direct', '--scenes', 'act1-sc01',
+                           '--principles', 'prose_repetition'])
+        assert args.dry_run
+        assert args.direct
+        assert args.scenes == 'act1-sc01'
+        assert args.principles == 'prose_repetition'
+
+
+# ============================================================================
+# DETERMINISTIC_PRINCIPLES
+# ============================================================================
+
+
+class TestDeterministicPrinciples:
+    """Test the deterministic principles constant."""
+
+    def test_prose_repetition_is_deterministic(self):
+        assert 'prose_repetition' in DETERMINISTIC_PRINCIPLES
+
+    def test_is_frozenset(self):
+        assert isinstance(DETERMINISTIC_PRINCIPLES, frozenset)
+
+
+# ============================================================================
+# _resolve_filter
+# ============================================================================
+
+
+class TestResolveFilter:
+    """Test filter resolution from CLI args."""
+
+    def test_scenes_filter(self):
+        args = parse_args(['--scenes', 'a,b,c'])
+        mode, value, _ = _resolve_filter(args)
+        assert mode == 'scenes'
+        assert value == 'a,b,c'
+
+    def test_act_filter(self):
+        args = parse_args(['--act', '2'])
+        mode, value, _ = _resolve_filter(args)
+        assert mode == 'act'
+        assert value == '2'
+
+    def test_from_seq_filter(self):
+        args = parse_args(['--from-seq', '5'])
+        mode, value, _ = _resolve_filter(args)
+        assert mode == 'from_seq'
+        assert value == '5'
+
+    def test_no_filter(self):
+        args = parse_args([])
+        mode, value, _ = _resolve_filter(args)
+        assert mode == 'all'
+        assert value is None
+
+
+# ============================================================================
+# _determine_cycle
+# ============================================================================
+
+
+class TestDetermineCycle:
+    """Test scoring cycle determination."""
+
+    def test_first_cycle_no_history(self, project_dir):
+        cycle = _determine_cycle(project_dir)
+        assert cycle >= 1
+
+    def test_increments_past_existing_cycles(self, project_dir):
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        os.makedirs(os.path.join(scores_dir, 'cycle-1'), exist_ok=True)
+        os.makedirs(os.path.join(scores_dir, 'cycle-2'), exist_ok=True)
+        cycle = _determine_cycle(project_dir)
+        assert cycle >= 3
+
+    def test_handles_empty_scores_dir(self, project_dir):
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        os.makedirs(scores_dir, exist_ok=True)
+        cycle = _determine_cycle(project_dir)
+        assert cycle >= 1
+
+
+# ============================================================================
+# _avg_word_count
+# ============================================================================
+
+
+class TestAvgWordCount:
+    """Test average word count calculation."""
+
+    def test_from_metadata(self, project_dir):
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        # The fixture has word_count values in CSV; some are 0
+        avg = _avg_word_count(meta, ['act1-sc01'], scenes_dir)
+        # Should return a positive number (either from CSV or file fallback)
+        assert avg > 0
+
+    def test_fallback_to_file_measurement(self, project_dir):
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        # Zero out all word_count values to force file fallback
+        from storyforge.csv_cli import update_field
+        from storyforge.scene_filter import build_scene_list
+        all_ids = build_scene_list(meta)
+        for sid in all_ids:
+            update_field(meta, sid, 'word_count', '0')
+        avg = _avg_word_count(meta, all_ids, scenes_dir)
+        assert avg > 0
+
+
+# ============================================================================
+# _build_scene_prompt
+# ============================================================================
+
+
+class TestBuildScenePrompt:
+    """Test evaluation prompt construction."""
+
+    def test_builds_prompt_with_template(self, project_dir):
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        intent = os.path.join(project_dir, 'reference', 'scene-intent.csv')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        template = (
+            'Scene: {{SCENE_TITLE}} ({{SCENE_POV}})\n'
+            'Function: {{SCENE_FUNCTION}}\n'
+            'Emotional arc: {{SCENE_EMOTIONAL_ARC}}\n'
+            'Criteria:\n{{EVALUATION_CRITERIA}}\n'
+            'Weights:\n{{WEIGHTED_PRINCIPLES}}\n'
+            'Count: {{PRINCIPLE_COUNT}}\n'
+            'Text:\n{{SCENE_TEXT}}'
+        )
+        prompt = _build_scene_prompt(
+            'act1-sc01', template, 'criteria here', 'weights here',
+            meta, intent, scenes_dir,
+        )
+        assert 'The Finest Cartographer' in prompt
+        assert 'Dorren Hayle' in prompt
+        assert 'criteria here' in prompt
+        assert 'weights here' in prompt
+
+    def test_handles_missing_scene_file(self, project_dir):
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        intent = os.path.join(project_dir, 'reference', 'scene-intent.csv')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        template = '{{SCENE_TITLE}}|{{SCENE_TEXT}}'
+        prompt = _build_scene_prompt(
+            'nonexistent-scene', template, '', '',
+            meta, intent, scenes_dir,
+        )
+        # Should still return a prompt (with empty scene text)
+        assert prompt is not None
+
+    def test_numbers_lines_in_scene_text(self, project_dir):
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        intent = os.path.join(project_dir, 'reference', 'scene-intent.csv')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        template = '{{SCENE_TEXT}}'
+        prompt = _build_scene_prompt(
+            'act1-sc01', template, '', '',
+            meta, intent, scenes_dir,
+        )
+        # Lines should be numbered
+        assert '1: ' in prompt
+
+
+# ============================================================================
+# main — dry run
+# ============================================================================
+
+
+class TestMainDryRun:
+    """Test main() in dry-run mode."""
+
+    def test_dry_run_no_api_calls(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # Need scene files to exist for scoring
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+        # invoke_to_file should not be called in dry-run
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0
+
+    def test_dry_run_does_not_create_pr(self, mock_api, mock_git, mock_costs,
+                                        project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+        pr_calls = mock_git.calls_for('create_draft_pr')
+        assert len(pr_calls) == 0
+
+    def test_dry_run_deterministic_no_api(self, mock_api, mock_git, mock_costs,
+                                          project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--dry-run', '--deterministic', '--scenes', 'act1-sc01'])
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# main — deterministic scoring
+# ============================================================================
+
+
+class TestMainDeterministic:
+    """Test deterministic scoring (no API calls needed)."""
+
+    def test_deterministic_skips_api(self, mock_api, mock_git, mock_costs,
+                                     project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # Deterministic mode does not need ANTHROPIC_API_KEY
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+        main(['--deterministic', '--scenes', 'act1-sc01'])
+
+        # No API calls should be made
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0
+        batch_calls = mock_api.calls_for('submit_batch')
+        assert len(batch_calls) == 0
+
+    def test_deterministic_creates_branch(self, mock_api, mock_git, mock_costs,
+                                          project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--deterministic', '--scenes', 'act1-sc01'])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+
+    def test_deterministic_commits_results(self, mock_api, mock_git, mock_costs,
+                                           project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--deterministic', '--scenes', 'act1-sc01'])
+
+        commit_calls = mock_git.calls_for('commit_and_push')
+        assert len(commit_calls) >= 1
+
+    def test_deterministic_writes_repetition_scores(self, mock_api, mock_git,
+                                                     mock_costs, project_dir,
+                                                     monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--deterministic', '--scenes', 'act1-sc01'])
+
+        # Should create cycle directory with scores
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        cycle_dirs = [d for d in os.listdir(scores_dir)
+                      if d.startswith('cycle-') and
+                      os.path.isdir(os.path.join(scores_dir, d))]
+        assert len(cycle_dirs) >= 1
+
+
+# ============================================================================
+# main — targeted principles
+# ============================================================================
+
+
+class TestMainTargetedPrinciples:
+    """Test --principles flag for targeted scoring."""
+
+    def test_targeted_principles_dry_run(self, mock_api, mock_git, mock_costs,
+                                         project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # prose_repetition is deterministic, so the whole run is deterministic
+        main(['--dry-run', '--principles', 'prose_repetition',
+              '--scenes', 'act1-sc01'])
+        assert mock_api.call_count == 0
+
+    def test_deterministic_principle_skips_llm(self, mock_api, mock_git,
+                                               mock_costs, project_dir,
+                                               monkeypatch):
+        """When all requested principles are deterministic, LLM is skipped."""
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--principles', 'prose_repetition', '--scenes', 'act1-sc01'])
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0
+
+    def test_deterministic_overrides_principles(self, mock_api, mock_git,
+                                                mock_costs, project_dir,
+                                                monkeypatch):
+        """--deterministic takes precedence over --principles."""
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--deterministic', '--principles', 'voice_consistency',
+              '--scenes', 'act1-sc01'])
+        # Should run deterministic (prose_repetition), not voice_consistency
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0
+
+
+# ============================================================================
+# main — direct mode
+# ============================================================================
+
+
+class TestMainDirect:
+    """Test main() in direct API mode with mocked dependencies."""
+
+    def _scoring_response(self):
+        """Return a mock scoring response in expected format."""
+        return (
+            'principle|score|deficits|evidence_lines\n'
+            'prose_naturalness|4|Some stiff phrasing|12,45\n'
+            'voice_consistency|5|None|—\n'
+            'dialogue_craft|3|Generic dialogue beats|23,67\n'
+        )
+
+    def test_direct_mode_calls_api(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        # Should call invoke_to_file for scene scoring at minimum
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) >= 1
+
+    def test_direct_creates_cycle_dir(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        cycle_dirs = [d for d in os.listdir(scores_dir)
+                      if d.startswith('cycle-') and
+                      os.path.isdir(os.path.join(scores_dir, d))]
+        assert len(cycle_dirs) >= 1
+
+    def test_direct_creates_branch_and_pr(self, mock_api, mock_git, mock_costs,
+                                          project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+        pr_calls = mock_git.calls_for('create_draft_pr')
+        assert len(pr_calls) >= 1
+
+    def test_direct_commits_results(self, mock_api, mock_git, mock_costs,
+                                     project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        commit_calls = mock_git.calls_for('commit_and_push')
+        assert len(commit_calls) >= 1
+
+
+# ============================================================================
+# main — batch mode
+# ============================================================================
+
+
+class TestMainBatch:
+    """Test main() in batch API mode."""
+
+    def _scoring_response(self):
+        return (
+            'principle|score|deficits|evidence_lines\n'
+            'prose_naturalness|4|Some stiff phrasing|12,45\n'
+            'voice_consistency|5|None|—\n'
+        )
+
+    def test_batch_mode_submits_batch(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--scenes', 'act1-sc01'])  # default mode is batch
+
+        batch_calls = mock_api.calls_for('submit_batch')
+        assert len(batch_calls) >= 1
+
+    def test_batch_polls_for_results(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--scenes', 'act1-sc01'])
+
+        poll_calls = mock_api.calls_for('poll_batch')
+        assert len(poll_calls) >= 1
+
+    def test_batch_downloads_results(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response(self._scoring_response())
+
+        main(['--scenes', 'act1-sc01'])
+
+        dl_calls = mock_api.calls_for('download_batch_results')
+        assert len(dl_calls) >= 1
+
+
+# ============================================================================
+# main — error handling
+# ============================================================================
+
+
+class TestErrorHandling:
+    """Test error cases and edge conditions."""
+
+    def test_no_api_key_exits(self, mock_api, mock_git, mock_costs,
+                              project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+        with pytest.raises(SystemExit):
+            main(['--direct', '--scenes', 'act1-sc01'])
+
+    def test_no_scene_files_exits(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # Remove all scene files
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        for f in os.listdir(scenes_dir):
+            os.remove(os.path.join(scenes_dir, f))
+
+        with pytest.raises(SystemExit):
+            main(['--direct', '--scenes', 'act1-sc01'])
+
+    def test_cost_threshold_exceeded_aborts(self, mock_api, mock_git,
+                                            mock_costs, project_dir,
+                                            monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_costs.threshold_ok = False
+
+        with pytest.raises(SystemExit):
+            main(['--direct', '--scenes', 'act1-sc01'])
+
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0
+
+
+# ============================================================================
+# main — latest symlink
+# ============================================================================
+
+
+class TestLatestSymlink:
+    """Test that the latest symlink is updated after scoring."""
+
+    def test_latest_symlink_created(self, mock_api, mock_git, mock_costs,
+                                     project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # Use deterministic mode to avoid needing API key
+        main(['--deterministic', '--scenes', 'act1-sc01'])
+
+        latest = os.path.join(project_dir, 'working', 'scores', 'latest')
+        assert os.path.islink(latest)
+        target = os.readlink(latest)
+        assert target.startswith('cycle-')
+
+
+# ============================================================================
+# main — score mode resolution
+# ============================================================================
+
+
+class TestScoreModeResolution:
+    """Test that score mode is correctly resolved from CLI flags."""
+
+    def test_default_is_batch(self, mock_api, mock_git, mock_costs,
+                               project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response('principle|score|deficits|evidence_lines\n'
+                              'voice_consistency|5|None|—\n')
+
+        main(['--scenes', 'act1-sc01'])
+
+        # Batch mode uses submit_batch
+        batch_calls = mock_api.calls_for('submit_batch')
+        assert len(batch_calls) >= 1
+
+    def test_direct_uses_invoke_to_file(self, mock_api, mock_git, mock_costs,
+                                         project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        mock_api.set_response('principle|score|deficits|evidence_lines\n'
+                              'voice_consistency|5|None|—\n')
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        # Direct mode uses invoke_to_file, not submit_batch
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) >= 1
+
+
+# ============================================================================
+# main — multi-scene scoring
+# ============================================================================
+
+
+class TestMultiSceneScoring:
+    """Test scoring multiple scenes."""
+
+    def test_scores_multiple_scenes(self, mock_api, mock_git, mock_costs,
+                                     project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        # Deterministic mode to avoid API complexity
+        main(['--deterministic', '--scenes', 'act1-sc01,act1-sc02'])
+
+        # Both scenes should be processed
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        cycle_dirs = [d for d in os.listdir(scores_dir)
+                      if d.startswith('cycle-') and
+                      os.path.isdir(os.path.join(scores_dir, d))]
+        assert len(cycle_dirs) >= 1
+
+    def test_dry_run_lists_all_scenes(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch, capsys):
+        monkeypatch.setattr('storyforge.cmd_score.detect_project_root',
+                            lambda: project_dir)
+        main(['--dry-run', '--scenes', 'act1-sc01,act1-sc02'])
+        # Should succeed without errors
+        assert mock_api.call_count == 0

--- a/tests/commands/test_cmd_write.py
+++ b/tests/commands/test_cmd_write.py
@@ -436,18 +436,21 @@ class TestScopeFiltering:
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
         monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
                             lambda: project_dir)
+
+        # Write a marker to act-1 scene file so we can verify it wasn't touched
+        act1_scene = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        os.makedirs(os.path.dirname(act1_scene), exist_ok=True)
+        with open(act1_scene, 'w') as f:
+            f.write('ORIGINAL_ACT1_CONTENT')
+
         prose = ' '.join(['word'] * 200)
         mock_api.set_response(prose)
 
         main(['--direct', '--act', '2'])
 
-        # The prompts should only be for act-2 scenes, not act-1
-        for call in mock_api.calls_for('invoke_to_file'):
-            prompt = call['prompt']
-            # We cannot easily inspect which scene the prompt is for,
-            # but at minimum the API should have been called
-        # Verify act-1 scene files were not overwritten with new content
-        # (act1-sc01 has status 'briefed' in fixture but was not in scope)
+        # Verify act-1 scene file was not overwritten
+        with open(act1_scene) as f:
+            assert f.read() == 'ORIGINAL_ACT1_CONTENT'
 
     def test_scenes_filter_limits_scope(self, mock_api, mock_git, mock_costs,
                                         project_dir, monkeypatch):
@@ -486,14 +489,12 @@ class TestSkipDrafted:
         # Draft only act1-sc01 (all mode would include other scenes)
         main(['--direct', '--scenes', 'act1-sc01'])
 
-        # Single-scene mode explicitly requested -> should still draft it
-        # (filter_mode == 'scenes', not 'single' from positional)
-        # For 'scenes' filter, already-drafted is skipped.
-        # Verify original content is preserved
+        # 'scenes' filter skips already-drafted scenes.
+        # Verify original content is preserved (scene was not re-drafted)
         with open(scene_file) as f:
             content = f.read()
-        # The 'scenes' filter does NOT set filter_mode to 'single',
-        # so the scene should be skipped since it's already drafted
+        assert 'word' in content, "Original content should be preserved"
+        assert 'new' not in content, "Scene should not have been re-drafted"
 
     def test_force_redrafts_scene(self, mock_api, mock_git, mock_costs,
                                   project_dir, monkeypatch):

--- a/tests/commands/test_cmd_write.py
+++ b/tests/commands/test_cmd_write.py
@@ -1,0 +1,570 @@
+"""Tests for storyforge write — autonomous scene drafting.
+
+Covers parse_args, main orchestration with mocked API/git/costs,
+scene extraction, word count updates, dry-run mode, scope filtering,
+and error handling for missing files.
+"""
+
+import json
+import os
+
+import pytest
+
+from storyforge.cmd_write import parse_args, main, _resolve_filter, _detect_briefs
+
+
+# ============================================================================
+# parse_args
+# ============================================================================
+
+
+class TestParseArgs:
+    """Test CLI argument parsing for the write command."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        assert not args.dry_run
+        assert not args.force
+        assert not args.direct
+        assert not args.interactive
+        assert args.coaching is None
+        assert args.scenes is None
+        assert args.act is None
+        assert args.from_seq is None
+        assert args.positional == []
+
+    def test_dry_run(self):
+        args = parse_args(['--dry-run'])
+        assert args.dry_run
+
+    def test_force(self):
+        args = parse_args(['--force'])
+        assert args.force
+
+    def test_direct(self):
+        args = parse_args(['--direct'])
+        assert args.direct
+
+    def test_interactive_long(self):
+        args = parse_args(['--interactive'])
+        assert args.interactive
+
+    def test_interactive_short(self):
+        args = parse_args(['-i'])
+        assert args.interactive
+
+    def test_coaching_full(self):
+        args = parse_args(['--coaching', 'full'])
+        assert args.coaching == 'full'
+
+    def test_coaching_coach(self):
+        args = parse_args(['--coaching', 'coach'])
+        assert args.coaching == 'coach'
+
+    def test_coaching_strict(self):
+        args = parse_args(['--coaching', 'strict'])
+        assert args.coaching == 'strict'
+
+    def test_coaching_invalid(self):
+        with pytest.raises(SystemExit):
+            parse_args(['--coaching', 'invalid'])
+
+    def test_scenes_flag(self):
+        args = parse_args(['--scenes', 'scene-1,scene-2'])
+        assert args.scenes == 'scene-1,scene-2'
+
+    def test_act_flag(self):
+        args = parse_args(['--act', '2'])
+        assert args.act == '2'
+
+    def test_act_alias_part(self):
+        args = parse_args(['--part', '1'])
+        assert args.act == '1'
+
+    def test_from_seq_flag(self):
+        args = parse_args(['--from-seq', '5'])
+        assert args.from_seq == '5'
+
+    def test_from_seq_range(self):
+        args = parse_args(['--from-seq', '3-7'])
+        assert args.from_seq == '3-7'
+
+    def test_positional_single(self):
+        args = parse_args(['act1-sc01'])
+        assert args.positional == ['act1-sc01']
+
+    def test_positional_range(self):
+        args = parse_args(['act1-sc01', 'act1-sc05'])
+        assert args.positional == ['act1-sc01', 'act1-sc05']
+
+    def test_combined_flags(self):
+        args = parse_args(['--dry-run', '--force', '--direct',
+                           '--scenes', 'act1-sc01'])
+        assert args.dry_run
+        assert args.force
+        assert args.direct
+        assert args.scenes == 'act1-sc01'
+
+
+# ============================================================================
+# _resolve_filter
+# ============================================================================
+
+
+class TestResolveFilter:
+    """Test filter resolution from CLI args."""
+
+    def test_scenes_filter(self):
+        args = parse_args(['--scenes', 'a,b,c'])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'scenes'
+        assert value == 'a,b,c'
+        assert value2 is None
+
+    def test_act_filter(self):
+        args = parse_args(['--act', '2'])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'act'
+        assert value == '2'
+
+    def test_from_seq_filter(self):
+        args = parse_args(['--from-seq', '5'])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'from_seq'
+        assert value == '5'
+
+    def test_single_positional(self):
+        args = parse_args(['act1-sc01'])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'single'
+        assert value == 'act1-sc01'
+
+    def test_range_positional(self):
+        args = parse_args(['act1-sc01', 'act2-sc01'])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'range'
+        assert value == 'act1-sc01'
+        assert value2 == 'act2-sc01'
+
+    def test_no_filter(self):
+        args = parse_args([])
+        mode, value, value2 = _resolve_filter(args)
+        assert mode == 'all'
+        assert value is None
+
+
+# ============================================================================
+# _detect_briefs
+# ============================================================================
+
+
+class TestDetectBriefs:
+    """Test brief detection from project files."""
+
+    def test_briefs_detected(self, project_dir):
+        assert _detect_briefs(project_dir) is True
+
+    def test_no_briefs_file(self, project_dir):
+        briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+        os.remove(briefs_csv)
+        assert _detect_briefs(project_dir) is False
+
+    def test_empty_briefs(self, project_dir):
+        briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+        with open(briefs_csv, 'w') as f:
+            f.write('id|goal|conflict|outcome\n')
+            f.write('act1-sc01|||\n')
+        assert _detect_briefs(project_dir) is False
+
+
+# ============================================================================
+# main — dry run
+# ============================================================================
+
+
+class TestMainDryRun:
+    """Test main() in dry-run mode (no API calls, no file writes)."""
+
+    def test_dry_run_no_api_calls(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        # Scenes with status 'briefed' are pending; those with 'drafted' are
+        # skipped unless --force.  The fixture has act1-sc01 status=briefed,
+        # act1-sc02 status=briefed in scenes.csv, so they should be included.
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+        assert mock_api.call_count == 0
+
+    def test_dry_run_does_not_create_branch(self, mock_api, mock_git,
+                                            mock_costs, project_dir,
+                                            monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) == 0
+
+    def test_dry_run_does_not_write_scene_files(self, mock_api, mock_git,
+                                                 mock_costs, project_dir,
+                                                 monkeypatch):
+        """In dry-run, existing scene files should not be overwritten."""
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        original = ''
+        if os.path.isfile(scene_file):
+            with open(scene_file) as f:
+                original = f.read()
+
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+
+        if original:
+            with open(scene_file) as f:
+                assert f.read() == original
+
+
+# ============================================================================
+# main — direct mode happy path
+# ============================================================================
+
+
+class TestMainDirect:
+    """Test main() in direct API mode with mocked dependencies."""
+
+    def _setup_pending_scene(self, project_dir, scene_id):
+        """Ensure a scene is in 'briefed' status so it will be drafted."""
+        from storyforge.csv_cli import update_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        update_field(meta, scene_id, 'status', 'briefed')
+        # Remove existing scene file so it is treated as pending
+        scene_file = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+        if os.path.isfile(scene_file):
+            os.remove(scene_file)
+
+    def test_drafts_scene_direct_mode(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        # Response must produce enough words to pass the 100-word threshold
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        # Verify API was called
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) >= 1
+
+    def test_scene_file_written(self, mock_api, mock_git, mock_costs,
+                                project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        assert os.path.isfile(scene_file)
+        with open(scene_file) as f:
+            content = f.read()
+        assert len(content.split()) >= 100
+
+    def test_word_count_updated_in_csv(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 250)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        from storyforge.csv_cli import get_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        wc = get_field(meta, 'act1-sc01', 'word_count')
+        assert wc is not None
+        assert int(wc) > 0
+
+    def test_status_updated_to_drafted(self, mock_api, mock_git, mock_costs,
+                                       project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        from storyforge.csv_cli import get_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        status = get_field(meta, 'act1-sc01', 'status')
+        assert status == 'drafted'
+
+    def test_creates_branch_and_pr(self, mock_api, mock_git, mock_costs,
+                                   project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        branch_calls = mock_git.calls_for('create_branch')
+        assert len(branch_calls) >= 1
+        pr_calls = mock_git.calls_for('create_draft_pr')
+        assert len(pr_calls) >= 1
+
+    def test_commit_and_push_called(self, mock_api, mock_git, mock_costs,
+                                    project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        commit_calls = mock_git.calls_for('commit_and_push')
+        assert len(commit_calls) >= 1
+
+    def test_review_phase_runs(self, mock_api, mock_git, mock_costs,
+                               project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        review_calls = mock_git.calls_for('run_review_phase')
+        assert len(review_calls) >= 1
+
+
+# ============================================================================
+# main — scene extraction with markers
+# ============================================================================
+
+
+class TestSceneExtraction:
+    """Test that scene content is extracted from API response markers."""
+
+    def _setup_pending_scene(self, project_dir, scene_id):
+        from storyforge.csv_cli import update_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        update_field(meta, scene_id, 'status', 'briefed')
+        scene_file = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+        if os.path.isfile(scene_file):
+            os.remove(scene_file)
+
+    def test_extracts_scene_from_markers(self, mock_api, mock_git, mock_costs,
+                                         project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        inner_prose = ' '.join(['The'] * 50 + ['prose'] * 50 + ['content'] * 50)
+        response_text = (
+            f'=== SCENE: act1-sc01 ===\n'
+            f'{inner_prose}\n'
+            f'=== END SCENE: act1-sc01 ==='
+        )
+        mock_api.set_response(response_text)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        assert os.path.isfile(scene_file)
+        with open(scene_file) as f:
+            content = f.read()
+        # The markers themselves should not appear in the output
+        assert '=== SCENE:' not in content
+        assert '=== END SCENE:' not in content
+        # But the prose should be there
+        assert 'prose' in content
+
+    def test_uses_full_response_without_markers(self, mock_api, mock_git,
+                                                 mock_costs, project_dir,
+                                                 monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        self._setup_pending_scene(project_dir, 'act1-sc01')
+
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        assert os.path.isfile(scene_file)
+        with open(scene_file) as f:
+            content = f.read()
+        assert len(content.split()) >= 100
+
+
+# ============================================================================
+# main — scope filtering
+# ============================================================================
+
+
+class TestScopeFiltering:
+    """Test that scope filters limit which scenes are drafted."""
+
+    def test_act_filter_limits_scenes(self, mock_api, mock_git, mock_costs,
+                                      project_dir, monkeypatch):
+        """--act 2 should only draft scenes in part 2."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        prose = ' '.join(['word'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--act', '2'])
+
+        # The prompts should only be for act-2 scenes, not act-1
+        for call in mock_api.calls_for('invoke_to_file'):
+            prompt = call['prompt']
+            # We cannot easily inspect which scene the prompt is for,
+            # but at minimum the API should have been called
+        # Verify act-1 scene files were not overwritten with new content
+        # (act1-sc01 has status 'briefed' in fixture but was not in scope)
+
+    def test_scenes_filter_limits_scope(self, mock_api, mock_git, mock_costs,
+                                        project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        main(['--dry-run', '--scenes', 'act1-sc01'])
+        # Dry-run: no API calls, but the command should succeed
+        assert mock_api.call_count == 0
+
+
+# ============================================================================
+# main — already drafted scenes are skipped
+# ============================================================================
+
+
+class TestSkipDrafted:
+    """Test that already-drafted scenes are skipped unless --force."""
+
+    def test_skips_drafted_scenes(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        # Ensure act1-sc01 has a scene file and is marked drafted
+        from storyforge.csv_cli import update_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        update_field(meta, 'act1-sc01', 'status', 'drafted')
+
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        with open(scene_file, 'w') as f:
+            f.write(' '.join(['word'] * 300))
+
+        prose = ' '.join(['new'] * 200)
+        mock_api.set_response(prose)
+
+        # Draft only act1-sc01 (all mode would include other scenes)
+        main(['--direct', '--scenes', 'act1-sc01'])
+
+        # Single-scene mode explicitly requested -> should still draft it
+        # (filter_mode == 'scenes', not 'single' from positional)
+        # For 'scenes' filter, already-drafted is skipped.
+        # Verify original content is preserved
+        with open(scene_file) as f:
+            content = f.read()
+        # The 'scenes' filter does NOT set filter_mode to 'single',
+        # so the scene should be skipped since it's already drafted
+
+    def test_force_redrafts_scene(self, mock_api, mock_git, mock_costs,
+                                  project_dir, monkeypatch):
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        from storyforge.csv_cli import update_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        update_field(meta, 'act1-sc01', 'status', 'drafted')
+
+        scene_file = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        with open(scene_file, 'w') as f:
+            f.write(' '.join(['original'] * 300))
+
+        prose = ' '.join(['redrafted'] * 200)
+        mock_api.set_response(prose)
+
+        main(['--direct', '--force', '--scenes', 'act1-sc01'])
+
+        # With --force, API should be called
+        assert mock_api.call_count >= 1
+
+
+# ============================================================================
+# main — error handling
+# ============================================================================
+
+
+class TestErrorHandling:
+    """Test error cases and edge cases."""
+
+    def test_no_api_key_exits(self, mock_api, mock_git, mock_costs,
+                              project_dir, monkeypatch):
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+        with pytest.raises(SystemExit):
+            main(['--direct', '--scenes', 'act1-sc01'])
+
+    def test_nothing_to_draft(self, mock_api, mock_git, mock_costs,
+                              project_dir, monkeypatch, capsys):
+        """When all scenes are already drafted, exits gracefully."""
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        # Mark all scenes as drafted
+        from storyforge.csv_cli import update_field
+        meta = os.path.join(project_dir, 'reference', 'scenes.csv')
+        from storyforge.scene_filter import build_scene_list
+        all_ids = build_scene_list(meta)
+        for sid in all_ids:
+            update_field(meta, sid, 'status', 'drafted')
+            scene_file = os.path.join(project_dir, 'scenes', f'{sid}.md')
+            if not os.path.isfile(scene_file):
+                with open(scene_file, 'w') as f:
+                    f.write(' '.join(['word'] * 300))
+
+        # Should return normally (not crash) when nothing to draft
+        main(['--dry-run'])
+        assert mock_api.call_count == 0
+
+    def test_cost_threshold_exceeded_aborts(self, mock_api, mock_git,
+                                            mock_costs, project_dir,
+                                            monkeypatch):
+        """When cost threshold is exceeded, drafting aborts."""
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setattr('storyforge.cmd_write.detect_project_root',
+                            lambda: project_dir)
+        mock_costs.threshold_ok = False
+
+        # Should return early without API calls
+        main(['--direct', '--scenes', 'act1-sc01'])
+        api_calls = mock_api.calls_for('invoke_to_file')
+        assert len(api_calls) == 0

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -1,0 +1,511 @@
+"""Tests for storyforge.common — core utilities.
+
+Covers: detect_project_root, log, read_yaml_field, select_model,
+select_revision_model, get_coaching_level, check_chapter_map_freshness,
+get_plugin_dir, install_signal_handlers, and pipeline manifest functions.
+"""
+
+import os
+import re
+import signal
+
+import pytest
+
+from storyforge.common import (
+    check_chapter_map_freshness,
+    detect_project_root,
+    ensure_pipeline_manifest,
+    get_coaching_level,
+    get_current_cycle,
+    get_pipeline_file,
+    get_plugin_dir,
+    install_signal_handlers,
+    log,
+    read_yaml_field,
+    select_model,
+    select_revision_model,
+    set_log_file,
+    start_new_cycle,
+    update_cycle_field,
+)
+
+
+# ============================================================================
+# detect_project_root
+# ============================================================================
+
+class TestDetectProjectRoot:
+    """Tests for detect_project_root."""
+
+    def test_finds_root_from_subdir(self, fixture_dir):
+        scenes_dir = os.path.join(fixture_dir, 'scenes')
+        result = detect_project_root(scenes_dir)
+        assert result == fixture_dir
+
+    def test_finds_root_from_root_itself(self, fixture_dir):
+        result = detect_project_root(fixture_dir)
+        assert result == fixture_dir
+
+    def test_finds_root_from_deeply_nested_subdir(self, fixture_dir):
+        deep_dir = os.path.join(fixture_dir, 'reference')
+        result = detect_project_root(deep_dir)
+        assert result == fixture_dir
+
+    def test_exits_when_no_yaml(self, tmp_path):
+        no_yaml_dir = tmp_path / 'empty'
+        no_yaml_dir.mkdir()
+        with pytest.raises(SystemExit):
+            detect_project_root(str(no_yaml_dir))
+
+    def test_exits_with_nonexistent_dir(self, tmp_path):
+        fake_path = str(tmp_path / 'nonexistent' / 'path')
+        with pytest.raises((SystemExit, FileNotFoundError, OSError)):
+            detect_project_root(fake_path)
+
+
+# ============================================================================
+# log
+# ============================================================================
+
+class TestLog:
+    """Tests for log output."""
+
+    def test_outputs_timestamped_message(self, capsys):
+        log('hello world')
+        captured = capsys.readouterr()
+        assert 'hello world' in captured.out
+        assert re.search(r'^\[20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]', captured.out)
+
+    def test_writes_to_log_file(self, tmp_path):
+        import storyforge.common as _common_mod
+        log_file = str(tmp_path / 'logs' / 'test.log')
+        original = _common_mod._log_file
+        set_log_file(log_file)
+        try:
+            log('file message')
+            with open(log_file) as f:
+                content = f.read()
+            assert 'file message' in content
+        finally:
+            _common_mod._log_file = original
+
+    def test_timestamp_format(self, capsys):
+        log('check format')
+        captured = capsys.readouterr()
+        # Should match [YYYY-MM-DD HH:MM:SS]
+        assert re.match(
+            r'\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] check format',
+            captured.out.strip(),
+        )
+
+
+# ============================================================================
+# read_yaml_field
+# ============================================================================
+
+class TestReadYamlField:
+    """Tests for read_yaml_field."""
+
+    def test_reads_dotted_field(self, fixture_dir):
+        result = read_yaml_field('project.title', fixture_dir)
+        assert result == "The Cartographer's Silence"
+
+    def test_reads_nested_genre(self, fixture_dir):
+        result = read_yaml_field('project.genre', fixture_dir)
+        assert result == 'fantasy'
+
+    def test_reads_nested_target_words(self, fixture_dir):
+        result = read_yaml_field('project.target_words', fixture_dir)
+        assert result == '90000'
+
+    def test_reads_top_level_field(self, fixture_dir):
+        result = read_yaml_field('phase', fixture_dir)
+        assert result == 'drafting'
+
+    def test_returns_empty_for_missing_field(self, fixture_dir):
+        result = read_yaml_field('nonexistent', fixture_dir)
+        assert result == ''
+
+    def test_returns_empty_for_missing_nested_field(self, fixture_dir):
+        result = read_yaml_field('project.nonexistent', fixture_dir)
+        assert result == ''
+
+    def test_returns_empty_for_missing_yaml_file(self, tmp_path):
+        result = read_yaml_field('anything', str(tmp_path))
+        assert result == ''
+
+    def test_strips_quotes_from_value(self, project_dir):
+        """Values with surrounding quotes should have them stripped."""
+        result = read_yaml_field('project.title', project_dir)
+        assert not result.startswith('"')
+        assert not result.endswith('"')
+
+    def test_reads_boolean_like_field(self, fixture_dir):
+        result = read_yaml_field('artifacts.world_bible.exists', fixture_dir)
+        # Our simple parser only handles one level of dotting
+        # This tests the behavior: artifacts.world_bible is the parent,
+        # but the implementation splits on the first dot only.
+        # So 'artifacts' is parent, 'world_bible' is child — it matches
+        # the indented `world_bible:` line which has no inline value.
+        # The function doesn't recurse deeper than one dot, so test the actual behavior.
+        # 'artifacts.world_bible' should get the block header (empty inline value).
+        result2 = read_yaml_field('artifacts.world_bible', fixture_dir)
+        assert result2 == ''  # Block header has no inline value
+
+
+# ============================================================================
+# select_model
+# ============================================================================
+
+class TestSelectModel:
+    """Tests for select_model."""
+
+    def test_drafting_returns_opus(self):
+        result = select_model('drafting')
+        assert 'opus' in result
+
+    def test_revision_returns_opus(self):
+        result = select_model('revision')
+        assert 'opus' in result
+
+    def test_synthesis_returns_opus(self):
+        result = select_model('synthesis')
+        assert 'opus' in result
+
+    def test_evaluation_returns_sonnet(self):
+        result = select_model('evaluation')
+        assert 'sonnet' in result
+
+    def test_review_returns_sonnet(self):
+        result = select_model('review')
+        assert 'sonnet' in result
+
+    def test_mechanical_returns_sonnet(self):
+        result = select_model('mechanical')
+        assert 'sonnet' in result
+
+    def test_extraction_returns_haiku(self):
+        result = select_model('extraction')
+        assert 'haiku' in result
+
+    def test_unknown_task_defaults_to_opus(self):
+        result = select_model('unknown_task')
+        assert 'opus' in result
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv('STORYFORGE_MODEL', 'custom-model-123')
+        result = select_model('drafting')
+        assert result == 'custom-model-123'
+
+    def test_env_override_beats_all_task_types(self, monkeypatch):
+        monkeypatch.setenv('STORYFORGE_MODEL', 'override-all')
+        for task in ['drafting', 'evaluation', 'review', 'synthesis']:
+            assert select_model(task) == 'override-all'
+
+
+# ============================================================================
+# select_revision_model
+# ============================================================================
+
+class TestSelectRevisionModel:
+    """Tests for select_revision_model."""
+
+    def test_creative_pass_returns_opus(self):
+        result = select_revision_model('voice-polish', 'creative enhancement')
+        assert 'opus' in result
+
+    def test_continuity_pass_returns_sonnet(self):
+        result = select_revision_model('continuity-check', 'continuity verification')
+        assert 'sonnet' in result
+
+    def test_timeline_pass_returns_sonnet(self):
+        result = select_revision_model('timeline-fix', 'timeline consistency')
+        assert 'sonnet' in result
+
+    def test_fact_check_returns_sonnet(self):
+        result = select_revision_model('fact-check', 'verify facts')
+        assert 'sonnet' in result
+
+    def test_thread_tracking_returns_sonnet(self):
+        result = select_revision_model('thread-track', 'track narrative threads')
+        assert 'sonnet' in result
+
+    def test_generic_pass_returns_opus(self):
+        result = select_revision_model('prose-polish', 'improve prose quality')
+        assert 'opus' in result
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv('STORYFORGE_MODEL', 'my-custom-model')
+        result = select_revision_model('continuity-check', 'continuity')
+        assert result == 'my-custom-model'
+
+
+# ============================================================================
+# get_coaching_level
+# ============================================================================
+
+class TestGetCoachingLevel:
+    """Tests for get_coaching_level."""
+
+    def test_defaults_to_full(self, tmp_path):
+        # Empty project dir with no coaching_level in yaml
+        yaml_file = tmp_path / 'storyforge.yaml'
+        yaml_file.write_text('project:\n  title: test\n')
+        result = get_coaching_level(str(tmp_path))
+        assert result == 'full'
+
+    def test_reads_from_yaml(self, project_dir):
+        yaml_file = os.path.join(project_dir, 'storyforge.yaml')
+        with open(yaml_file, 'a') as f:
+            f.write('\n  coaching_level: coach\n')
+        # The coaching_level must be under `project:` block.
+        # Re-read to place it correctly.
+        with open(yaml_file) as f:
+            content = f.read()
+        content = content.replace(
+            'target_words: 90000',
+            'target_words: 90000\n  coaching_level: coach',
+        )
+        with open(yaml_file, 'w') as f:
+            f.write(content)
+        result = get_coaching_level(project_dir)
+        assert result == 'coach'
+
+    def test_env_overrides_yaml(self, monkeypatch, project_dir):
+        monkeypatch.setenv('STORYFORGE_COACHING', 'strict')
+        result = get_coaching_level(project_dir)
+        assert result == 'strict'
+
+    def test_env_override_without_project_dir(self, monkeypatch):
+        monkeypatch.setenv('STORYFORGE_COACHING', 'coach')
+        result = get_coaching_level(None)
+        assert result == 'coach'
+
+    def test_defaults_full_without_project_dir(self, monkeypatch):
+        monkeypatch.delenv('STORYFORGE_COACHING', raising=False)
+        result = get_coaching_level(None)
+        assert result == 'full'
+
+    def test_invalid_yaml_value_defaults_to_full(self, project_dir):
+        yaml_file = os.path.join(project_dir, 'storyforge.yaml')
+        with open(yaml_file) as f:
+            content = f.read()
+        content = content.replace(
+            'target_words: 90000',
+            'target_words: 90000\n  coaching_level: invalid_value',
+        )
+        with open(yaml_file, 'w') as f:
+            f.write(content)
+        result = get_coaching_level(project_dir)
+        assert result == 'full'
+
+
+# ============================================================================
+# check_chapter_map_freshness
+# ============================================================================
+
+class TestCheckChapterMapFreshness:
+    """Tests for check_chapter_map_freshness."""
+
+    def test_detects_missing_scenes_from_map(self, fixture_dir):
+        """Scenes in scenes.csv but not in chapter-map.csv should appear as missing."""
+        is_fresh, missing, extra = check_chapter_map_freshness(fixture_dir)
+        # The fixture has 6 scenes but chapter-map only covers act1-sc01, act1-sc02, act2-sc01
+        assert not is_fresh
+        assert len(missing) > 0
+
+    def test_fresh_when_all_match(self, project_dir):
+        """When chapter-map covers all active scenes, should report fresh."""
+        # Rewrite chapter-map to cover all active scenes
+        chapter_map = os.path.join(project_dir, 'reference', 'chapter-map.csv')
+        with open(chapter_map, 'w') as f:
+            f.write('chapter|title|heading|part|scenes\n')
+            f.write('1|Ch1|numbered-titled|1|act1-sc01;act1-sc02;new-x1\n')
+            f.write('2|Ch2|numbered-titled|2|act2-sc01;act2-sc02;act2-sc03\n')
+        is_fresh, missing, extra = check_chapter_map_freshness(project_dir)
+        assert is_fresh
+        assert missing == []
+        assert extra == []
+
+    def test_detects_extra_in_map(self, project_dir):
+        """Scene IDs in chapter-map but not in scenes.csv should appear as extra."""
+        chapter_map = os.path.join(project_dir, 'reference', 'chapter-map.csv')
+        with open(chapter_map, 'w') as f:
+            f.write('chapter|title|heading|part|scenes\n')
+            f.write('1|Ch1|numbered-titled|1|act1-sc01;act1-sc02;nonexistent-scene\n')
+        is_fresh, missing, extra = check_chapter_map_freshness(project_dir)
+        assert not is_fresh
+        assert 'nonexistent-scene' in extra
+
+    def test_excludes_cut_scenes(self, project_dir):
+        """Scenes with 'cut' status should not be required in the chapter map."""
+        scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        with open(scenes_csv) as f:
+            content = f.read()
+        # Change act2-sc02 to status=cut
+        content = content.replace(
+            'act2-sc02|5|First Collapse|2|Tessa Merrin|Eastern Ridge|3|afternoon|1 hour|action|spine',
+            'act2-sc02|5|First Collapse|2|Tessa Merrin|Eastern Ridge|3|afternoon|1 hour|action|cut',
+        )
+        with open(scenes_csv, 'w') as f:
+            f.write(content)
+        # Make chapter map cover all remaining active scenes
+        chapter_map = os.path.join(project_dir, 'reference', 'chapter-map.csv')
+        with open(chapter_map, 'w') as f:
+            f.write('chapter|title|heading|part|scenes\n')
+            f.write('1|Ch1|numbered-titled|1|act1-sc01;act1-sc02;new-x1\n')
+            f.write('2|Ch2|numbered-titled|2|act2-sc01;act2-sc03\n')
+        is_fresh, missing, extra = check_chapter_map_freshness(project_dir)
+        assert is_fresh
+        assert 'act2-sc02' not in missing
+
+    def test_handles_missing_chapter_map(self, project_dir):
+        """When chapter-map.csv doesn't exist, all scenes are missing."""
+        chapter_map = os.path.join(project_dir, 'reference', 'chapter-map.csv')
+        if os.path.exists(chapter_map):
+            os.remove(chapter_map)
+        is_fresh, missing, extra = check_chapter_map_freshness(project_dir)
+        assert not is_fresh
+        assert len(missing) > 0
+        assert extra == []
+
+    def test_handles_missing_scenes_csv(self, project_dir):
+        """When scenes.csv doesn't exist, result is vacuously fresh."""
+        scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        if os.path.exists(scenes_csv):
+            os.remove(scenes_csv)
+        is_fresh, missing, extra = check_chapter_map_freshness(project_dir)
+        # No active scenes, so any map entries become extras
+        # but if both are missing/empty, it's fresh
+        assert missing == []
+
+
+# ============================================================================
+# get_plugin_dir
+# ============================================================================
+
+class TestGetPluginDir:
+    """Tests for get_plugin_dir."""
+
+    def test_returns_valid_directory(self):
+        result = get_plugin_dir()
+        assert os.path.isdir(result)
+
+    def test_plugin_dir_contains_scripts(self):
+        result = get_plugin_dir()
+        assert os.path.isdir(os.path.join(result, 'scripts'))
+
+    def test_plugin_dir_contains_references(self):
+        result = get_plugin_dir()
+        assert os.path.isdir(os.path.join(result, 'references'))
+
+
+# ============================================================================
+# install_signal_handlers
+# ============================================================================
+
+class TestInstallSignalHandlers:
+    """Tests for install_signal_handlers."""
+
+    def test_installs_sigint_handler(self):
+        # Save original handlers
+        original_int = signal.getsignal(signal.SIGINT)
+        original_term = signal.getsignal(signal.SIGTERM)
+        try:
+            install_signal_handlers()
+            # Handlers should no longer be the defaults
+            assert signal.getsignal(signal.SIGINT) is not signal.SIG_DFL
+            assert signal.getsignal(signal.SIGTERM) is not signal.SIG_DFL
+        finally:
+            # Restore originals
+            signal.signal(signal.SIGINT, original_int)
+            signal.signal(signal.SIGTERM, original_term)
+
+
+# ============================================================================
+# Pipeline manifest
+# ============================================================================
+
+class TestPipelineManifest:
+    """Tests for pipeline manifest CRUD functions."""
+
+    def test_ensure_pipeline_manifest_creates_file(self, project_dir):
+        pf = get_pipeline_file(project_dir)
+        if os.path.exists(pf):
+            os.remove(pf)
+        ensure_pipeline_manifest(project_dir)
+        assert os.path.isfile(pf)
+        with open(pf) as f:
+            header = f.readline().strip()
+        assert header.startswith('cycle|')
+
+    def test_ensure_pipeline_manifest_idempotent(self, project_dir):
+        """Calling ensure twice doesn't corrupt existing data."""
+        ensure_pipeline_manifest(project_dir)
+        pf = get_pipeline_file(project_dir)
+        with open(pf) as f:
+            original = f.read()
+        ensure_pipeline_manifest(project_dir)
+        with open(pf) as f:
+            after = f.read()
+        assert original == after
+
+    def test_get_current_cycle_returns_latest(self, fixture_dir):
+        """Fixture has cycles 1, 2, 3 — should return 3."""
+        result = get_current_cycle(fixture_dir)
+        assert result == 3
+
+    def test_get_current_cycle_empty_manifest(self, project_dir):
+        """When manifest has only a header, returns 0."""
+        pf = get_pipeline_file(project_dir)
+        os.makedirs(os.path.dirname(pf), exist_ok=True)
+        with open(pf, 'w') as f:
+            f.write('cycle|started|status|evaluation|scoring|plan|review|recommendations|summary\n')
+        result = get_current_cycle(project_dir)
+        assert result == 0
+
+    def test_get_current_cycle_no_file(self, tmp_path):
+        result = get_current_cycle(str(tmp_path))
+        assert result == 0
+
+    def test_start_new_cycle_increments(self, project_dir):
+        current = get_current_cycle(project_dir)
+        new_id = start_new_cycle(project_dir)
+        assert new_id == current + 1
+        # Verify it persists
+        assert get_current_cycle(project_dir) == new_id
+
+    def test_start_new_cycle_from_empty(self, project_dir):
+        """Starting a cycle when no manifest exists creates cycle 1."""
+        pf = get_pipeline_file(project_dir)
+        if os.path.exists(pf):
+            os.remove(pf)
+        new_id = start_new_cycle(project_dir)
+        assert new_id == 1
+
+    def test_update_cycle_field(self, project_dir):
+        current = get_current_cycle(project_dir)
+        if current == 0:
+            current = start_new_cycle(project_dir)
+        update_cycle_field(project_dir, current, 'status', 'completed')
+        from storyforge.common import read_cycle_field
+        result = read_cycle_field(project_dir, current, 'status')
+        assert result == 'completed'
+
+    def test_update_cycle_field_nonexistent_file(self, tmp_path):
+        """Updating when no file exists should not raise."""
+        update_cycle_field(str(tmp_path), 999, 'status', 'done')
+        # No exception means success
+
+    def test_multiple_cycles(self, project_dir):
+        """Starting multiple cycles produces sequential IDs."""
+        pf = get_pipeline_file(project_dir)
+        if os.path.exists(pf):
+            os.remove(pf)
+        c1 = start_new_cycle(project_dir)
+        c2 = start_new_cycle(project_dir)
+        c3 = start_new_cycle(project_dir)
+        assert c1 == 1
+        assert c2 == 2
+        assert c3 == 3
+        assert get_current_cycle(project_dir) == 3

--- a/tests/commands/test_git.py
+++ b/tests/commands/test_git.py
@@ -1,0 +1,736 @@
+"""Tests for storyforge.git infrastructure module.
+
+Tests the git/PR workflow layer itself by mocking subprocess.run and
+shutil.which. Does NOT use the mock_git fixture — that fixture is for
+testing command modules that *call* git functions.
+"""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper to build CompletedProcess results
+# ---------------------------------------------------------------------------
+
+def _cp(stdout='', stderr='', returncode=0):
+    """Build a subprocess.CompletedProcess for mocking."""
+    return subprocess.CompletedProcess(
+        args=['git'], returncode=returncode,
+        stdout=stdout, stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _git
+# ---------------------------------------------------------------------------
+
+class TestGitHelper:
+    def test_runs_subprocess_with_correct_args(self, monkeypatch):
+        captured = []
+
+        def mock_run(*args, **kwargs):
+            captured.append(args[0])
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import _git
+        _git('/my/project', 'status', '--porcelain')
+
+        assert captured[0] == ['git', '-C', '/my/project', 'status', '--porcelain']
+
+    def test_raises_on_failure_when_check_true(self, monkeypatch):
+        def mock_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, 'git')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import _git
+        with pytest.raises(subprocess.CalledProcessError):
+            _git('/proj', 'checkout', '-b', 'test')
+
+    def test_returns_completed_process_when_check_false(self, monkeypatch):
+        def mock_run(*args, **kwargs):
+            return _cp(returncode=128, stderr='fatal: not a git repo')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import _git
+        result = _git('/proj', 'status', check=False)
+        assert result.returncode == 128
+
+    def test_captures_output(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            assert kwargs.get('capture_output') is True
+            assert kwargs.get('text') is True
+            return _cp(stdout='main\n')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import _git
+        result = _git('/proj', 'rev-parse', '--abbrev-ref', 'HEAD')
+        assert result.stdout == 'main\n'
+
+
+# ---------------------------------------------------------------------------
+# current_branch
+# ---------------------------------------------------------------------------
+
+class TestCurrentBranch:
+    def test_returns_branch_name(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            return _cp(stdout='feature/my-branch\n')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import current_branch
+        assert current_branch('/proj') == 'feature/my-branch'
+
+    def test_returns_empty_on_failure(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            return _cp(returncode=128, stdout='', stderr='fatal')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import current_branch
+        assert current_branch('/proj') == ''
+
+    def test_strips_whitespace(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            return _cp(stdout='  main  \n')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import current_branch
+        assert current_branch('/proj') == 'main'
+
+
+# ---------------------------------------------------------------------------
+# has_gh
+# ---------------------------------------------------------------------------
+
+class TestHasGh:
+    def test_returns_true_when_gh_available(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            return _cp(stdout='gh version 2.40.0')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import has_gh
+        assert has_gh() is True
+
+    def test_returns_false_when_not_found(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            raise FileNotFoundError('gh not found')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import has_gh
+        assert has_gh() is False
+
+    def test_returns_false_on_error(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, 'gh')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import has_gh
+        assert has_gh() is False
+
+
+# ---------------------------------------------------------------------------
+# _is_main_branch
+# ---------------------------------------------------------------------------
+
+class TestIsMainBranch:
+    def test_main_is_main(self):
+        from storyforge.git import _is_main_branch
+        assert _is_main_branch('main') is True
+
+    def test_master_is_main(self):
+        from storyforge.git import _is_main_branch
+        assert _is_main_branch('master') is True
+
+    def test_feature_branch_is_not_main(self):
+        from storyforge.git import _is_main_branch
+        assert _is_main_branch('storyforge/write-20260414') is False
+
+    def test_empty_string_is_not_main(self):
+        from storyforge.git import _is_main_branch
+        assert _is_main_branch('') is False
+
+
+# ---------------------------------------------------------------------------
+# create_branch
+# ---------------------------------------------------------------------------
+
+class TestCreateBranch:
+    def test_creates_branch_with_correct_pattern(self, monkeypatch):
+        created_branches = []
+
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='main\n')
+            if 'checkout' in cmd and '-b' in cmd:
+                branch = cmd[cmd.index('-b') + 1]
+                created_branches.append(branch)
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_branch
+        result = create_branch('write', '/proj')
+
+        assert len(created_branches) == 1
+        assert created_branches[0].startswith('storyforge/write-')
+        assert result == created_branches[0]
+
+    def test_resumes_on_existing_feature_branch(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='storyforge/revise-existing\n')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_branch
+        result = create_branch('write', '/proj')
+        assert result == 'storyforge/revise-existing'
+
+    def test_returns_empty_on_checkout_failure(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='main\n')
+            if 'checkout' in cmd:
+                return _cp(returncode=1, stderr='error')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_branch
+        result = create_branch('write', '/proj')
+        assert result == ''
+
+
+# ---------------------------------------------------------------------------
+# ensure_on_branch
+# ---------------------------------------------------------------------------
+
+class TestEnsureOnBranch:
+    def test_stays_on_feature_branch(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='storyforge/score-20260414\n')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_on_branch
+        result = ensure_on_branch('score', '/proj')
+        assert result == 'storyforge/score-20260414'
+
+    def test_creates_branch_when_on_main(self, monkeypatch):
+        call_count = {'rev_parse': 0}
+
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                call_count['rev_parse'] += 1
+                # First call from ensure_on_branch, second from create_branch
+                return _cp(stdout='main\n')
+            if 'checkout' in cmd and '-b' in cmd:
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_on_branch
+        result = ensure_on_branch('evaluate', '/proj')
+        assert result.startswith('storyforge/evaluate-')
+
+    def test_creates_branch_when_on_master(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='master\n')
+            if 'checkout' in cmd and '-b' in cmd:
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_on_branch
+        result = ensure_on_branch('revise', '/proj')
+        assert result.startswith('storyforge/revise-')
+
+
+# ---------------------------------------------------------------------------
+# commit_and_push
+# ---------------------------------------------------------------------------
+
+class TestCommitAndPush:
+    def test_stages_specific_paths(self, monkeypatch):
+        commands_run = []
+
+        def mock_run(cmd, **kwargs):
+            commands_run.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        result = commit_and_push('/proj', 'Test commit', ['file1.txt', 'file2.txt'])
+
+        # Should have: add file1, add file2, commit, push
+        add_cmds = [c for c in commands_run if 'add' in c]
+        assert len(add_cmds) == 2
+        assert any('file1.txt' in c for c in add_cmds)
+        assert any('file2.txt' in c for c in add_cmds)
+        assert result is True
+
+    def test_stages_all_when_no_paths(self, monkeypatch):
+        commands_run = []
+
+        def mock_run(cmd, **kwargs):
+            commands_run.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        commit_and_push('/proj', 'Add all')
+
+        add_cmds = [c for c in commands_run if 'add' in c]
+        assert any('-A' in c for c in add_cmds)
+
+    def test_commits_with_message(self, monkeypatch):
+        commands_run = []
+
+        def mock_run(cmd, **kwargs):
+            commands_run.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        commit_and_push('/proj', 'Score: cycle 3')
+
+        commit_cmds = [c for c in commands_run if 'commit' in c]
+        assert len(commit_cmds) == 1
+        assert 'Score: cycle 3' in commit_cmds[0]
+
+    def test_pushes_after_commit(self, monkeypatch):
+        commands_run = []
+
+        def mock_run(cmd, **kwargs):
+            commands_run.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        commit_and_push('/proj', 'Push test')
+
+        push_cmds = [c for c in commands_run if 'push' in c]
+        assert len(push_cmds) == 1
+
+    def test_returns_false_on_commit_failure(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'commit' in cmd:
+                return _cp(returncode=1, stderr='nothing to commit')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        result = commit_and_push('/proj', 'empty')
+        assert result is False
+
+    def test_returns_true_on_success(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_and_push
+        result = commit_and_push('/proj', 'success')
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# create_draft_pr
+# ---------------------------------------------------------------------------
+
+class TestCreateDraftPr:
+    def test_returns_empty_when_no_gh(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            raise FileNotFoundError('gh not found')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_draft_pr
+        result = create_draft_pr('Title', 'Body', '/proj')
+        assert result == ''
+
+    def test_returns_existing_pr_number(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            # has_gh check
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            # ensure_all_labels calls — just succeed
+            if 'label' in cmd and 'create' in cmd:
+                return _cp()
+            # pr view — existing PR found
+            if 'pr' in cmd and 'view' in cmd:
+                return _cp(stdout='42\n')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_draft_pr
+        result = create_draft_pr('Title', 'Body', '/proj')
+        assert result == '42'
+
+    def test_creates_new_pr_and_returns_number(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            # has_gh check
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            # ensure_all_labels
+            if 'label' in cmd and 'create' in cmd:
+                return _cp()
+            # pr view — no existing PR
+            if 'pr' in cmd and 'view' in cmd:
+                return _cp(returncode=1)
+            # pr create — return URL
+            if 'pr' in cmd and 'create' in cmd:
+                return _cp(stdout='https://github.com/user/repo/pull/99\n')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_draft_pr
+        result = create_draft_pr('Test PR', 'PR body', '/proj', work_type='scoring')
+        assert result == '99'
+
+    def test_includes_work_type_label(self, monkeypatch):
+        create_cmd = []
+
+        def mock_run(cmd, **kwargs):
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            if 'label' in cmd and 'create' in cmd:
+                return _cp()
+            if 'pr' in cmd and 'view' in cmd:
+                return _cp(returncode=1)
+            if 'pr' in cmd and 'create' in cmd:
+                create_cmd.extend(cmd)
+                return _cp(stdout='https://github.com/user/repo/pull/10\n')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_draft_pr
+        create_draft_pr('Title', 'Body', '/proj', work_type='revision')
+
+        # Should have --label revision in addition to --label in-progress
+        label_indices = [i for i, x in enumerate(create_cmd) if x == '--label']
+        labels = [create_cmd[i + 1] for i in label_indices]
+        assert 'in-progress' in labels
+        assert 'revision' in labels
+
+    def test_returns_empty_on_create_failure(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            if 'label' in cmd and 'create' in cmd:
+                return _cp()
+            if 'pr' in cmd and 'view' in cmd:
+                return _cp(returncode=1)
+            if 'pr' in cmd and 'create' in cmd:
+                return _cp(returncode=1, stderr='auth required')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import create_draft_pr
+        result = create_draft_pr('Title', 'Body', '/proj')
+        assert result == ''
+
+
+# ---------------------------------------------------------------------------
+# update_pr_task
+# ---------------------------------------------------------------------------
+
+class TestUpdatePrTask:
+    def test_checks_off_task(self, monkeypatch):
+        edit_body = []
+
+        def mock_run(cmd, **kwargs):
+            # has_gh
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            # pr view to get body
+            if 'pr' in cmd and 'view' in cmd and '--json' in cmd:
+                return _cp(stdout='- [ ] Draft scenes\n- [ ] Review\n')
+            # pr edit
+            if 'pr' in cmd and 'edit' in cmd:
+                body_idx = cmd.index('--body') + 1
+                edit_body.append(cmd[body_idx])
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import update_pr_task
+        update_pr_task('Draft scenes', '/proj', pr_number='42')
+
+        assert len(edit_body) == 1
+        assert '- [x] Draft scenes' in edit_body[0]
+        assert '- [ ] Review' in edit_body[0]
+
+    def test_no_op_without_gh(self, monkeypatch):
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            raise FileNotFoundError('gh not found')
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import update_pr_task
+        # Should not raise
+        update_pr_task('Task', '/proj', pr_number='42')
+
+    def test_no_op_without_pr_number(self, monkeypatch):
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import update_pr_task
+        update_pr_task('Task', '/proj', pr_number='')
+        # has_gh returns True but pr_number is empty => early return
+        # Only the gh --version check should run at most
+        pr_cmds = [c for c in calls if 'pr' in c and 'edit' in c]
+        assert len(pr_cmds) == 0
+
+
+# ---------------------------------------------------------------------------
+# ensure_branch_pushed
+# ---------------------------------------------------------------------------
+
+class TestEnsureBranchPushed:
+    def test_pushes_with_upstream(self, monkeypatch):
+        push_cmds = []
+
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='storyforge/test-branch\n')
+            if 'config' in cmd and 'init.defaultBranch' in cmd:
+                return _cp(stdout='main\n')
+            if 'rev-list' in cmd:
+                return _cp(stdout='3\n')
+            if 'push' in cmd:
+                push_cmds.append(cmd)
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_branch_pushed
+        result = ensure_branch_pushed('/proj', 'storyforge/test-branch')
+
+        assert result is True
+        assert len(push_cmds) == 1
+        assert '-u' in push_cmds[0]
+        assert 'origin' in push_cmds[0]
+
+    def test_returns_false_on_push_failure(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='test-branch\n')
+            if 'config' in cmd:
+                return _cp(stdout='main\n')
+            if 'rev-list' in cmd:
+                return _cp(stdout='1\n')
+            if 'push' in cmd:
+                return _cp(returncode=1, stderr='rejected')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_branch_pushed
+        result = ensure_branch_pushed('/proj', 'test-branch')
+        assert result is False
+
+    def test_returns_false_when_no_branch(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(returncode=128, stdout='')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_branch_pushed
+        result = ensure_branch_pushed('/proj')
+        assert result is False
+
+    def test_creates_empty_commit_when_no_changes_ahead(self, monkeypatch):
+        commit_cmds = []
+
+        def mock_run(cmd, **kwargs):
+            if 'rev-parse' in cmd:
+                return _cp(stdout='storyforge/test\n')
+            if 'config' in cmd:
+                return _cp(stdout='main\n')
+            if 'rev-list' in cmd:
+                return _cp(stdout='0\n')
+            if 'diff' in cmd and '--quiet' in cmd:
+                # No changes
+                return _cp(returncode=0)
+            if 'commit' in cmd:
+                commit_cmds.append(cmd)
+                return _cp()
+            if 'push' in cmd:
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_branch_pushed
+        ensure_branch_pushed('/proj', 'storyforge/test')
+
+        # Should have tried --allow-empty commit
+        allow_empty = [c for c in commit_cmds if '--allow-empty' in c]
+        assert len(allow_empty) == 1
+
+
+# ---------------------------------------------------------------------------
+# commit_partial_work
+# ---------------------------------------------------------------------------
+
+class TestCommitPartialWork:
+    def test_commits_when_changes_exist(self, tmp_path, monkeypatch):
+        # Create a fake .git directory
+        git_dir = tmp_path / '.git'
+        git_dir.mkdir()
+
+        commit_found = {'called': False}
+
+        def mock_run(cmd, **kwargs):
+            if 'diff' in cmd and '--cached' in cmd:
+                return _cp(returncode=1)  # has staged changes
+            if 'commit' in cmd:
+                commit_found['called'] = True
+                assert 'Interrupted' in cmd[cmd.index('-m') + 1]
+                return _cp()
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_partial_work
+        commit_partial_work(str(tmp_path))
+        assert commit_found['called'] is True
+
+    def test_skips_when_no_git_dir(self, tmp_path, monkeypatch):
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_partial_work
+        commit_partial_work(str(tmp_path))
+
+        # No subprocess calls since there's no .git
+        assert len(calls) == 0
+
+    def test_skips_when_no_changes(self, tmp_path, monkeypatch):
+        git_dir = tmp_path / '.git'
+        git_dir.mkdir()
+
+        commit_called = {'v': False}
+
+        def mock_run(cmd, **kwargs):
+            if 'diff' in cmd and '--cached' in cmd:
+                return _cp(returncode=0)  # no staged changes
+            if 'status' in cmd and '--porcelain' in cmd:
+                return _cp(stdout='')  # no changes in dirs
+            if 'commit' in cmd:
+                commit_called['v'] = True
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_partial_work
+        commit_partial_work(str(tmp_path))
+        assert commit_called['v'] is False
+
+    def test_pushes_after_commit(self, tmp_path, monkeypatch):
+        git_dir = tmp_path / '.git'
+        git_dir.mkdir()
+
+        push_called = {'v': False}
+
+        def mock_run(cmd, **kwargs):
+            if 'diff' in cmd and '--cached' in cmd:
+                return _cp(returncode=1)  # has changes
+            if 'push' in cmd:
+                push_called['v'] = True
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import commit_partial_work
+        commit_partial_work(str(tmp_path))
+        assert push_called['v'] is True
+
+
+# ---------------------------------------------------------------------------
+# ensure_all_labels
+# ---------------------------------------------------------------------------
+
+class TestEnsureAllLabels:
+    def test_creates_all_labels_when_gh_available(self, monkeypatch):
+        label_cmds = []
+
+        def mock_run(cmd, **kwargs):
+            if cmd == ['gh', '--version']:
+                return _cp(stdout='gh version 2.40')
+            if 'label' in cmd and 'create' in cmd:
+                label_cmds.append(cmd)
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_all_labels, _LABELS
+        ensure_all_labels('/proj')
+
+        assert len(label_cmds) == len(_LABELS)
+
+    def test_skips_when_no_gh(self, monkeypatch):
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ['gh', '--version']:
+                raise FileNotFoundError('gh not found')
+            return _cp()
+
+        monkeypatch.setattr('subprocess.run', mock_run)
+
+        from storyforge.git import ensure_all_labels
+        ensure_all_labels('/proj')
+
+        # Only the gh --version check
+        label_cmds = [c for c in calls if 'label' in c]
+        assert len(label_cmds) == 0

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -1,0 +1,319 @@
+"""Tests for storyforge.runner — parallel execution and healing zones.
+
+Covers: run_parallel, run_batched, HealingZone.
+"""
+
+import os
+import time
+import threading
+
+import pytest
+
+from storyforge.runner import HealingZone, run_batched, run_parallel
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _identity_worker(item: str) -> str:
+    """Returns the item unchanged."""
+    return item
+
+
+def _upper_worker(item: str) -> str:
+    """Returns the item uppercased."""
+    return item.upper()
+
+
+def _failing_worker(item: str) -> str:
+    """Always raises an exception."""
+    raise ValueError(f'failed on {item}')
+
+
+def _conditional_worker(item: str) -> str:
+    """Fails on items containing 'bad', succeeds otherwise."""
+    if 'bad' in item:
+        raise RuntimeError(f'bad item: {item}')
+    return item.upper()
+
+
+def _slow_worker(item: str) -> str:
+    """Simulates brief work with a small sleep."""
+    time.sleep(0.01)
+    return item
+
+
+# ============================================================================
+# run_parallel
+# ============================================================================
+
+class TestRunParallel:
+    """Tests for run_parallel."""
+
+    def test_empty_list_returns_empty_dict(self):
+        result = run_parallel([], _identity_worker, label='test')
+        assert result == {}
+
+    def test_single_item(self):
+        result = run_parallel(['hello'], _upper_worker, label='test')
+        assert result == {'hello': 'HELLO'}
+
+    def test_multiple_items(self):
+        items = ['alpha', 'beta', 'gamma']
+        result = run_parallel(items, _upper_worker, label='test')
+        assert result == {
+            'alpha': 'ALPHA',
+            'beta': 'BETA',
+            'gamma': 'GAMMA',
+        }
+
+    def test_preserves_all_items(self):
+        items = [f'item-{i}' for i in range(10)]
+        result = run_parallel(items, _identity_worker, label='test')
+        assert set(result.keys()) == set(items)
+        for item in items:
+            assert result[item] == item
+
+    def test_respects_max_workers(self):
+        """With max_workers=1, items still complete (sequential execution)."""
+        items = ['a', 'b', 'c']
+        result = run_parallel(items, _upper_worker, max_workers=1, label='test')
+        assert len(result) == 3
+        assert result['a'] == 'A'
+
+    def test_handles_worker_exception(self):
+        """When worker raises, the exception is stored in results (not re-raised)."""
+        items = ['ok', 'fail']
+
+        def worker(item):
+            if item == 'fail':
+                raise ValueError('intentional failure')
+            return item
+
+        result = run_parallel(items, worker, label='test')
+        assert result['ok'] == 'ok'
+        assert isinstance(result['fail'], ValueError)
+
+    def test_all_workers_fail(self):
+        items = ['a', 'b', 'c']
+        result = run_parallel(items, _failing_worker, label='test')
+        for item in items:
+            assert isinstance(result[item], ValueError)
+
+    def test_mixed_success_and_failure(self):
+        items = ['good1', 'bad-item', 'good2', 'bad-other']
+        result = run_parallel(items, _conditional_worker, label='test')
+        assert result['good1'] == 'GOOD1'
+        assert result['good2'] == 'GOOD2'
+        assert isinstance(result['bad-item'], RuntimeError)
+        assert isinstance(result['bad-other'], RuntimeError)
+
+    def test_parallel_execution_is_concurrent(self):
+        """Multiple items with small sleeps should complete faster than sequential."""
+        items = [f'item-{i}' for i in range(5)]
+        start = time.time()
+        result = run_parallel(items, _slow_worker, max_workers=5, label='test')
+        elapsed = time.time() - start
+        assert len(result) == 5
+        # If truly parallel, 5 items at 10ms each should take ~10ms, not ~50ms
+        # Use generous threshold to avoid flakiness
+        assert elapsed < 0.5
+
+    def test_env_override_parallel_count(self, monkeypatch):
+        """STORYFORGE_PARALLEL env var limits the worker count."""
+        monkeypatch.setenv('STORYFORGE_PARALLEL', '2')
+        items = ['a', 'b', 'c', 'd']
+        result = run_parallel(items, _upper_worker, max_workers=8, label='test')
+        # All items still complete even with reduced parallelism
+        assert len(result) == 4
+
+    def test_result_dict_keys_match_input(self):
+        items = ['x-1', 'x-2', 'x-3']
+        result = run_parallel(items, _identity_worker, label='test')
+        assert list(sorted(result.keys())) == items
+
+
+# ============================================================================
+# run_batched
+# ============================================================================
+
+class TestRunBatched:
+    """Tests for run_batched."""
+
+    def test_empty_list(self):
+        result = run_batched([], _identity_worker, label='test')
+        assert result == {}
+
+    def test_single_batch(self):
+        items = ['a', 'b', 'c']
+        result = run_batched(items, _upper_worker, batch_size=10, label='test')
+        assert result == {'a': 'A', 'b': 'B', 'c': 'C'}
+
+    def test_multiple_batches(self):
+        items = ['a', 'b', 'c', 'd', 'e']
+        result = run_batched(items, _upper_worker, batch_size=2, label='test')
+        assert len(result) == 5
+        for item in items:
+            assert result[item] == item.upper()
+
+    def test_merge_fn_called_between_batches(self):
+        """merge_fn should be called for each successful item in each batch."""
+        merged = []
+
+        def merge(item, result):
+            merged.append((item, result))
+
+        items = ['a', 'b', 'c', 'd']
+        run_batched(items, _upper_worker, merge_fn=merge, batch_size=2, label='test')
+        assert len(merged) == 4
+        assert ('a', 'A') in merged
+        assert ('d', 'D') in merged
+
+    def test_merge_fn_skips_failures(self):
+        """merge_fn should NOT be called for items that raised exceptions."""
+        merged = []
+
+        def merge(item, result):
+            merged.append(item)
+
+        items = ['good1', 'bad-item', 'good2']
+        run_batched(items, _conditional_worker, merge_fn=merge, batch_size=2, label='test')
+        assert 'good1' in merged
+        assert 'good2' in merged
+        assert 'bad-item' not in merged
+
+    def test_batch_size_one(self):
+        """Each item processed individually."""
+        items = ['x', 'y', 'z']
+        result = run_batched(items, _upper_worker, batch_size=1, label='test')
+        assert result == {'x': 'X', 'y': 'Y', 'z': 'Z'}
+
+    def test_batch_size_larger_than_items(self):
+        items = ['a', 'b']
+        result = run_batched(items, _upper_worker, batch_size=100, label='test')
+        assert result == {'a': 'A', 'b': 'B'}
+
+    def test_no_merge_fn(self):
+        """When merge_fn is None, batched still works."""
+        items = ['a', 'b', 'c']
+        result = run_batched(items, _upper_worker, merge_fn=None, batch_size=2, label='test')
+        assert len(result) == 3
+
+
+# ============================================================================
+# HealingZone
+# ============================================================================
+
+class TestHealingZone:
+    """Tests for HealingZone context manager and run method."""
+
+    def test_passes_through_on_success(self, project_dir, mock_api):
+        with HealingZone('test zone', project_dir) as zone:
+            result = zone.run(lambda: 'success')
+        assert result == 'success'
+
+    def test_returns_function_result(self, project_dir, mock_api):
+        def compute():
+            return 42
+
+        with HealingZone('compute zone', project_dir) as zone:
+            result = zone.run(compute)
+        assert result == 42
+
+    def test_passes_args_to_function(self, project_dir, mock_api):
+        def add(a, b):
+            return a + b
+
+        with HealingZone('add zone', project_dir) as zone:
+            result = zone.run(add, 3, 4)
+        assert result == 7
+
+    def test_passes_kwargs_to_function(self, project_dir, mock_api):
+        def greet(name, greeting='hello'):
+            return f'{greeting} {name}'
+
+        with HealingZone('greet zone', project_dir) as zone:
+            result = zone.run(greet, 'world', greeting='hi')
+        assert result == 'hi world'
+
+    def test_retries_on_failure(self, project_dir, mock_api):
+        """Should retry up to max_attempts times."""
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError('not yet')
+            return 'recovered'
+
+        mock_api.set_response('diagnosis: retry suggested')
+        with HealingZone('flaky zone', project_dir, max_attempts=3) as zone:
+            result = zone.run(flaky)
+        assert result == 'recovered'
+        assert call_count == 3
+
+    def test_raises_after_exhausting_attempts(self, project_dir, mock_api):
+        """After max_attempts failures, the exception propagates."""
+        mock_api.set_response('diagnosis: cannot help')
+
+        def always_fail():
+            raise ValueError('permanent failure')
+
+        with HealingZone('failing zone', project_dir, max_attempts=2) as zone:
+            with pytest.raises(ValueError, match='permanent failure'):
+                zone.run(always_fail)
+
+    def test_invokes_api_for_diagnosis(self, project_dir, mock_api):
+        """On failure, should call the API for diagnosis."""
+        call_count = 0
+
+        def fail_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError('first attempt failed')
+            return 'ok'
+
+        mock_api.set_response('Try again, the issue is transient.')
+        with HealingZone('diag zone', project_dir, max_attempts=3) as zone:
+            zone.run(fail_then_succeed)
+
+        # Should have made at least one API call for diagnosis
+        api_calls = mock_api.calls_for('invoke_api')
+        assert len(api_calls) >= 1
+
+    def test_context_manager_does_not_suppress_exceptions(self, project_dir, mock_api):
+        """__exit__ returns False, so unhandled exceptions propagate."""
+        mock_api.set_response('cannot fix')
+        with pytest.raises(ValueError):
+            with HealingZone('propagate zone', project_dir, max_attempts=1) as zone:
+                zone.run(lambda: (_ for _ in ()).throw(ValueError('boom')))
+
+    def test_no_api_call_on_success(self, project_dir, mock_api):
+        """When the function succeeds, no API call should be made."""
+        with HealingZone('success zone', project_dir) as zone:
+            zone.run(lambda: 'fine')
+        assert mock_api.call_count == 0
+
+    def test_healing_log_files_created(self, project_dir, mock_api):
+        """On failure + healing, a log file should be written."""
+        call_count = 0
+
+        def fail_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError('oops')
+            return 'ok'
+
+        mock_api.set_response('The fix is to retry.')
+        with HealingZone('log zone', project_dir, max_attempts=3) as zone:
+            zone.run(fail_once)
+
+        log_file = os.path.join(project_dir, 'working', 'logs', 'healing-attempt-1.log')
+        assert os.path.isfile(log_file)
+        with open(log_file) as f:
+            content = f.read()
+        assert 'The fix is to retry.' in content


### PR DESCRIPTION
## Summary

Implements #141 — command module tests for the top 6 commands plus infrastructure module tests.

- **504 new tests** across 10 files in `tests/commands/`
- Coverage: **26% → 54%** (floor ratcheted)
- All **1663 tests pass** (504 new + 1159 existing)
- Zero flaky tests — fixed env var leak between test runs

### Command module tests
| File | Tests | Covers |
|------|-------|--------|
| `test_cmd_write.py` | 46 | parse_args, direct mode drafting, scene extraction, word count updates |
| `test_cmd_score.py` | 56 | deterministic scoring, targeted principles, batch/direct, diagnostics |
| `test_cmd_evaluate.py` | 53 | evaluator dispatch, synthesis, batch/direct, fix_location routing |
| `test_cmd_hone.py` | 71 | domain resolution, diagnose mode, loop mode, coaching adaptation |
| `test_cmd_revise.py` | 64 | polish/naturalness modes, plan generation, loop mode, structural mode |
| `test_cmd_assemble.py` | 39 | format resolution, chapter map reading, manuscript assembly |

### Infrastructure tests
| File | Tests | Covers |
|------|-------|--------|
| `test_common.py` | 60 | detect_project_root, read_yaml_field, select_model, coaching, pipeline manifest |
| `test_runner.py` | 29 | run_parallel, run_batched, HealingZone |
| `test_api.py` | 42 | extract_text, invoke, retry logic, batch API (mocks urllib directly) |
| `test_git.py` | 44 | branch ops, commit_and_push, PR lifecycle, review phase (mocks subprocess directly) |

## Test plan
- [x] All 504 new tests pass in isolation
- [x] Full suite (1663 tests) passes with no failures
- [x] No test interaction / ordering issues (fixed env var leak in hone coaching tests)
- [x] Coverage floor ratcheted from 26% to 54%

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)