### PR TITLE
Add two-phase deterministic polish loop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -915,6 +915,7 @@ def _run_polish_loop(project_dir: str, max_loops: int,
 
     prev_avg = 0.0
     baseline_summary = None
+    summary = _summarize_diagnosis([])  # safe default if loop never executes
 
     for iteration in range(1, max_loops + 1):
         log(f'\n=== Iteration {iteration}/{max_loops}: Deterministic Score ===')
@@ -926,7 +927,9 @@ def _run_polish_loop(project_dir: str, max_loops: int,
                 sys.exit(1)
             diag_rows = _read_diagnosis(latest_dir)
             if not diag_rows:
-                log('WARNING: No diagnosis found in existing scores — generating empty baseline')
+                log('ERROR: --skip-initial-score but no diagnosis.csv in existing scores')
+                log('  Run a scoring cycle first, or remove --skip-initial-score')
+                sys.exit(1)
             log('  Skipped initial scoring (--skip-initial-score) — using existing scores')
             summary = _summarize_diagnosis(diag_rows)
         else:
@@ -964,12 +967,9 @@ def _run_polish_loop(project_dir: str, max_loops: int,
                             f'Polish: upstream brief fixes for {len(upstream_scenes)} scenes',
                             ['reference/', 'scenes/', 'working/'])
 
-        # Generate targeted plan from diagnosis
+        # Generate targeted plan from diagnosis (writes plan file via _create_versioned_plan)
         log(f'\n=== Iteration {iteration}/{max_loops}: Polish (Sonnet) ===')
         plan_rows = _generate_targeted_polish_plan(csv_plan_file, diag_rows)
-
-        plan_rows[0]['status'] = 'pending'
-        _write_csv_plan(csv_plan_file, plan_rows)
 
         # Use Sonnet for mechanical fixes during deterministic phase
         _execute_single_pass(project_dir, csv_plan_file, plan_rows, iteration,

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -8,7 +8,7 @@ Usage:
     storyforge revise                 # Start from first pending pass
     storyforge revise 3               # Start from pass number 3 (1-indexed)
     storyforge revise --polish        # Craft-only polish plan
-    storyforge revise --polish --loop # Score → polish → re-score until stable
+    storyforge revise --polish --loop # Deterministic score → polish → re-score, then full LLM score
     storyforge revise --naturalness   # 3-pass AI pattern removal
     storyforge revise --structural    # CSV-only from structural proposals
     storyforge revise --dry-run       # Print prompts only
@@ -69,6 +69,8 @@ def parse_args(argv):
                         help='Maximum iterations in --loop mode (default: 5)')
     parser.add_argument('--skip-initial-score', action='store_true',
                         help='Skip initial scoring in --polish --loop (use existing scores)')
+    parser.add_argument('--skip-final-score', action='store_true',
+                        help='Skip full LLM scoring after deterministic loop converges (requires --loop)')
     parser.add_argument('--no-annotations', action='store_true',
                         help='Exclude reader annotations from revision plan')
     parser.add_argument('pass_num', nargs='?', type=int, default=0,
@@ -538,6 +540,78 @@ def _generate_targeted_polish_plan(plan_file: str, diag_rows: list[dict]) -> lis
     return rows
 
 
+def _run_deterministic_score(project_dir: str,
+                             scene_ids: list[str]) -> tuple[str, list[dict]]:
+    """Run deterministic-only scoring (no API calls, $0 cost).
+
+    Scores the 6 deterministic principles (prose_repetition, avoid_passive,
+    avoid_adverbs, no_weather_dreams, sentence_as_thought, economy_clarity),
+    generates diagnosis, and returns (cycle_dir, diag_rows).
+
+    Same return signature as _run_lightweight_score for drop-in use.
+    """
+    from storyforge.scoring import merge_score_files, generate_diagnosis
+    from storyforge.cmd_score import (
+        DETERMINISTIC_PRINCIPLES,
+        _score_repetition, _score_passive, _score_adverbs,
+        _score_weather, _score_rhythm, _score_economy,
+    )
+
+    scores_base = os.path.join(project_dir, 'working', 'scores')
+
+    # Determine cycle number
+    highest = 0
+    if os.path.isdir(scores_base):
+        for name in os.listdir(scores_base):
+            if name.startswith('cycle-'):
+                try:
+                    highest = max(highest, int(name.removeprefix('cycle-')))
+                except ValueError:
+                    pass
+    cycle = highest + 1
+    cycle_dir = os.path.join(scores_base, f'cycle-{cycle}')
+    os.makedirs(cycle_dir, exist_ok=True)
+
+    log(f'  Deterministic scoring {len(scene_ids)} scenes (cycle {cycle}, $0)...')
+
+    scores_path = os.path.join(cycle_dir, 'scene-scores.csv')
+
+    # Run each deterministic scorer and merge results
+    scorers = [
+        ('prose_repetition', _score_repetition),
+        ('avoid_passive', _score_passive),
+        ('avoid_adverbs', _score_adverbs),
+        ('no_weather_dreams', _score_weather),
+        ('sentence_as_thought', _score_rhythm),
+        ('economy_clarity', _score_economy),
+    ]
+    for principle, scorer_fn in scorers:
+        path = scorer_fn(scene_ids, project_dir, cycle_dir)
+        merge_score_files(scores_path, path)
+
+    # Generate diagnosis
+    plugin_dir = get_plugin_dir()
+    weights_file = os.path.join(project_dir, 'working', 'craft-weights.csv')
+
+    # Initialize weights if not yet present
+    from storyforge.scoring import init_craft_weights
+    init_craft_weights(project_dir, plugin_dir)
+
+    prev_dir = os.path.join(scores_base, f'cycle-{highest}') if highest > 0 else '-'
+    if prev_dir != '-' and not os.path.isdir(prev_dir):
+        prev_dir = '-'
+    generate_diagnosis(cycle_dir, prev_dir, weights_file)
+
+    # Update latest symlink
+    latest_link = os.path.join(scores_base, 'latest')
+    if os.path.islink(latest_link):
+        os.remove(latest_link)
+    os.symlink(f'cycle-{cycle}', latest_link)
+
+    diag_rows = _read_diagnosis(cycle_dir)
+    return cycle_dir, diag_rows
+
+
 def _run_lightweight_score(project_dir: str, scene_ids: list[str],
                            parallel: int = 6) -> tuple[str, list[dict]]:
     """Run scene-level scoring only (no branch/PR) and return (cycle_dir, diagnosis_rows).
@@ -791,8 +865,16 @@ def _redraft_scenes(project_dir: str, scene_ids: list[str]) -> int:
 
 def _run_polish_loop(project_dir: str, max_loops: int,
                      coaching_override: str | None, *,
-                     skip_initial_score: bool = False) -> None:
-    """Score → polish → re-score convergence loop."""
+                     skip_initial_score: bool = False,
+                     skip_final_score: bool = False) -> None:
+    """Two-phase polish loop: deterministic scoring → full LLM scoring.
+
+    Phase 1: Score only deterministic principles (free, instant), polish with
+    Sonnet (mechanical fixes), repeat until converged or max_loops reached.
+
+    Phase 2: Run one full LLM scoring pass for the complete picture (unless
+    --skip-final-score is set).
+    """
     from storyforge.common import get_coaching_level, read_yaml_field
     from storyforge.git import create_branch, ensure_branch_pushed, commit_and_push
     from storyforge.scene_filter import build_scene_list
@@ -824,14 +906,20 @@ def _run_polish_loop(project_dir: str, max_loops: int,
     log('============================================')
 
     csv_plan_file = os.path.join(project_dir, 'working', 'plans', 'revision-plan.csv')
+    sonnet_model = select_model('evaluation')
+
+    # ------------------------------------------------------------------
+    # Phase 1: Deterministic scoring loop (free, instant)
+    # ------------------------------------------------------------------
+    log(f'\n=== Phase 1: Deterministic Polish (free) ===')
+
     prev_avg = 0.0
     baseline_summary = None
 
     for iteration in range(1, max_loops + 1):
-        log(f'\n=== Iteration {iteration}/{max_loops}: Score ===')
+        log(f'\n=== Iteration {iteration}/{max_loops}: Deterministic Score ===')
 
         if iteration == 1 and skip_initial_score:
-            # Load existing scores instead of running a new scoring cycle
             latest_dir = os.path.join(project_dir, 'working', 'scores', 'latest')
             if not os.path.isdir(latest_dir):
                 log('ERROR: --skip-initial-score but no existing scores in working/scores/latest')
@@ -842,7 +930,7 @@ def _run_polish_loop(project_dir: str, max_loops: int,
             log('  Skipped initial scoring (--skip-initial-score) — using existing scores')
             summary = _summarize_diagnosis(diag_rows)
         else:
-            cycle_dir, diag_rows = _run_lightweight_score(project_dir, scene_ids)
+            cycle_dir, diag_rows = _run_deterministic_score(project_dir, scene_ids)
             summary = _summarize_diagnosis(diag_rows)
 
         if iteration == 1:
@@ -877,38 +965,46 @@ def _run_polish_loop(project_dir: str, max_loops: int,
                             ['reference/', 'scenes/', 'working/'])
 
         # Generate targeted plan from diagnosis
-        log(f'\n=== Iteration {iteration}/{max_loops}: Polish ===')
+        log(f'\n=== Iteration {iteration}/{max_loops}: Polish (Sonnet) ===')
         plan_rows = _generate_targeted_polish_plan(csv_plan_file, diag_rows)
 
-        # Execute the single polish pass
-        # Reset status to pending
         plan_rows[0]['status'] = 'pending'
         _write_csv_plan(csv_plan_file, plan_rows)
 
-        # Run the pass through the standard execution path
-        _execute_single_pass(project_dir, csv_plan_file, plan_rows, iteration)
+        # Use Sonnet for mechanical fixes during deterministic phase
+        _execute_single_pass(project_dir, csv_plan_file, plan_rows, iteration,
+                             model_override=sonnet_model)
 
     else:
         log(f'\n  Reached max iterations ({max_loops})')
 
-    # Final score for summary
-    log(f'\n=== Final Score ===')
-    _, final_diag = _run_lightweight_score(project_dir, scene_ids)
-    final_summary = _summarize_diagnosis(final_diag)
+    # Commit deterministic phase results
+    commit_and_push(project_dir, 'Polish: deterministic phase complete', ['working/'])
+
+    # ------------------------------------------------------------------
+    # Phase 2: Full LLM scoring (one run for the complete picture)
+    # ------------------------------------------------------------------
+    if skip_final_score:
+        log(f'\n=== Skipping Phase 2: Full Score (--skip-final-score) ===')
+        final_summary = summary
+    else:
+        log(f'\n=== Phase 2: Full Score ===')
+        _, final_diag = _run_lightweight_score(project_dir, scene_ids)
+        final_summary = _summarize_diagnosis(final_diag)
+        commit_and_push(project_dir, 'Polish: full score after deterministic loop',
+                        ['working/'])
 
     log('\n============================================')
     log('Polish loop complete')
     if baseline_summary:
-        log(f'  Before: avg {baseline_summary["overall_avg"]:.2f}, '
+        log(f'  Deterministic baseline: avg {baseline_summary["overall_avg"]:.2f}, '
             f'{baseline_summary["high_count"]} high / {baseline_summary["medium_count"]} medium priority')
-    log(f'  After:  avg {final_summary["overall_avg"]:.2f}, '
+    log(f'  Final: avg {final_summary["overall_avg"]:.2f}, '
         f'{final_summary["high_count"]} high / {final_summary["medium_count"]} medium priority')
     if baseline_summary and baseline_summary['overall_avg'] > 0:
         delta = final_summary['overall_avg'] - baseline_summary['overall_avg']
-        log(f'  Improvement: {delta:+.2f} avg score')
+        log(f'  Deterministic improvement: {delta:+.2f} avg score')
     log('============================================')
-
-    commit_and_push(project_dir, 'Polish: loop complete', ['working/'])
 
 
 def _extract_scene_rationales(project_dir: str, scene_ids: list,
@@ -988,7 +1084,8 @@ def _build_revision_config(plan_row: dict, extra: dict | None = None) -> str:
 
 
 def _execute_single_pass(project_dir: str, csv_plan_file: str,
-                         plan_rows: list[dict], iteration: int) -> None:
+                         plan_rows: list[dict], iteration: int,
+                         model_override: str | None = None) -> None:
     """Execute a single revision pass from a plan. Subset of main pass loop."""
     from storyforge.common import select_revision_model, get_coaching_level
     from storyforge.git import commit_and_push
@@ -1054,7 +1151,7 @@ def _execute_single_pass(project_dir: str, csv_plan_file: str,
     prompt = result.stdout
 
     # Select model and invoke API
-    pass_model = select_revision_model(pass_name, pass_purpose)
+    pass_model = model_override or select_revision_model(pass_name, pass_purpose)
     log_dir = os.path.join(project_dir, 'working', 'logs')
     step_log = os.path.join(log_dir, f'loop-{iteration}-{pass_name}.json')
 
@@ -1273,15 +1370,19 @@ def main(argv=None):
             print('ERROR: --loop and --interactive are incompatible', file=sys.stderr)
             sys.exit(1)
 
-    # Validate --skip-initial-score
+    # Validate --skip-initial-score / --skip-final-score
     if args.skip_initial_score and not args.loop:
         print('ERROR: --skip-initial-score requires --loop', file=sys.stderr)
+        sys.exit(1)
+    if args.skip_final_score and not args.loop:
+        print('ERROR: --skip-final-score requires --loop', file=sys.stderr)
         sys.exit(1)
 
     # Loop mode — takes over execution entirely
     if args.loop:
         _run_polish_loop(project_dir, args.max_loops, args.coaching,
-                         skip_initial_score=args.skip_initial_score)
+                         skip_initial_score=args.skip_initial_score,
+                         skip_final_score=args.skip_final_score)
         return
 
     # Auto-generate plans

--- a/tests/test_revise_loop.py
+++ b/tests/test_revise_loop.py
@@ -365,33 +365,195 @@ class TestDeterministicScore:
         assert os.path.isdir(cycle_dir)
 
 
-class TestExecuteSinglePassModelOverride:
-    """Tests for the model_override parameter on _execute_single_pass."""
+class TestPolishLoopOrchestration:
+    """Integration tests for _run_polish_loop two-phase orchestration."""
 
-    def test_model_override_skips_select_revision_model(self, monkeypatch):
-        """When model_override is set, select_revision_model should not be called."""
-        from storyforge import cmd_revise
+    def _setup_project(self, tmp_path):
+        """Create a minimal project with one scene for loop testing."""
+        project_dir = str(tmp_path / 'project')
+        for d in ('scenes', 'reference', 'working/scores', 'working/plans',
+                  'working/logs'):
+            os.makedirs(os.path.join(project_dir, d))
 
-        called_select = []
-        original_select = cmd_revise.select_revision_model
+        with open(os.path.join(project_dir, 'reference', 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|Test|1|Alice|drafted|100|1000\n')
 
-        def tracking_select(name, purpose=''):
-            called_select.append((name, purpose))
-            return original_select(name, purpose)
+        with open(os.path.join(project_dir, 'scenes', 's01.md'), 'w') as f:
+            f.write('Alice walked slowly through the very quiet garden.\n')
 
-        monkeypatch.setattr('storyforge.cmd_revise.select_revision_model', tracking_select)
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
 
-        # Verify the model_override path directly: when override is set,
-        # `model_override or select_revision_model(...)` short-circuits.
-        override = 'claude-sonnet-4-6'
-        result = override or tracking_select('targeted-polish', 'test')
-        assert result == 'claude-sonnet-4-6'
-        assert len(called_select) == 0  # select was never called
+        return project_dir
 
-    def test_no_override_calls_select_revision_model(self):
-        """Without model_override, select_revision_model determines the model."""
-        from storyforge.common import select_revision_model
-        override = None
-        result = override or select_revision_model('targeted-polish', 'craft polish')
-        # Should get a model string back from select_revision_model
-        assert result in ('claude-opus-4-6', 'claude-sonnet-4-6')
+    def _make_diag(self, high=1, medium=0, avg=3.0):
+        """Build fake diagnosis rows."""
+        rows = []
+        if high:
+            rows.append({'principle': 'avoid_passive', 'scale': 'scene',
+                         'avg_score': str(avg), 'worst_items': 's01',
+                         'delta_from_last': '', 'priority': 'high',
+                         'root_cause': 'craft'})
+        if medium:
+            rows.append({'principle': 'avoid_adverbs', 'scale': 'scene',
+                         'avg_score': str(avg + 0.5), 'worst_items': 's01',
+                         'delta_from_last': '', 'priority': 'medium',
+                         'root_cause': 'craft'})
+        return rows
+
+    def test_phase1_uses_deterministic_score(self, tmp_path, monkeypatch):
+        """Phase 1 should call _run_deterministic_score, not _run_lightweight_score."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+        calls = {'deterministic': 0, 'lightweight': 0}
+
+        converged_diag = self._make_diag(high=0, medium=0)
+
+        def fake_deterministic(proj, scene_ids):
+            calls['deterministic'] += 1
+            cycle_dir = os.path.join(proj, 'working', 'scores', f'cycle-{calls["deterministic"]}')
+            os.makedirs(cycle_dir, exist_ok=True)
+            return cycle_dir, converged_diag
+
+        def fake_lightweight(proj, scene_ids):
+            calls['lightweight'] += 1
+            cycle_dir = os.path.join(proj, 'working', 'scores', f'cycle-full-{calls["lightweight"]}')
+            os.makedirs(cycle_dir, exist_ok=True)
+            return cycle_dir, converged_diag
+
+        monkeypatch.setattr('storyforge.cmd_revise._run_deterministic_score', fake_deterministic)
+        monkeypatch.setattr('storyforge.cmd_revise._run_lightweight_score', fake_lightweight)
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        _run_polish_loop(project_dir, 3, None)
+
+        # Phase 1 used deterministic, Phase 2 used lightweight
+        assert calls['deterministic'] == 1
+        assert calls['lightweight'] == 1
+
+    def test_skip_final_score_skips_phase2(self, tmp_path, monkeypatch):
+        """--skip-final-score should prevent _run_lightweight_score from being called."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+        calls = {'lightweight': 0}
+
+        converged_diag = self._make_diag(high=0, medium=0)
+
+        def fake_deterministic(proj, scene_ids):
+            cycle_dir = os.path.join(proj, 'working', 'scores', 'cycle-1')
+            os.makedirs(cycle_dir, exist_ok=True)
+            return cycle_dir, converged_diag
+
+        def fake_lightweight(proj, scene_ids):
+            calls['lightweight'] += 1
+            return '', converged_diag
+
+        monkeypatch.setattr('storyforge.cmd_revise._run_deterministic_score', fake_deterministic)
+        monkeypatch.setattr('storyforge.cmd_revise._run_lightweight_score', fake_lightweight)
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        _run_polish_loop(project_dir, 3, None, skip_final_score=True)
+
+        assert calls['lightweight'] == 0  # Phase 2 was skipped
+
+    def test_polish_uses_sonnet_model(self, tmp_path, monkeypatch):
+        """Phase 1 polish passes should use Sonnet, not Opus."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+        captured_overrides = []
+
+        # First call: high issues (triggers polish). Second call: converged.
+        call_count = [0]
+        def fake_deterministic(proj, scene_ids):
+            call_count[0] += 1
+            cycle_dir = os.path.join(proj, 'working', 'scores', f'cycle-{call_count[0]}')
+            os.makedirs(cycle_dir, exist_ok=True)
+            if call_count[0] == 1:
+                return cycle_dir, self._make_diag(high=1, avg=2.0)
+            return cycle_dir, self._make_diag(high=0, medium=0, avg=4.5)
+
+        def fake_execute(proj, plan_file, plan_rows, iteration, model_override=None):
+            captured_overrides.append(model_override)
+
+        monkeypatch.setattr('storyforge.cmd_revise._run_deterministic_score', fake_deterministic)
+        monkeypatch.setattr('storyforge.cmd_revise._run_lightweight_score',
+                            lambda p, s: ('', self._make_diag(high=0)))
+        monkeypatch.setattr('storyforge.cmd_revise._execute_single_pass', fake_execute)
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        _run_polish_loop(project_dir, 3, None)
+
+        assert len(captured_overrides) == 1
+        assert captured_overrides[0] == 'claude-sonnet-4-6'
+
+    def test_convergence_stops_loop(self, tmp_path, monkeypatch):
+        """Loop should stop when avg doesn't improve between iterations."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+
+        call_count = [0]
+        def fake_deterministic(proj, scene_ids):
+            call_count[0] += 1
+            cycle_dir = os.path.join(proj, 'working', 'scores', f'cycle-{call_count[0]}')
+            os.makedirs(cycle_dir, exist_ok=True)
+            # Same score every time — should converge after iteration 2
+            return cycle_dir, self._make_diag(high=1, avg=3.0)
+
+        polish_count = [0]
+        def fake_execute(proj, plan_file, plan_rows, iteration, model_override=None):
+            polish_count[0] += 1
+
+        monkeypatch.setattr('storyforge.cmd_revise._run_deterministic_score', fake_deterministic)
+        monkeypatch.setattr('storyforge.cmd_revise._run_lightweight_score',
+                            lambda p, s: ('', []))
+        monkeypatch.setattr('storyforge.cmd_revise._execute_single_pass', fake_execute)
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        _run_polish_loop(project_dir, 5, None, skip_final_score=True)
+
+        # Iteration 1: score + polish. Iteration 2: score, avg <= prev → converge.
+        assert call_count[0] == 2
+        assert polish_count[0] == 1
+
+    def test_zero_max_loops_no_crash(self, tmp_path, monkeypatch):
+        """max_loops=0 should not crash even with skip_final_score=True."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        # Should not raise NameError
+        _run_polish_loop(project_dir, 0, None, skip_final_score=True)
+
+    def test_skip_initial_score_exits_on_empty_diagnosis(self, tmp_path, monkeypatch):
+        """--skip-initial-score with no diagnosis.csv should error, not silently converge."""
+        from storyforge.cmd_revise import _run_polish_loop
+
+        project_dir = self._setup_project(tmp_path)
+
+        # Create a latest dir with no diagnosis.csv
+        latest_dir = os.path.join(project_dir, 'working', 'scores', 'latest')
+        os.makedirs(latest_dir, exist_ok=True)
+
+        monkeypatch.setattr('storyforge.cmd_revise.create_branch', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.ensure_branch_pushed', lambda *a: None)
+        monkeypatch.setattr('storyforge.cmd_revise.commit_and_push', lambda *a, **kw: None)
+
+        with pytest.raises(SystemExit):
+            _run_polish_loop(project_dir, 3, None, skip_initial_score=True)

--- a/tests/test_revise_loop.py
+++ b/tests/test_revise_loop.py
@@ -21,6 +21,23 @@ class TestLoopFlags:
         args = parse_args(['--polish'])
         assert args.loop is False
 
+    def test_parse_skip_final_score(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--polish', '--loop', '--skip-final-score'])
+        assert args.skip_final_score is True
+
+    def test_skip_final_score_default_false(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--polish', '--loop'])
+        assert args.skip_final_score is False
+
+    def test_skip_final_score_requires_loop(self):
+        """--skip-final-score without --loop should exit with error."""
+        from storyforge.cmd_revise import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(['--polish', '--skip-final-score'])
+        assert exc_info.value.code != 0
+
 
 class TestDiagnosisReader:
     def test_read_diagnosis(self, tmp_path):
@@ -241,3 +258,140 @@ class TestVersionedPlans:
         # Symlink points to new plan
         current = _read_csv_plan(plan_file)
         assert current[0]['name'] == 'plan-two'
+
+
+class TestDeterministicScore:
+    """Tests for _run_deterministic_score — lightweight, free scoring path."""
+
+    def _setup_project(self, tmp_path):
+        """Create a minimal project structure for deterministic scoring."""
+        project_dir = str(tmp_path / 'project')
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        ref_dir = os.path.join(project_dir, 'reference')
+        working_dir = os.path.join(project_dir, 'working')
+        scores_dir = os.path.join(working_dir, 'scores')
+        os.makedirs(scenes_dir)
+        os.makedirs(ref_dir)
+        os.makedirs(scores_dir)
+
+        # Minimal scenes.csv
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('test-scene|1|Test Scene|1|Alice|drafted|100|1000\n')
+
+        # A simple scene file
+        with open(os.path.join(scenes_dir, 'test-scene.md'), 'w') as f:
+            f.write('Alice walked slowly through the very quiet garden. '
+                    'She was being watched carefully by the old gardener. '
+                    'The weather was grey and overcast, rain threatening the horizon. '
+                    'It was really quite remarkably beautiful despite everything.\n')
+
+        # storyforge.yaml
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test Project\n')
+
+        return project_dir
+
+    def test_returns_cycle_dir_and_diag_rows(self, tmp_path):
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+        cycle_dir, diag_rows = _run_deterministic_score(project_dir, ['test-scene'])
+
+        assert os.path.isdir(cycle_dir)
+        assert 'cycle-1' in cycle_dir
+        assert isinstance(diag_rows, list)
+
+    def test_creates_scene_scores_csv(self, tmp_path):
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+        cycle_dir, _ = _run_deterministic_score(project_dir, ['test-scene'])
+
+        scores_file = os.path.join(cycle_dir, 'scene-scores.csv')
+        assert os.path.isfile(scores_file)
+
+        with open(scores_file) as f:
+            content = f.read()
+        # Should have scores for deterministic principles
+        assert 'avoid_passive' in content
+        assert 'avoid_adverbs' in content
+        assert 'economy_clarity' in content
+
+    def test_updates_latest_symlink(self, tmp_path):
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+        _run_deterministic_score(project_dir, ['test-scene'])
+
+        latest = os.path.join(project_dir, 'working', 'scores', 'latest')
+        assert os.path.islink(latest)
+        assert os.readlink(latest) == 'cycle-1'
+
+    def test_increments_cycle_number(self, tmp_path):
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+
+        cycle_dir_1, _ = _run_deterministic_score(project_dir, ['test-scene'])
+        assert 'cycle-1' in cycle_dir_1
+
+        cycle_dir_2, _ = _run_deterministic_score(project_dir, ['test-scene'])
+        assert 'cycle-2' in cycle_dir_2
+
+        latest = os.path.join(project_dir, 'working', 'scores', 'latest')
+        assert os.readlink(latest) == 'cycle-2'
+
+    def test_generates_diagnosis(self, tmp_path):
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+        cycle_dir, diag_rows = _run_deterministic_score(project_dir, ['test-scene'])
+
+        diag_file = os.path.join(cycle_dir, 'diagnosis.csv')
+        assert os.path.isfile(diag_file)
+
+    def test_no_api_calls(self, tmp_path, monkeypatch):
+        """Deterministic scoring should never call the API."""
+        from storyforge.cmd_revise import _run_deterministic_score
+
+        project_dir = self._setup_project(tmp_path)
+
+        # Poison the API key — if it tries to call the API, it'll fail
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+        # Should succeed without any API key
+        cycle_dir, diag_rows = _run_deterministic_score(project_dir, ['test-scene'])
+        assert os.path.isdir(cycle_dir)
+
+
+class TestExecuteSinglePassModelOverride:
+    """Tests for the model_override parameter on _execute_single_pass."""
+
+    def test_model_override_skips_select_revision_model(self, monkeypatch):
+        """When model_override is set, select_revision_model should not be called."""
+        from storyforge import cmd_revise
+
+        called_select = []
+        original_select = cmd_revise.select_revision_model
+
+        def tracking_select(name, purpose=''):
+            called_select.append((name, purpose))
+            return original_select(name, purpose)
+
+        monkeypatch.setattr('storyforge.cmd_revise.select_revision_model', tracking_select)
+
+        # Verify the model_override path directly: when override is set,
+        # `model_override or select_revision_model(...)` short-circuits.
+        override = 'claude-sonnet-4-6'
+        result = override or tracking_select('targeted-polish', 'test')
+        assert result == 'claude-sonnet-4-6'
+        assert len(called_select) == 0  # select was never called
+
+    def test_no_override_calls_select_revision_model(self):
+        """Without model_override, select_revision_model determines the model."""
+        from storyforge.common import select_revision_model
+        override = None
+        result = override or select_revision_model('targeted-polish', 'craft polish')
+        # Should get a model string back from select_revision_model
+        assert result in ('claude-opus-4-6', 'claude-sonnet-4-6')


### PR DESCRIPTION
## Summary
- Polish loop now runs deterministic scoring (free, instant) in phase 1 with Sonnet for mechanical fixes, then one full LLM score in phase 2
- New `--skip-final-score` flag to opt out of phase 2
- Fixes pre-existing issues: NameError on zero max_loops, misleading convergence on empty diagnosis, redundant plan file writes

## Test plan
- [x] 3247 tests pass, coverage 74.52%
- [x] Unit tests for _run_deterministic_score (cycle dirs, scores CSV, symlinks, diagnosis, no API calls)
- [x] Integration tests for two-phase loop orchestration (phase routing, model override, convergence, edge cases)
- [x] Regression tests for --skip-final-score flag validation and empty diagnosis error

🤖 Generated with [Claude Code](https://claude.com/claude-code)