### PR TITLE
Dynamic scene count guidance + honor author preferences

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/prompts_elaborate.py
+++ b/scripts/lib/python/storyforge/prompts_elaborate.py
@@ -273,6 +273,27 @@ If the world needs a bible, output:
 # Stage 3: Scene Map
 # ============================================================================
 
+def _scene_count_range(project_dir: str) -> tuple[int, int]:
+    """Compute the target scene count range from manuscript target_words.
+
+    Scenes should average 1500-2000 words for optimal pipeline behavior:
+    - Under 1200 words: too short to establish, turn, and resolve
+    - Over 3000 words: Claude loses grip on brief constraints in later paragraphs
+    - 1500-2000 is the sweet spot for brief adherence, scoring precision, and revision
+    """
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    raw = read_yaml_field(yaml_path, 'project.target_words')
+    try:
+        target = int(raw)
+    except (TypeError, ValueError):
+        target = 80000  # default
+
+    # Compute range: target / 2000 (lower) to target / 1500 (upper), floor 40
+    lo = max(40, target // 2000)
+    hi = max(lo + 10, target // 1500)
+    return lo, hi
+
+
 def build_map_prompt(project_dir: str, plugin_dir: str,
                      registries_text: str = '') -> str:
     """Build the prompt for the scene map stage."""
@@ -283,6 +304,8 @@ def build_map_prompt(project_dir: str, plugin_dir: str,
     intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
 
     registries_section = f'\n\n{registries_text}\n' if registries_text else ''
+
+    lo, hi = _scene_count_range(project_dir)
 
     return f"""You are mapping a novel — expanding the architecture into a complete scene-by-scene plan with locations, timeline, characters, and thread tracking.
 
@@ -306,7 +329,9 @@ def build_map_prompt(project_dir: str, plugin_dir: str,
 {registries_section}
 ## Instructions
 
-Expand the architecture into the full scene count (40-60 scenes). For each scene:
+Expand the architecture into {lo}-{hi} scenes. Prefer **more, shorter scenes** (1500-2000 words each) over fewer, longer ones. This is important for drafting quality — Claude follows brief constraints more reliably in focused scenes under 2500 words, and scoring/revision are more precise on smaller units.
+
+For each scene:
 
 1. Keep all existing scenes (adjust as needed)
 2. Fill in gaps: transitions, subplot scenes, breathing room

--- a/skills/elaborate/SKILL.md
+++ b/skills/elaborate/SKILL.md
@@ -70,8 +70,6 @@ Based on the author's request, determine the mode:
 
 ### Specific requests (always honored, bypass auto-advance):
 
-**Never question the author's creative direction.** If they say "I want more scenes," "make them shorter," "split this," or "change the structure" — do it immediately. Do not ask for motivation, suggest they reconsider, or explain trade-offs unless they ask. The author's instruction is the requirement.
-
 - **"Start a new novel"** / **"Let's begin"** → Start at spine. Ask for the seed (logline, genre, characters, themes, constraints). Whatever they give you is the seed.
 - **"Work on the spine/architecture/map/briefs"** → Go to that specific stage.
 - **"Develop the voice"** / **"Voice guide"** / **"Style"** → Voice development (see Voice Stage below). Typically happens after architecture and before briefs.
@@ -197,8 +195,6 @@ If they choose Option B, provide the full command and end.
 5. Write updates
 6. Run validation — MICE nesting, timeline, character references
 7. Commit: `git add -A && git commit -m "Elaborate: scene map" && git push`
-
-**If the author requests a different scene count, honor it immediately.** Scene count is an authorial choice — do not question it, ask for motivation, or suggest alternatives. Adjust the map to match their target.
 
 ### Briefs Stage (Interactive)
 

--- a/skills/elaborate/SKILL.md
+++ b/skills/elaborate/SKILL.md
@@ -59,8 +59,8 @@ Based on the project state, identify where the author is:
 | spine | 0 | — | — | — | Needs spine |
 | spine | 5-10 | function only | — | — | Spine done, ready for architecture |
 | architecture | 15-25 | has value_shift | — | — | Architecture done, ready for map |
-| scene-map | 40-60 | has characters, on_stage | — | — | Map done, ready for briefs |
-| briefs | 40-60 | full | has goal/conflict/outcome | — | Briefs done, ready for drafting |
+| scene-map | target_words/2000 to target_words/1500 | has characters, on_stage | — | — | Map done, ready for briefs |
+| briefs | same as map | full | has goal/conflict/outcome | — | Briefs done, ready for drafting |
 | drafting+ | status=drafted | populated but gaps | populated | failures > 0 | **Gap-fill mode** |
 | drafting+ | — | — | — | passes | Past elaboration — redirect to forge |
 
@@ -69,6 +69,8 @@ Based on the project state, identify where the author is:
 Based on the author's request, determine the mode:
 
 ### Specific requests (always honored, bypass auto-advance):
+
+**Never question the author's creative direction.** If they say "I want more scenes," "make them shorter," "split this," or "change the structure" — do it immediately. Do not ask for motivation, suggest they reconsider, or explain trade-offs unless they ask. The author's instruction is the requirement.
 
 - **"Start a new novel"** / **"Let's begin"** → Start at spine. Ask for the seed (logline, genre, characters, themes, constraints). Whatever they give you is the seed.
 - **"Work on the spine/architecture/map/briefs"** → Go to that specific stage.
@@ -189,11 +191,14 @@ If they choose Option B, provide the full command and end.
 ### Scene Map Stage (Interactive)
 
 1. Read architecture scenes and reference materials
-2. Expand to 40-60 scenes: fill gaps, add transitions
-3. Assign locations, timeline, characters, MICE threads — **all registry-backed fields must use canonical IDs** (characters, locations, values, mice_threads). Add new registry entries for anything introduced at this stage.
-4. Write updates
-5. Run validation — MICE nesting, timeline, character references
-6. Commit: `git add -A && git commit -m "Elaborate: scene map" && git push`
+2. Compute target scene count from `project.target_words`: `target_words / 2000` (lower) to `target_words / 1500` (upper), minimum 40. For an 80k novel this is 40-53; for 100k it's 50-67. **Prefer more, shorter scenes** (1500-2000 words each) — Claude follows brief constraints more reliably in focused scenes, and scoring/revision are more precise on smaller units.
+3. Expand to that range: fill gaps, add transitions, subplot scenes, breathing room
+4. Assign locations, timeline, characters, MICE threads — **all registry-backed fields must use canonical IDs** (characters, locations, values, mice_threads). Add new registry entries for anything introduced at this stage.
+5. Write updates
+6. Run validation — MICE nesting, timeline, character references
+7. Commit: `git add -A && git commit -m "Elaborate: scene map" && git push`
+
+**If the author requests a different scene count, honor it immediately.** Scene count is an authorial choice — do not question it, ask for motivation, or suggest alternatives. Adjust the map to match their target.
 
 ### Briefs Stage (Interactive)
 


### PR DESCRIPTION
## Summary

- Scene count is now computed from `project.target_words` instead of hardcoded 40-60
- Prompt explicitly guides toward shorter, focused scenes (1500-2000 words)
- Skill now instructs Claude to never question author's creative direction on scene count

## Changes

**`prompts_elaborate.py`**: New `_scene_count_range()` function computes lo/hi from target_words. `build_map_prompt()` uses dynamic range and explains the pipeline rationale for smaller scenes.

**`skills/elaborate/SKILL.md`**: Updated scene-map stage to use dynamic range with formula. Added directive: "If the author requests a different scene count, honor it immediately."

## Scene count examples
| Target words | Scene range | Avg scene size |
|-------------|-------------|----------------|
| 80,000 | 40-53 | 1500-2000 |
| 100,000 | 50-67 | 1500-2000 |
| 120,000 | 60-80 | 1500-2000 |

## Test plan
- [x] All existing elaborate and prompt tests pass (316 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)