### PR TITLE
Fix structural intent passes losing proposal directives

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -167,8 +167,12 @@ def _write_hone_findings(path, fix_location, targets, guidance):
     scene_ids = [t.strip() for t in targets.split(';') if t.strip()] if targets else []
     with open(path, 'w') as f:
         f.write('scene_id|target_file|fields|guidance\n')
-        for sid in scene_ids:
-            f.write(f'{sid}|{target_file}||{guidance}\n')
+        if not scene_ids:
+            # Global scope — write a single row with empty scene_id
+            f.write(f'|{target_file}||{guidance}\n')
+        else:
+            for sid in scene_ids:
+                f.write(f'{sid}|{target_file}||{guidance}\n')
 
 
 def _redraft_from_briefs(project_dir, scene_ids, model, log_dir):
@@ -412,25 +416,39 @@ def _generate_structural_plan(project_dir, plan_file):
     for row in proposals:
         dim = row['dimension']
         if dim not in groups:
-            groups[dim] = {'fix_location': row['fix_location'], 'targets': [], 'rationales': []}
+            groups[dim] = {'fix_location': row['fix_location'], 'targets': [], 'rationales': [], 'changes': []}
         target = row.get('target', 'global').strip()
         if target and target != 'global':
             groups[dim]['targets'].append(target)
         groups[dim]['rationales'].append(row.get('rationale', row.get('change', '')))
+        change = row.get('change', '').strip()
+        if change:
+            groups[dim]['changes'].append(change)
 
     # Sort by fix_location priority
     priority = {'structural': 0, 'intent': 1, 'registry': 2, 'brief': 3}
     sorted_dims = sorted(groups.items(), key=lambda x: priority.get(x[1]['fix_location'], 9))
 
+    from storyforge.structural import _PRESCRIPTIONS_FULL
+
     rows = []
     for i, (dim, info) in enumerate(sorted_dims, 1):
+        # Build guidance from prescription text + proposal change directives
+        guidance_parts = []
+        prescription = _PRESCRIPTIONS_FULL.get(dim, '')
+        if prescription:
+            guidance_parts.append(prescription)
+        if info['changes']:
+            guidance_parts.append('Proposed changes: ' + '; '.join(info['changes']))
+        guidance_text = ' '.join(guidance_parts)
+
         rows.append({
             'pass': str(i),
             'name': f'structural-{dim.replace("_", "-")}',
             'purpose': '; '.join(info['rationales']),
             'scope': 'full',
             'targets': ';'.join(info['targets']) if info['targets'] else '',
-            'guidance': '',
+            'guidance': guidance_text,
             'protection': 'all-strengths',
             'findings': '',
             'status': 'pending',

--- a/scripts/lib/python/storyforge/hone.py
+++ b/scripts/lib/python/storyforge/hone.py
@@ -2196,6 +2196,9 @@ def hone_intent(
         }
 
     # --- Deterministic fix: not_subset (no API required) ---
+    # Add on_stage characters that are missing from characters (not the reverse).
+    # character_presence scoring rewards characters being in on_stage, so we
+    # expand the characters list rather than shrinking on_stage.
     det_fields_rewritten = 0
     not_subset_issues = [i for i in all_issues if i['issue'] == 'not_subset']
     for issue in not_subset_issues:
@@ -2206,10 +2209,11 @@ def hone_intent(
         valid_chars = {c.strip().lower() for c in chars_raw.split(';') if c.strip()}
         on_stage_raw = intent_map[sid].get('on_stage', '')
         on_stage_entries = [c.strip() for c in on_stage_raw.split(';') if c.strip()]
-        filtered = [c for c in on_stage_entries if c.lower() in valid_chars]
-        new_on_stage = ';'.join(filtered)
-        if new_on_stage != on_stage_raw:
-            intent_map[sid]['on_stage'] = new_on_stage
+        missing = [c for c in on_stage_entries if c.lower() not in valid_chars]
+        if missing:
+            existing_chars = [c.strip() for c in chars_raw.split(';') if c.strip()]
+            new_chars = existing_chars + missing
+            intent_map[sid]['characters'] = ';'.join(new_chars)
             det_fields_rewritten += 1
 
     # Write deterministic fixes immediately if any

--- a/tests/test_hone_intent.py
+++ b/tests/test_hone_intent.py
@@ -749,8 +749,9 @@ class TestHoneIntentSignature:
         )
         assert result == {'scenes_flagged': 0, 'scenes_rewritten': 0, 'fields_rewritten': 0}
 
-    def test_deterministic_subset_fix(self, tmp_path):
-        """Not-subset violations should be fixed without API calls."""
+    def test_deterministic_subset_fix_adds_to_characters(self, tmp_path):
+        """Regression: not_subset fix should add missing on_stage chars to characters,
+        not remove them from on_stage. character_presence rewards on_stage presence."""
         from storyforge.hone import hone_intent
         from storyforge.elaborate import _read_csv_as_map
         ref_dir = tmp_path / 'reference'
@@ -768,9 +769,45 @@ class TestHoneIntentSignature:
             coaching_level='strict',  # strict = no API calls, but deterministic fixes still apply
         )
         assert result['fields_rewritten'] >= 1
-        # Verify the fix was written
+        # Verify: bren was ADDED to characters (not removed from on_stage)
         updated = _read_csv_as_map(str(ref_dir / 'scene-intent.csv'))
+        characters = updated['scene-a']['characters']
         on_stage = updated['scene-a']['on_stage']
-        assert 'bren' not in on_stage.lower()
+        # on_stage should be unchanged — bren should still be there
+        assert 'bren' in on_stage.lower()
         assert 'kael' in on_stage.lower()
         assert 'sera' in on_stage.lower()
+        # characters should now include bren
+        assert 'bren' in characters.lower()
+        assert 'kael' in characters.lower()
+        assert 'sera' in characters.lower()
+
+    def test_not_subset_fix_preserves_existing_characters(self, tmp_path):
+        """The fix should preserve all existing characters when adding new ones."""
+        from storyforge.hone import hone_intent
+        from storyforge.elaborate import _read_csv_as_map
+        ref_dir = tmp_path / 'reference'
+        ref_dir.mkdir()
+        (ref_dir / 'scene-intent.csv').write_text(
+            'id|function|action_sequel|emotional_arc|value_at_stake|value_shift|turning_point|characters|on_stage|mice_threads\n'
+            'scene-a|Kael reads the letter|action|dread|truth|-/+|action|kael;sera;dana|kael;sera;bren;tomas|\n'
+        )
+        (ref_dir / 'scenes.csv').write_text('id|seq|title|part|pov|location|timeline_day|time_of_day|duration|type|status|word_count|target_words\nscene-a|1|Test|1|kael|here|1|morning|short|action|drafted|1000|1500\n')
+        os.makedirs(str(tmp_path / 'working' / 'logs'), exist_ok=True)
+        result = hone_intent(
+            ref_dir=str(ref_dir),
+            project_dir=str(tmp_path),
+            log_dir=str(tmp_path / 'working' / 'logs'),
+            coaching_level='strict',
+        )
+        assert result['fields_rewritten'] >= 1
+        updated = _read_csv_as_map(str(ref_dir / 'scene-intent.csv'))
+        characters = updated['scene-a']['characters']
+        chars_list = [c.strip().lower() for c in characters.split(';')]
+        # All original characters preserved
+        assert 'kael' in chars_list
+        assert 'sera' in chars_list
+        assert 'dana' in chars_list
+        # Missing on_stage chars added
+        assert 'bren' in chars_list
+        assert 'tomas' in chars_list

--- a/tests/test_revise_upstream.py
+++ b/tests/test_revise_upstream.py
@@ -1,5 +1,6 @@
 """Tests for revise upstream delegation and validation gate."""
 
+import csv
 import os
 
 
@@ -48,11 +49,132 @@ class TestWriteHoneFindings:
             content = f.read()
         assert 'scene-intent.csv' in content
 
-    def test_empty_targets(self, tmp_path):
+    def test_empty_targets_writes_global_scope_row(self, tmp_path):
+        """Regression: empty targets must produce a global-scope row, not an empty file."""
         from storyforge.cmd_revise import _write_hone_findings
         path = str(tmp_path / 'findings.csv')
         _write_hone_findings(path, 'brief', '', 'General fix')
 
         with open(path) as f:
             lines = f.read().strip().split('\n')
-        assert len(lines) == 1  # Only header, no data rows
+        assert len(lines) == 2  # Header + one global-scope row
+        assert lines[1].startswith('|scene-briefs.csv||General fix')
+
+    def test_empty_targets_intent_target_file(self, tmp_path):
+        """Global scope for intent fix_location uses scene-intent.csv."""
+        from storyforge.cmd_revise import _write_hone_findings
+        path = str(tmp_path / 'findings.csv')
+        _write_hone_findings(path, 'intent', '', 'Fix intent globally')
+
+        with open(path) as f:
+            lines = f.read().strip().split('\n')
+        assert len(lines) == 2
+        assert 'scene-intent.csv' in lines[1]
+
+
+class TestGenerateStructuralPlan:
+    """Regression tests for _generate_structural_plan guidance population."""
+
+    def _write_proposals(self, project_dir, rows):
+        """Write a proposals CSV from a list of row dicts."""
+        scores_dir = os.path.join(project_dir, 'working', 'scores')
+        os.makedirs(scores_dir, exist_ok=True)
+        filepath = os.path.join(scores_dir, 'structural-proposals.csv')
+        header = 'id|dimension|fix_location|target|change|rationale|status'
+        lines = [header]
+        for row in rows:
+            lines.append(
+                f"{row['id']}|{row['dimension']}|{row['fix_location']}|"
+                f"{row['target']}|{row['change']}|{row['rationale']}|{row['status']}"
+            )
+        with open(filepath, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+
+    def test_guidance_includes_prescription_and_change(self, tmp_path):
+        """Regression: guidance must contain prescription text and change directives."""
+        from storyforge.cmd_revise import _generate_structural_plan
+
+        project_dir = str(tmp_path)
+        plans_dir = os.path.join(project_dir, 'working', 'plans')
+        os.makedirs(plans_dir, exist_ok=True)
+        plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+
+        self._write_proposals(project_dir, [{
+            'id': 'sp001',
+            'dimension': 'character_presence',
+            'fix_location': 'intent',
+            'target': 'scene-a',
+            'change': 'add Charlie to on_stage',
+            'rationale': 'Charlie absent from mid-section',
+            'status': 'pending',
+        }])
+
+        rows = _generate_structural_plan(project_dir, plan_file)
+        assert len(rows) == 1
+        guidance = rows[0]['guidance']
+        # Must include the prescription text from _PRESCRIPTIONS_FULL
+        assert 'add them to on_stage' in guidance
+        # Must include the proposal's change directive
+        assert 'add Charlie to on_stage' in guidance
+
+    def test_guidance_empty_change_still_has_prescription(self, tmp_path):
+        """Even with empty change field, guidance should have the prescription."""
+        from storyforge.cmd_revise import _generate_structural_plan
+
+        project_dir = str(tmp_path)
+        plans_dir = os.path.join(project_dir, 'working', 'plans')
+        os.makedirs(plans_dir, exist_ok=True)
+        plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+
+        self._write_proposals(project_dir, [{
+            'id': 'sp001',
+            'dimension': 'pacing_shape',
+            'fix_location': 'intent',
+            'target': 'global',
+            'change': '',
+            'rationale': 'score 0.60 below target 0.70',
+            'status': 'pending',
+        }])
+
+        rows = _generate_structural_plan(project_dir, plan_file)
+        assert len(rows) == 1
+        guidance = rows[0]['guidance']
+        assert 'act proportions' in guidance.lower() or 'Part 1' in guidance
+        # No "Proposed changes:" since change field is empty
+        assert 'Proposed changes:' not in guidance
+
+    def test_multiple_proposals_same_dimension_merge_changes(self, tmp_path):
+        """Multiple proposals for same dimension should merge change directives."""
+        from storyforge.cmd_revise import _generate_structural_plan
+
+        project_dir = str(tmp_path)
+        plans_dir = os.path.join(project_dir, 'working', 'plans')
+        os.makedirs(plans_dir, exist_ok=True)
+        plan_file = os.path.join(plans_dir, 'revision-plan.csv')
+
+        self._write_proposals(project_dir, [
+            {
+                'id': 'sp001',
+                'dimension': 'character_presence',
+                'fix_location': 'intent',
+                'target': 'scene-a',
+                'change': 'add Charlie to on_stage',
+                'rationale': 'Charlie absent',
+                'status': 'pending',
+            },
+            {
+                'id': 'sp002',
+                'dimension': 'character_presence',
+                'fix_location': 'intent',
+                'target': 'scene-b',
+                'change': 'add Dana to characters',
+                'rationale': 'Dana missing',
+                'status': 'pending',
+            },
+        ])
+
+        rows = _generate_structural_plan(project_dir, plan_file)
+        assert len(rows) == 1
+        guidance = rows[0]['guidance']
+        assert 'add Charlie to on_stage' in guidance
+        assert 'add Dana to characters' in guidance


### PR DESCRIPTION
## Summary

Closes #182

Three compounding bugs caused structural intent passes to do the **opposite** of what proposals specified — a `character_presence` proposal to "add to on_stage/characters" resulted in antagonists being removed, dropping the score from 0.66 to 0.52.

- **`_generate_structural_plan()` discarded the `change` field** — guidance was hardcoded to `''`. Now populates it with `_PRESCRIPTIONS_FULL[dimension]` + the proposal's change directives.
- **`_write_hone_findings()` produced empty output for global-scope passes** — when targets was empty, only a header row was written. Now writes a global-scope row with guidance.
- **`not_subset` deterministic fix enforced the wrong direction** — removed characters from `on_stage` instead of adding them to `characters`. Now expands `characters` to include the missing entries.

## Test plan

- [x] 3 regression tests for `_generate_structural_plan` guidance population
- [x] 2 regression tests for `_write_hone_findings` global-scope behavior
- [x] 2 regression tests for `not_subset` fix direction (adds to characters, preserves existing)
- [x] All 79 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)