### PR TITLE
Add score-driven revision with staleness detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/docs/superpowers/plans/2026-04-15-score-driven-revision.md
+++ b/docs/superpowers/plans/2026-04-15-score-driven-revision.md
@@ -1,0 +1,1116 @@
+# Score-Driven Revision Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add evaluation staleness detection, a `--scores` revision mode that plans purely from scoring data, and deferred redrafting to avoid redundant scene re-drafts during upstream passes.
+
+**Architecture:** Three independent components: (1) a staleness checker in `scoring.py` that compares eval age against manuscript changes, (2) a `--scores` plan generator in `cmd_revise.py` that reads diagnosis data, (3) a deferred-redraft mode in the pass execution loop. Each can be built and tested independently.
+
+**Tech Stack:** Python, existing `storyforge` modules (`scoring.py`, `cmd_revise.py`, `cmd_evaluate.py`, `hone.py`), pipe-delimited CSV, git.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `scripts/lib/python/storyforge/scoring.py` | Add `check_eval_staleness()` and `is_full_llm_cycle()` |
+| `scripts/lib/python/storyforge/cmd_evaluate.py` | Write word count snapshot at end of eval |
+| `scripts/lib/python/storyforge/cmd_revise.py` | Add `--scores` flag + `_generate_scores_plan()`, deferred redraft logic |
+| `tests/test_eval_staleness.py` | Tests for staleness detection |
+| `tests/test_revise_scores.py` | Tests for `--scores` plan generation |
+| `tests/test_deferred_redraft.py` | Tests for deferred redrafting |
+
+---
+
+### Task 1: Add `is_full_llm_cycle()` to scoring.py
+
+A utility that checks whether a scoring cycle directory contains full LLM results (not just deterministic). Used by staleness detection to count meaningful scoring runs.
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/scoring.py`
+- Create: `tests/test_eval_staleness.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_eval_staleness.py
+"""Tests for evaluation staleness detection."""
+
+import os
+import pytest
+
+
+class TestIsFullLlmCycle:
+    def test_deterministic_only_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-1')
+        os.makedirs(cycle_dir)
+        # Write scores with only deterministic principles
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+            f.write('s01|avoid_passive|3.5\n')
+            f.write('s01|avoid_adverbs|4.0\n')
+            f.write('s01|economy_clarity|3.8\n')
+            f.write('s01|prose_repetition|4.2\n')
+            f.write('s01|no_weather_dreams|5.0\n')
+            f.write('s01|sentence_as_thought|3.9\n')
+
+        assert is_full_llm_cycle(cycle_dir) is False
+
+    def test_full_llm_returns_true(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-2')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+            f.write('s01|avoid_passive|3.5\n')
+            f.write('s01|prose_naturalness|2.8\n')
+            f.write('s01|dialogue_authenticity|3.2\n')
+
+        assert is_full_llm_cycle(cycle_dir) is True
+
+    def test_missing_scores_file_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-3')
+        os.makedirs(cycle_dir)
+        assert is_full_llm_cycle(cycle_dir) is False
+
+    def test_empty_scores_file_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-4')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+
+        assert is_full_llm_cycle(cycle_dir) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py::TestIsFullLlmCycle -v`
+Expected: FAIL — `is_full_llm_cycle` does not exist
+
+- [ ] **Step 3: Implement `is_full_llm_cycle`**
+
+Add at the end of `scripts/lib/python/storyforge/scoring.py` (before any `if __name__` block if present):
+
+```python
+# The 6 deterministic principles that don't require LLM calls
+_DETERMINISTIC_PRINCIPLES = frozenset([
+    'prose_repetition', 'avoid_passive', 'avoid_adverbs',
+    'no_weather_dreams', 'sentence_as_thought', 'economy_clarity',
+])
+
+
+def is_full_llm_cycle(cycle_dir: str) -> bool:
+    """Check if a scoring cycle contains full LLM results (not deterministic-only).
+
+    A full LLM cycle has scores for principles beyond the 6 deterministic ones.
+    """
+    scores_file = os.path.join(cycle_dir, 'scene-scores.csv')
+    if not os.path.isfile(scores_file):
+        return False
+
+    with open(scores_file, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f, delimiter='|')
+        for row in reader:
+            principle = row.get('principle', '').strip()
+            if principle and principle not in _DETERMINISTIC_PRINCIPLES:
+                return True
+    return False
+```
+
+Make sure `import csv` and `import os` are present at the top of `scoring.py` (they already are).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py::TestIsFullLlmCycle -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/scoring.py tests/test_eval_staleness.py
+git commit -m "Add is_full_llm_cycle to distinguish deterministic from full scoring"
+git push
+```
+
+---
+
+### Task 2: Write word count snapshot in cmd_evaluate.py
+
+At the end of a successful evaluation, write `word-counts.csv` into the eval directory.
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_evaluate.py` (insert before line 1331, the cost summary block)
+- Modify: `tests/test_eval_staleness.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_eval_staleness.py`:
+
+```python
+class TestWordCountSnapshot:
+    def test_write_snapshot(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+        ref_dir = str(tmp_path / 'reference')
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|First|1|Alice|drafted|2847|3000\n')
+            f.write('s02|2|Second|1|Bob|drafted|3102|3000\n')
+
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+
+        snapshot = os.path.join(eval_dir, 'word-counts.csv')
+        assert os.path.isfile(snapshot)
+
+        with open(snapshot) as f:
+            content = f.read()
+        assert 'id|word_count' in content
+        assert 's01|2847' in content
+        assert 's02|3102' in content
+
+    def test_write_snapshot_skips_zero_wordcount(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+        ref_dir = str(tmp_path / 'reference')
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|First|1|Alice|drafted|2847|3000\n')
+            f.write('s02|2|Second|1|Bob|outline|0|3000\n')
+
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+
+        with open(os.path.join(eval_dir, 'word-counts.csv')) as f:
+            content = f.read()
+        assert 's01|2847' in content
+        assert 's02' not in content  # zero word count excluded
+
+    def test_write_snapshot_no_scenes_csv(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+
+        # Should not raise, just skip
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+        assert not os.path.isfile(os.path.join(eval_dir, 'word-counts.csv'))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py::TestWordCountSnapshot -v`
+Expected: FAIL — `_write_word_count_snapshot` does not exist
+
+- [ ] **Step 3: Implement `_write_word_count_snapshot`**
+
+Add to `scripts/lib/python/storyforge/cmd_evaluate.py` near the other helper functions (before `main()`):
+
+```python
+def _write_word_count_snapshot(eval_dir: str, project_dir: str) -> None:
+    """Write word count snapshot for staleness detection."""
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    if not os.path.isfile(scenes_csv):
+        return
+
+    from storyforge.csv_cli import get_column, list_ids
+    ids = list_ids(scenes_csv)
+    wc_col = get_column(scenes_csv, 'word_count')
+
+    snapshot_path = os.path.join(eval_dir, 'word-counts.csv')
+    with open(snapshot_path, 'w') as f:
+        f.write('id|word_count\n')
+        for scene_id, wc in zip(ids, wc_col):
+            if wc and wc != '0':
+                f.write(f'{scene_id}|{wc}\n')
+```
+
+- [ ] **Step 4: Wire into main()**
+
+In `cmd_evaluate.py`, insert before line 1331 (the `# Cost summary` comment):
+
+```python
+    # Write word count snapshot for staleness detection
+    _write_word_count_snapshot(eval_dir, project_dir)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py -v`
+Expected: All passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_evaluate.py tests/test_eval_staleness.py
+git commit -m "Add word count snapshot at end of evaluation for staleness detection"
+git push
+```
+
+---
+
+### Task 3: Implement `check_eval_staleness()` in scoring.py
+
+The core staleness detection function. Compares latest eval against current state.
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/scoring.py`
+- Modify: `tests/test_eval_staleness.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_eval_staleness.py`:
+
+```python
+class TestCheckEvalStaleness:
+    def _setup_project(self, tmp_path, eval_date='20260408-120000',
+                       snapshot_words=None, current_words=None,
+                       full_cycles_after_eval=0, det_cycles_after_eval=0):
+        """Build a minimal project with eval dir and scoring cycles."""
+        project_dir = str(tmp_path / 'project')
+        eval_base = os.path.join(project_dir, 'working', 'evaluations')
+        scores_base = os.path.join(project_dir, 'working', 'scores')
+        ref_dir = os.path.join(project_dir, 'reference')
+        os.makedirs(eval_base)
+        os.makedirs(scores_base)
+        os.makedirs(ref_dir)
+
+        # Create eval dir with optional word count snapshot
+        eval_dir = os.path.join(eval_base, f'eval-{eval_date}')
+        os.makedirs(eval_dir)
+        with open(os.path.join(eval_dir, 'synthesis.md'), 'w') as f:
+            f.write('Evaluation summary')
+
+        if snapshot_words:
+            with open(os.path.join(eval_dir, 'word-counts.csv'), 'w') as f:
+                f.write('id|word_count\n')
+                for sid, wc in snapshot_words.items():
+                    f.write(f'{sid}|{wc}\n')
+
+        # Create current scenes.csv
+        words = current_words or snapshot_words or {'s01': 3000}
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            for i, (sid, wc) in enumerate(words.items(), 1):
+                f.write(f'{sid}|{i}|Scene {i}|1|Alice|drafted|{wc}|3000\n')
+
+        # Create scoring cycles (deterministic-only)
+        for c in range(1, det_cycles_after_eval + 1):
+            cycle_dir = os.path.join(scores_base, f'cycle-{c}')
+            os.makedirs(cycle_dir)
+            with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+                f.write('scene_id|principle|score\n')
+                f.write('s01|avoid_passive|3.5\n')
+
+        # Create full LLM cycles (numbered after deterministic)
+        offset = det_cycles_after_eval
+        for c in range(1, full_cycles_after_eval + 1):
+            cycle_dir = os.path.join(scores_base, f'cycle-{offset + c}')
+            os.makedirs(cycle_dir)
+            with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+                f.write('scene_id|principle|score\n')
+                f.write('s01|avoid_passive|3.5\n')
+                f.write('s01|prose_naturalness|2.8\n')
+
+        # storyforge.yaml
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
+
+        return project_dir
+
+    def test_no_eval_is_stale(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(os.path.join(project_dir, 'working', 'evaluations'))
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert 'no evaluation found' in result['reasons']
+
+    def test_fresh_eval_no_changes(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000, 's02': 2500}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['word_delta_pct'] == 0.0
+        assert result['score_runs_since'] == 0
+
+    def test_stale_by_word_delta(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        snapshot = {'s01': 3000, 's02': 2500, 's03': 2000}  # total 7500
+        current = {'s01': 4000, 's02': 3500, 's03': 2000}   # delta=2000, 26.7%
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=snapshot, current_words=current)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert result['word_delta_pct'] > 0.20
+        assert any('word delta' in r for r in result['reasons'])
+
+    def test_not_stale_below_word_threshold(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        snapshot = {'s01': 3000, 's02': 2500}  # total 5500
+        current = {'s01': 3200, 's02': 2600}   # delta=300, 5.5%
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=snapshot, current_words=current)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['word_delta_pct'] < 0.20
+
+    def test_stale_by_full_score_runs(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words,
+            full_cycles_after_eval=2)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert result['score_runs_since'] >= 2
+        assert any('score runs' in r for r in result['reasons'])
+
+    def test_deterministic_cycles_dont_count(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words,
+            det_cycles_after_eval=5, full_cycles_after_eval=1)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['score_runs_since'] == 1
+
+    def test_no_snapshot_still_works(self, tmp_path):
+        """Old evals without word-counts.csv should not crash."""
+        from storyforge.scoring import check_eval_staleness
+
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=None, current_words={'s01': 3000})
+        result = check_eval_staleness(project_dir)
+        # Without snapshot, word delta can't be computed — defaults to 0
+        assert result['word_delta_pct'] == 0.0
+        assert result['stale'] is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py::TestCheckEvalStaleness -v`
+Expected: FAIL — `check_eval_staleness` does not exist
+
+- [ ] **Step 3: Implement `check_eval_staleness`**
+
+Add to `scripts/lib/python/storyforge/scoring.py` after `is_full_llm_cycle`:
+
+```python
+STALENESS_WORD_DELTA_THRESHOLD = 0.20  # 20% cumulative word delta
+STALENESS_SCORE_RUNS_THRESHOLD = 2     # 2+ full LLM scoring runs
+
+
+def check_eval_staleness(project_dir: str) -> dict:
+    """Check whether the latest evaluation is stale relative to current manuscript state.
+
+    Returns dict with keys: stale, reasons, eval_dir, eval_date,
+    word_delta_pct, score_runs_since.
+    """
+    result = {
+        'stale': False,
+        'reasons': [],
+        'eval_dir': None,
+        'eval_date': None,
+        'word_delta_pct': 0.0,
+        'score_runs_since': 0,
+    }
+
+    # Find latest evaluation
+    eval_base = os.path.join(project_dir, 'working', 'evaluations')
+    if not os.path.isdir(eval_base):
+        result['stale'] = True
+        result['reasons'].append('no evaluation found')
+        return result
+
+    eval_dirs = sorted([
+        d for d in os.listdir(eval_base)
+        if d.startswith('eval-') and os.path.isdir(os.path.join(eval_base, d))
+    ])
+    if not eval_dirs:
+        result['stale'] = True
+        result['reasons'].append('no evaluation found')
+        return result
+
+    latest_eval = eval_dirs[-1]
+    result['eval_dir'] = os.path.join(eval_base, latest_eval)
+    # Extract date portion (eval-YYYYMMDD or eval-YYYYMMDD-HHMMSS)
+    result['eval_date'] = latest_eval.removeprefix('eval-')[:8]
+
+    # Count full LLM scoring runs since eval
+    scores_base = os.path.join(project_dir, 'working', 'scores')
+    if os.path.isdir(scores_base):
+        for name in sorted(os.listdir(scores_base)):
+            if not name.startswith('cycle-'):
+                continue
+            cycle_dir = os.path.join(scores_base, name)
+            if not os.path.isdir(cycle_dir):
+                continue
+            if is_full_llm_cycle(cycle_dir):
+                result['score_runs_since'] += 1
+
+    if result['score_runs_since'] >= STALENESS_SCORE_RUNS_THRESHOLD:
+        result['stale'] = True
+        result['reasons'].append(
+            f'{result["score_runs_since"]} full score runs since evaluation')
+
+    # Compute word delta from snapshot
+    snapshot_file = os.path.join(result['eval_dir'], 'word-counts.csv')
+    if os.path.isfile(snapshot_file):
+        snapshot = {}
+        with open(snapshot_file, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f, delimiter='|')
+            for row in reader:
+                sid = row.get('id', '').strip()
+                wc = row.get('word_count', '0').strip()
+                if sid and wc and wc != '0':
+                    snapshot[sid] = int(wc)
+
+        # Read current word counts
+        from storyforge.csv_cli import get_column, list_ids
+        scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        if os.path.isfile(scenes_csv) and snapshot:
+            ids = list_ids(scenes_csv)
+            wc_col = get_column(scenes_csv, 'word_count')
+            current = {}
+            for sid, wc in zip(ids, wc_col):
+                if wc and wc != '0':
+                    current[sid] = int(wc)
+
+            total_snapshot = sum(snapshot.values())
+            if total_snapshot > 0:
+                delta_sum = sum(
+                    abs(current.get(sid, 0) - snapshot.get(sid, 0))
+                    for sid in set(snapshot) | set(current)
+                )
+                result['word_delta_pct'] = delta_sum / total_snapshot
+
+                if result['word_delta_pct'] >= STALENESS_WORD_DELTA_THRESHOLD:
+                    result['stale'] = True
+                    pct = result['word_delta_pct'] * 100
+                    result['reasons'].append(f'{pct:.0f}% word delta since evaluation')
+
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_eval_staleness.py -v`
+Expected: All passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/scoring.py tests/test_eval_staleness.py
+git commit -m "Add check_eval_staleness for detecting outdated evaluation findings"
+git push
+```
+
+---
+
+### Task 4: Add `--scores` flag and `_generate_scores_plan()` to cmd_revise.py
+
+New plan generator that reads diagnosis data and creates upstream + craft passes.
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_revise.py` (add flag to `parse_args`, add plan generator, wire into `main()`)
+- Create: `tests/test_revise_scores.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_revise_scores.py
+"""Tests for revise --scores mode."""
+
+import os
+import pytest
+
+
+class TestScoresFlag:
+    def test_parse_scores_flag(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--scores'])
+        assert args.scores is True
+
+    def test_scores_default_false(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--polish'])
+        assert args.scores is False
+
+    def test_scores_mutually_exclusive_with_polish(self):
+        from storyforge.cmd_revise import main
+        with pytest.raises(SystemExit):
+            main(['--scores', '--polish'])
+
+    def test_scores_mutually_exclusive_with_structural(self):
+        from storyforge.cmd_revise import main
+        with pytest.raises(SystemExit):
+            main(['--scores', '--structural'])
+
+
+class TestGenerateScoresPlan:
+    def test_generates_brief_pass_from_diagnosis(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01;s03;s05', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'economy_clarity', 'scale': 'scene', 'avg_score': '2.5',
+             'worst_items': 's01;s02', 'priority': 'high', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert len(rows) >= 1
+        # Should have at least one brief pass
+        brief_passes = [r for r in rows if r['fix_location'] == 'brief']
+        assert len(brief_passes) >= 1
+        # Targets should include worst scenes
+        all_targets = ';'.join(r['targets'] for r in brief_passes)
+        assert 's01' in all_targets
+
+    def test_generates_craft_pass_for_craft_root_cause(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01', 'priority': 'high', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        craft_passes = [r for r in rows if r['fix_location'] == 'craft']
+        assert len(craft_passes) >= 1
+
+    def test_brief_passes_come_before_craft(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'dialogue_authenticity', 'scale': 'scene', 'avg_score': '2.5',
+             'worst_items': 's02', 'priority': 'high', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        # Find first brief and first craft pass positions
+        brief_idx = next(i for i, r in enumerate(rows) if r['fix_location'] == 'brief')
+        craft_idx = next(i for i, r in enumerate(rows) if r['fix_location'] == 'craft')
+        assert brief_idx < craft_idx
+
+    def test_no_actionable_items_returns_empty(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '4.5',
+             'worst_items': '', 'priority': 'low', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert rows == []
+
+    def test_scenes_ranked_by_frequency(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'p1', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01;s02;s03', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'p2', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01;s03', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'p3', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01', 'priority': 'medium', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        brief_passes = [r for r in rows if r['fix_location'] == 'brief']
+        # s01 appears in all 3, s03 in 2, s02 in 1
+        # All should be targeted but s01 should appear
+        all_targets = ';'.join(r['targets'] for r in brief_passes)
+        assert 's01' in all_targets
+
+    def test_excludes_act_scale(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'genre_contract', 'scale': 'act', 'avg_score': '1.5',
+             'worst_items': '', 'priority': 'high', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert rows == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_revise_scores.py -v`
+Expected: FAIL — `_generate_scores_plan` and `args.scores` don't exist
+
+- [ ] **Step 3: Add `--scores` flag to `parse_args`**
+
+In `cmd_revise.py`, in `parse_args()`, after the `--polish` argument (line ~62), add:
+
+```python
+    parser.add_argument('--scores', action='store_true',
+                        help='Auto-generate revision plan from scoring diagnosis (upstream + craft)')
+```
+
+- [ ] **Step 4: Update the mutual exclusivity check in `main()`**
+
+In `main()`, find the mode count check (line ~1456):
+
+```python
+    mode_count = sum([args.structural, args.polish, args.naturalness])
+```
+
+Change to:
+
+```python
+    mode_count = sum([args.structural, args.polish, args.naturalness, args.scores])
+```
+
+- [ ] **Step 5: Implement `_generate_scores_plan`**
+
+Insert after `_generate_structural_plan` (~line 450) in `cmd_revise.py`:
+
+```python
+def _generate_scores_plan(plan_file: str, diag_rows: list[dict]) -> list[dict]:
+    """Generate a revision plan from scoring diagnosis data.
+
+    Creates upstream (brief) passes for brief-root-cause items and
+    targeted craft passes for craft-root-cause items. Returns empty list
+    if no actionable items.
+    """
+    from collections import Counter
+
+    # Filter to actionable scene-level items
+    actionable = [r for r in diag_rows
+                  if r.get('scale') == 'scene'
+                  and r.get('priority') in ('high', 'medium')
+                  and r.get('worst_items')]
+
+    if not actionable:
+        return []
+
+    # Separate by root cause
+    brief_items = [r for r in actionable if r.get('root_cause') == 'brief']
+    craft_items = [r for r in actionable if r.get('root_cause') != 'brief']
+
+    rows = []
+    pass_num = 0
+
+    # Brief passes: rank scenes by frequency across principles
+    if brief_items:
+        scene_freq = Counter()
+        scene_principles = {}
+        for item in brief_items:
+            for sid in item['worst_items'].split(';'):
+                sid = sid.strip()
+                if sid:
+                    scene_freq[sid] += 1
+                    scene_principles.setdefault(sid, []).append(
+                        item['principle'].replace('_', ' '))
+
+        # Sort by frequency (chronic underperformers first)
+        ranked = [sid for sid, _ in scene_freq.most_common()]
+
+        # Build guidance from principles
+        principle_names = sorted(set(
+            item['principle'].replace('_', ' ') for item in brief_items))
+        guidance = (
+            'Score-driven upstream fixes. Weak principles: '
+            + ', '.join(principle_names)
+            + '. Scenes ranked by frequency of appearance across weak principles.'
+            + ' Fix abstract, overspecified, or verbose brief fields.'
+        )
+
+        pass_num += 1
+        rows.append({
+            'pass': str(pass_num),
+            'name': 'score-driven-briefs',
+            'purpose': f'Fix briefs for {len(ranked)} scenes with brief-root-cause issues across {len(brief_items)} principles',
+            'scope': 'scene-level',
+            'targets': ';'.join(ranked),
+            'guidance': guidance,
+            'protection': 'voice-quality',
+            'findings': 'scores',
+            'status': 'pending',
+            'model_tier': 'sonnet',
+            'fix_location': 'brief',
+        })
+
+    # Craft pass: targeted polish for craft-root-cause items
+    if craft_items:
+        craft_scenes = set()
+        craft_principles = []
+        for item in craft_items:
+            craft_principles.append(
+                f'{item["principle"].replace("_", " ")} (avg {item.get("avg_score", "?")})')
+            for sid in item['worst_items'].split(';'):
+                sid = sid.strip()
+                if sid:
+                    craft_scenes.add(sid)
+
+        guidance = (
+            'Score-driven craft polish. Target principles:\n'
+            + '\n'.join(f'  - {p}' for p in craft_principles)
+            + '\nFollow the voice guide strictly. Preserve plot, character, and continuity.'
+        )
+
+        pass_num += 1
+        rows.append({
+            'pass': str(pass_num),
+            'name': 'score-driven-craft',
+            'purpose': f'Craft polish targeting {len(craft_items)} weak principles',
+            'scope': 'scene-level',
+            'targets': ';'.join(sorted(craft_scenes)),
+            'guidance': guidance,
+            'protection': 'voice-quality',
+            'findings': 'scores',
+            'status': 'pending',
+            'model_tier': 'opus',
+            'fix_location': 'craft',
+        })
+
+    if rows:
+        _create_versioned_plan(plan_file, rows)
+        log(f'Generated score-driven plan: {len(rows)} passes')
+
+    return rows
+```
+
+- [ ] **Step 6: Wire `--scores` into `main()`**
+
+In `main()`, after the `--polish` plan generation block (line ~1490) and before `elif os.path.isfile(csv_plan_file)`, add:
+
+```python
+    elif args.scores:
+        log('Scores mode -- generating revision plan from diagnosis data...')
+        diag_file = os.path.join(project_dir, 'working', 'scores', 'latest', 'diagnosis.csv')
+        if not os.path.isfile(diag_file):
+            log(f'ERROR: No diagnosis found at {diag_file}')
+            log('Run: storyforge score first')
+            sys.exit(1)
+        diag_rows = _read_diagnosis(os.path.dirname(diag_file))
+        plan_rows = _generate_scores_plan(csv_plan_file, diag_rows)
+        if not plan_rows:
+            log('No actionable items in diagnosis — nothing to revise')
+            sys.exit(0)
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_revise_scores.py -v`
+Expected: All passed
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_revise.py tests/test_revise_scores.py
+git commit -m "Add --scores flag for score-driven revision planning"
+git push
+```
+
+---
+
+### Task 5: Implement deferred redrafting
+
+Change the pass execution loop to batch redrafts after all upstream passes complete.
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_revise.py` (the main pass loop in `main()`, lines ~1682-1825)
+- Create: `tests/test_deferred_redraft.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_deferred_redraft.py
+"""Tests for deferred redrafting in revision pass execution."""
+
+import os
+import pytest
+
+
+class TestDeferredRedraft:
+    def test_collect_upstream_scenes(self):
+        """_collect_upstream_scenes should gather all scenes from upstream passes."""
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-fix-1', 'fix_location': 'brief',
+             'targets': 's01;s02;s03', 'status': 'pending'},
+            {'pass': '2', 'name': 'intent-fix', 'fix_location': 'intent',
+             'targets': 's02;s04', 'status': 'pending'},
+            {'pass': '3', 'name': 'craft-polish', 'fix_location': 'craft',
+             'targets': 's01;s05', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        # Only brief + intent passes, not craft
+        assert scenes == {'s01', 's02', 's03', 's04'}
+        assert count == 2  # 2 upstream passes
+
+    def test_no_upstream_passes_returns_empty(self):
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'craft', 'fix_location': 'craft',
+             'targets': 's01', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == set()
+        assert count == 0
+
+    def test_skips_completed_passes(self):
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-1', 'fix_location': 'brief',
+             'targets': 's01', 'status': 'completed'},
+            {'pass': '2', 'name': 'brief-2', 'fix_location': 'brief',
+             'targets': 's02', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == {'s02'}
+        assert count == 1
+
+    def test_single_upstream_pass_still_defers(self):
+        """Even with one upstream pass, redraft should be deferred (consistent behavior)."""
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-fix', 'fix_location': 'brief',
+             'targets': 's01;s02', 'status': 'pending'},
+            {'pass': '2', 'name': 'craft', 'fix_location': 'craft',
+             'targets': '', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == {'s01', 's02'}
+        assert count == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_deferred_redraft.py -v`
+Expected: FAIL — `_collect_upstream_scenes` does not exist
+
+- [ ] **Step 3: Implement `_collect_upstream_scenes`**
+
+Add to `cmd_revise.py` after `_count_passes` (~line 200):
+
+```python
+def _collect_upstream_scenes(plan_rows: list[dict]) -> tuple[set[str], int]:
+    """Scan plan for pending upstream passes and collect all target scenes.
+
+    Returns (scene_ids, upstream_pass_count). Used to defer redrafting
+    until all upstream CSV fixes are complete.
+    """
+    scenes = set()
+    count = 0
+    for row in plan_rows:
+        if row.get('fix_location') not in ('brief', 'intent'):
+            continue
+        if row.get('status') == 'completed':
+            continue
+        count += 1
+        targets = row.get('targets', '')
+        for sid in targets.split(';'):
+            sid = sid.strip()
+            if sid:
+                scenes.add(sid)
+    return scenes, count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_deferred_redraft.py -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Modify the main pass loop to defer redrafts**
+
+In the main pass loop in `main()`, the hone delegation block (lines ~1752-1825) currently calls `_redraft_from_briefs` at line 1804. We need to:
+
+1. **Before the main pass loop** (~line 1682), add lookahead:
+
+```python
+    # Check for deferred redrafting (multiple upstream passes)
+    deferred_scenes, upstream_count = _collect_upstream_scenes(plan_rows)
+    defer_redraft = upstream_count >= 1 and len(deferred_scenes) > 0
+    if defer_redraft:
+        log(f'Deferred redrafting enabled: {upstream_count} upstream passes, '
+            f'{len(deferred_scenes)} scenes will be redrafted after all CSV fixes')
+    redraft_needed = set()  # Track scenes that actually changed
+```
+
+2. **In the hone delegation block**, replace the redraft call at line 1801-1804:
+
+Replace:
+```python
+            # Redraft affected scenes in full coaching mode
+            if effective_coaching == 'full' and targets:
+                affected = [t.strip() for t in targets.split(';') if t.strip()]
+                _redraft_from_briefs(project_dir, affected, pass_model, log_dir)
+```
+
+With:
+```python
+            # Track or execute redraft
+            if effective_coaching == 'full' and targets:
+                affected = [t.strip() for t in targets.split(';') if t.strip()]
+                if defer_redraft:
+                    redraft_needed.update(affected)
+                    log(f'  Deferred redraft for {len(affected)} scenes (will batch after all upstream passes)')
+                else:
+                    _redraft_from_briefs(project_dir, affected, pass_model, log_dir)
+```
+
+3. **After the main pass loop ends** (after the `for pass_num in range(...)` loop), add batch redraft:
+
+```python
+    # Batch redraft deferred scenes
+    if defer_redraft and redraft_needed:
+        log(f'\n=== Batch Redraft: {len(redraft_needed)} scenes ===')
+        pass_model = select_revision_model('redraft', 'redraft from corrected briefs')
+        _redraft_from_briefs(project_dir, sorted(redraft_needed), pass_model, log_dir)
+```
+
+- [ ] **Step 6: Run deferred redraft tests**
+
+Run: `python3 -m pytest tests/test_deferred_redraft.py -v`
+Expected: All passed
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `python3 -m pytest tests/ --tb=short`
+Expected: No regressions
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_revise.py tests/test_deferred_redraft.py
+git commit -m "Add deferred redrafting to batch scene re-drafts after all upstream passes"
+git push
+```
+
+---
+
+### Task 6: Update revise skill for staleness awareness
+
+Modify the SKILL.md to call staleness detection and adjust recommendations.
+
+**Files:**
+- Modify: `skills/revise/SKILL.md`
+
+- [ ] **Step 1: Read current skill**
+
+Read `skills/revise/SKILL.md` to understand the current structure — specifically the "Read Project State" and "Determine Mode" sections.
+
+- [ ] **Step 2: Add staleness check to "Read Project State"**
+
+In the section where the skill reads project state (scores, evaluations), add a staleness check step:
+
+```markdown
+### Staleness Check
+
+Run the staleness check to determine how to weight evaluation findings:
+
+```bash
+python3 -c "
+from storyforge.scoring import check_eval_staleness
+import json, sys
+result = check_eval_staleness('PROJECT_DIR')
+print(json.dumps(result, indent=2))
+"
+```
+
+**If `stale: true`:** The evaluation findings are historical context only. Do NOT use them to generate specific scene targets or structural recommendations. Base all revision planning on current scores (diagnosis.csv). Present a staleness notice to the author.
+
+**If `stale: false`:** Evaluation findings are current and actionable. Use them alongside scores as today.
+
+**If `eval_dir: null`:** No evaluation exists. Use scores only.
+```
+
+- [ ] **Step 3: Update "Determine Mode" with score-driven option**
+
+Add the stale-eval option set to the mode determination section. When eval is stale, the primary options become:
+
+```markdown
+#### When Evaluation Is Stale
+
+> **Note:** The evaluation from {eval_date} has been superseded by significant changes ({reasons}). Recommendations below are based on current scores. Evaluation findings are shown as historical context below.
+
+1. **Score-driven revision** (`storyforge revise --scores`) — Upstream brief fixes + targeted craft polish based on current diagnosis. **Recommended.**
+2. **Polish loop** (`storyforge revise --polish --loop`) — Craft-only convergence from current scores.
+3. **Re-evaluate first** — Run `storyforge evaluate` before planning revision.
+4. **Use evaluation anyway** — Treat stale evaluation findings as still actionable (author override).
+```
+
+- [ ] **Step 4: Add `--scores` to the script delegation section**
+
+In the script delegation section where option A/B is offered, add the `--scores` command:
+
+```markdown
+> **Option A: Run it here**
+> I'll launch the command in this conversation.
+>
+> **Option B: Run it yourself**
+> ```bash
+> cd [project_dir] && [plugin_path]/storyforge revise --scores
+> ```
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/revise/SKILL.md
+git commit -m "Update revise skill with staleness detection and score-driven mode"
+git push
+```
+
+---
+
+### Task 7: Version bump
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Bump patch version**
+
+Change `"version": "1.15.1"` to `"version": "1.16.0"` (minor bump — new feature).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "Bump version to 1.16.0"
+git push
+```

--- a/docs/superpowers/specs/2026-04-15-score-driven-revision-design.md
+++ b/docs/superpowers/specs/2026-04-15-score-driven-revision-design.md
@@ -1,0 +1,163 @@
+# Score-Driven Revision with Staleness Detection
+
+## Problem
+
+The revise pipeline treats evaluation findings (from `cmd_evaluate.py`) and scoring data (from `cmd_score.py`) with equal weight, but evaluations can become stale after significant manuscript changes. When multiple polish loops, brief rewrites, and redrafts have occurred since the last evaluation, the eval findings describe prose that no longer exists. This leads to revision plans anchored on outdated structural recommendations.
+
+Additionally, when a revision plan contains multiple upstream passes (brief/intent fixes) targeting overlapping scenes, each pass redrafts its scenes immediately — wasting expensive Opus calls when a later pass will modify the same scene's CSV data and require yet another redraft.
+
+## Goals
+
+1. Detect when evaluation findings are stale relative to current manuscript state
+2. Provide a purely score-driven revision mode (`--scores`) that works from diagnosis data alone
+3. Adapt the interactive revise skill to downweight stale evaluations automatically
+4. Defer scene redrafting until all upstream CSV fixes are complete
+
+## Non-Goals
+
+- Re-running evaluations automatically (that's the author's decision)
+- Changing how scoring or diagnosis works
+- Modifying the evaluation pipeline itself (beyond adding a word count snapshot)
+
+## Design
+
+### Component 1: Word Count Snapshots at Evaluation Time
+
+**Where:** `cmd_evaluate.py`, at the end of a successful evaluation run.
+
+**What:** Write `working/evaluations/eval-{date}/word-counts.csv` — a pipe-delimited file:
+
+```
+id|word_count
+before|2847
+seeing|3102
+sleepless|2560
+```
+
+One row per scene, copied from the current `scenes.csv` `word_count` column. This is a snapshot of what the evaluation actually assessed.
+
+**Cost:** Zero API calls, ~1ms. The file is tiny.
+
+### Component 2: Staleness Detection Function
+
+**Where:** New function `check_eval_staleness(project_dir)` in `scoring.py` (alongside existing diagnosis logic).
+
+**Returns:**
+
+```python
+{
+    'stale': bool,
+    'reasons': list[str],
+    'eval_dir': str | None,
+    'eval_date': str | None,
+    'word_delta_pct': float,
+    'score_runs_since': int,
+}
+```
+
+**Algorithm:**
+
+1. **Find latest evaluation:** Scan `working/evaluations/` for `eval-*` directories, sort by date suffix, take the most recent. If none exists, return `stale=True` with reason `'no evaluation found'`.
+
+2. **Count full scoring runs since eval:** Scan `working/scores/cycle-*` directories. A cycle counts as a "full LLM scoring run" if it contains files beyond what deterministic-only scoring produces (deterministic scoring only creates `scene-scores.csv` and `diagnosis.csv` from the 6 deterministic scorers; full LLM scoring also creates per-evaluator output files or a marker). Count cycles whose date (from directory name or file mtime) post-dates the evaluation. **Stale if >= 2 full scoring runs since eval.**
+
+3. **Compute word delta:** Read the eval's `word-counts.csv` snapshot. For each scene, compute `abs(current_word_count - snapshot_word_count)`. Sum all deltas and divide by the sum of snapshot word counts to get a percentage. **Stale if >= 20% cumulative word delta.**
+
+4. **Fallback for old evals without snapshots:** If `word-counts.csv` doesn't exist in the eval directory, fall back to `git diff --stat` on `scenes/` since the eval date. Parse insertions + deletions as a proxy for change magnitude. This is less precise (line-level, not word-level) but serviceable for legacy evals.
+
+5. **Either signal triggers staleness.** Both signals are reported in `reasons` so the skill can explain why.
+
+### Component 3: Score-Driven Revision Mode (`--scores`)
+
+**Where:** New flag in `cmd_revise.py`, mutually exclusive with `--polish`, `--naturalness`, `--structural`.
+
+**What it does:**
+
+1. Read `working/scores/latest/diagnosis.csv`
+2. Separate high/medium priority items by `root_cause`:
+   - `root_cause: brief` — scenes needing upstream CSV fixes
+   - `root_cause: craft` — scenes needing prose-level polish
+3. For brief-root-cause items: cross-reference `worst_items` across all affected principles. Rank scenes by how many weak principles they appear in (chronic underperformers first).
+4. Generate a revision plan:
+   - One or more `fix_location: brief` passes targeting the worst scenes (grouped into manageable batches)
+   - A `fix_location: craft` targeted polish pass for craft-root-cause items
+5. Execute the plan using existing infrastructure (hone for brief fixes, revision prompts for craft)
+
+**Relationship to other modes:**
+- `--scores` generates a complete upstream + craft plan from scoring data
+- `--polish --loop` does craft-only convergence (with some upstream detection built in)
+- `--scores` followed by `--polish --loop` would be a full score-driven pipeline
+- If `--scores` finds no upstream issues, it falls through to a targeted craft plan (similar to `--polish` but with principle-specific targeting from diagnosis)
+
+### Component 4: Deferred Redrafting
+
+**Where:** The pass execution logic in `cmd_revise.py`, specifically in `_execute_single_pass` and the callers that iterate over plan passes.
+
+**Problem:** Currently, each upstream pass (brief/intent fix) calls `_redraft_scenes()` at the end. When passes 1, 2, and 3 all target overlapping scenes, scenes get redrafted multiple times — each redraft takes ~1 min with Opus and is wasted if a subsequent pass modifies the same scene's CSV data.
+
+**Solution:** Before executing passes, look ahead in the plan:
+
+1. Identify all passes with `fix_location` in `('brief', 'intent')` — these are upstream passes.
+2. Collect the union of all scenes targeted across those passes.
+3. Execute each upstream pass's CSV fixes (hone delegation) **without redrafting**.
+4. After all upstream passes complete, redraft the deduplicated set of scenes that had any CSV field modified.
+5. Commit once after the batch redraft.
+6. Then proceed to craft passes as normal.
+
+**Implementation approach:** The main pass execution loop already iterates over plan rows. Add a "deferred redraft" mode:
+- Before the loop, partition plan rows into upstream passes and craft passes
+- Execute upstream passes with redrafting suppressed (a flag or separate code path in the upstream delegation logic)
+- Track which scenes had CSV changes across all upstream passes
+- Batch redraft the union
+- Then execute craft passes normally
+
+**Edge case:** If there's only one upstream pass, this optimization still applies (no behavioral change — it just redrafts at the same time it would have before). The optimization is most impactful with 2+ upstream passes targeting overlapping scenes.
+
+### Component 5: Revise Skill Adaptation
+
+**Where:** `skills/revise/SKILL.md`
+
+**New behavior in the "Read Project State" step:**
+
+The skill calls `check_eval_staleness()` (via a Python one-liner or by reading the function's output). Based on the result:
+
+**Fresh eval (not stale):**
+- Current behavior unchanged. Eval findings are precise and actionable. Scores supplement.
+- Options presented as today: full revision, upstream + polish, polish only, naturalness.
+
+**Stale eval:**
+- Skill displays a staleness notice: "The evaluation from {date} has been superseded by significant changes ({reasons}). Recommendations below are based on current scores. Evaluation findings are shown as historical context."
+- Eval findings are presented in a clearly labeled "Historical Context" section — not hidden, but not used to generate specific scene targets or structural recommendations.
+- Primary recommendation shifts to `--scores` mode.
+- Option list:
+  1. **Score-driven revision** (`--scores`) — upstream brief fixes + targeted craft polish based on current diagnosis. Recommended.
+  2. **Polish loop** (`--polish --loop`) — craft-only convergence from current scores.
+  3. **Re-evaluate first** — run a fresh evaluation before planning revision.
+  4. **Use evaluation anyway** — treat stale eval findings as still actionable (author override).
+
+**No eval:**
+- Score-driven and polish modes only. No eval-based options presented.
+
+## Distinguishing Full LLM Scoring from Deterministic-Only Cycles
+
+The staleness check needs to count full LLM scoring runs, not deterministic iterations. The simplest reliable signal: a full LLM scoring cycle produces score files for non-deterministic principles (e.g., `prose_naturalness`, `dialogue_authenticity`). A deterministic-only cycle only contains scores for the 6 deterministic principles (`prose_repetition`, `avoid_passive`, `avoid_adverbs`, `no_weather_dreams`, `sentence_as_thought`, `economy_clarity`).
+
+The staleness checker reads `scene-scores.csv` in each cycle directory and checks whether any non-deterministic principles are present. If so, it's a full run.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `scripts/lib/python/storyforge/cmd_evaluate.py` | Write word count snapshot at end of eval |
+| `scripts/lib/python/storyforge/scoring.py` | Add `check_eval_staleness()` function |
+| `scripts/lib/python/storyforge/cmd_revise.py` | Add `--scores` flag, plan generation from diagnosis, deferred redrafting logic |
+| `skills/revise/SKILL.md` | Staleness-aware recommendation flow |
+| `tests/test_revise_loop.py` | Tests for `--scores` flag |
+| `tests/test_scoring.py` | Tests for `check_eval_staleness()` |
+
+## Thresholds
+
+| Signal | Threshold | Rationale |
+|--------|-----------|-----------|
+| Cumulative word delta | >= 20% of manuscript | At this level, 1 in 5 words has changed — the eval assessed meaningfully different prose |
+| Full scoring runs since eval | >= 2 | Two full score cycles means the manuscript has been through at least one complete score-polish-rescore cycle |

--- a/scripts/lib/python/storyforge/cmd_evaluate.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate.py
@@ -804,6 +804,24 @@ def _update_cycle(project_dir, cycle_id, field, value):
         f.writelines(lines)
 
 
+def _write_word_count_snapshot(eval_dir: str, project_dir: str) -> None:
+    """Write word count snapshot for staleness detection."""
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    if not os.path.isfile(scenes_csv):
+        return
+
+    from storyforge.csv_cli import get_column, list_ids
+    ids = list_ids(scenes_csv)
+    wc_col = get_column(scenes_csv, 'word_count')
+
+    snapshot_path = os.path.join(eval_dir, 'word-counts.csv')
+    with open(snapshot_path, 'w') as f:
+        f.write('id|word_count\n')
+        for scene_id, wc in zip(ids, wc_col):
+            if wc and wc != '0':
+                f.write(f'{scene_id}|{wc}\n')
+
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -1327,6 +1345,9 @@ def main(argv=None):
     if os.path.isfile(os.path.join(eval_dir, 'findings.yaml')):
         log(f'  Browse findings:    cat {eval_dir}/findings.yaml')
     log(f'  Read individual:    ls {eval_dir}/')
+
+    # Write word count snapshot for staleness detection
+    _write_word_count_snapshot(eval_dir, project_dir)
 
     # Cost summary
     print_summary(project_dir, 'evaluate')

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -62,6 +62,8 @@ def parse_args(argv):
                         help='Auto-generate 3-pass plan targeting AI prose patterns')
     parser.add_argument('--polish', action='store_true',
                         help='Auto-generate craft-only polish plan')
+    parser.add_argument('--scores', action='store_true',
+                        help='Auto-generate revision plan from scoring diagnosis (upstream + craft)')
     parser.add_argument('--coaching', choices=['full', 'coach', 'strict'],
                         help='Override coaching level')
     parser.add_argument('--loop', action='store_true',
@@ -442,6 +444,109 @@ def _generate_structural_plan(project_dir, plan_file):
 
     for i, (dim, info) in enumerate(sorted_dims, 1):
         log(f'  Pass {i}: {dim} (fix_location: {info["fix_location"]})')
+
+    return rows
+
+
+def _generate_scores_plan(plan_file: str, diag_rows: list) -> list:
+    """Generate a revision plan from scoring diagnosis data.
+
+    Creates upstream (brief) passes for brief-root-cause items and
+    targeted craft passes for craft-root-cause items. Returns empty list
+    if no actionable items.
+    """
+    from collections import Counter
+
+    # Filter to actionable scene-level items
+    actionable = [r for r in diag_rows
+                  if r.get('scale') == 'scene'
+                  and r.get('priority') in ('high', 'medium')
+                  and r.get('worst_items')]
+
+    if not actionable:
+        return []
+
+    # Separate by root cause
+    brief_items = [r for r in actionable if r.get('root_cause') == 'brief']
+    craft_items = [r for r in actionable if r.get('root_cause') != 'brief']
+
+    rows = []
+    pass_num = 0
+
+    # Brief passes: rank scenes by frequency across principles
+    if brief_items:
+        scene_freq = Counter()
+        scene_principles = {}
+        for item in brief_items:
+            for sid in item['worst_items'].split(';'):
+                sid = sid.strip()
+                if sid:
+                    scene_freq[sid] += 1
+                    scene_principles.setdefault(sid, []).append(
+                        item['principle'].replace('_', ' '))
+
+        ranked = [sid for sid, _ in scene_freq.most_common()]
+
+        principle_names = sorted(set(
+            item['principle'].replace('_', ' ') for item in brief_items))
+        guidance = (
+            'Score-driven upstream fixes. Weak principles: '
+            + ', '.join(principle_names)
+            + '. Scenes ranked by frequency of appearance across weak principles.'
+            + ' Fix abstract, overspecified, or verbose brief fields.'
+        )
+
+        pass_num += 1
+        rows.append({
+            'pass': str(pass_num),
+            'name': 'score-driven-briefs',
+            'purpose': f'Fix briefs for {len(ranked)} scenes with brief-root-cause issues across {len(brief_items)} principles',
+            'scope': 'scene-level',
+            'targets': ';'.join(ranked),
+            'guidance': guidance,
+            'protection': 'voice-quality',
+            'findings': 'scores',
+            'status': 'pending',
+            'model_tier': 'sonnet',
+            'fix_location': 'brief',
+        })
+
+    # Craft pass: targeted polish for craft-root-cause items
+    if craft_items:
+        craft_scenes = set()
+        craft_principles = []
+        for item in craft_items:
+            craft_principles.append(
+                f'{item["principle"].replace("_", " ")} (avg {item.get("avg_score", "?")})')
+            for sid in item['worst_items'].split(';'):
+                sid = sid.strip()
+                if sid:
+                    craft_scenes.add(sid)
+
+        guidance = (
+            'Score-driven craft polish. Target principles:\n'
+            + '\n'.join(f'  - {p}' for p in craft_principles)
+            + '\nFollow the voice guide strictly. Preserve plot, character, and continuity.'
+        )
+
+        pass_num += 1
+        rows.append({
+            'pass': str(pass_num),
+            'name': 'score-driven-craft',
+            'purpose': f'Craft polish targeting {len(craft_items)} weak principles',
+            'scope': 'scene-level',
+            'targets': ';'.join(sorted(craft_scenes)),
+            'guidance': guidance,
+            'protection': 'voice-quality',
+            'findings': 'scores',
+            'status': 'pending',
+            'model_tier': 'opus',
+            'fix_location': 'craft',
+        })
+
+    if rows:
+        _create_versioned_plan(plan_file, rows)
+        log(f'Generated score-driven plan: {len(rows)} passes')
 
     return rows
 
@@ -1481,9 +1586,9 @@ def main(argv=None):
     yaml_plan_file = os.path.join(project_dir, 'working', 'plans', 'revision-plan.yaml')
 
     # Check mutually exclusive modes
-    mode_count = sum([args.structural, args.polish, args.naturalness])
+    mode_count = sum([args.structural, args.polish, args.naturalness, args.scores])
     if mode_count > 1:
-        print('ERROR: --structural, --polish, and --naturalness are mutually exclusive.', file=sys.stderr)
+        print('ERROR: --structural, --polish, --naturalness, and --scores are mutually exclusive.', file=sys.stderr)
         sys.exit(1)
 
     # Validate --loop
@@ -1532,6 +1637,18 @@ def main(argv=None):
             commit_and_push(project_dir, 'Naturalness: upstream brief fixes',
                             ['reference/', 'scenes/', 'working/'])
         plan_rows = _generate_naturalness_plan(csv_plan_file, project_dir)
+    elif args.scores:
+        log('Scores mode -- generating revision plan from diagnosis data...')
+        diag_file = os.path.join(project_dir, 'working', 'scores', 'latest', 'diagnosis.csv')
+        if not os.path.isfile(diag_file):
+            log(f'ERROR: No diagnosis found at {diag_file}')
+            log('Run: storyforge score first')
+            sys.exit(1)
+        diag_rows = _read_diagnosis(os.path.dirname(diag_file))
+        plan_rows = _generate_scores_plan(csv_plan_file, diag_rows)
+        if not plan_rows:
+            log('No actionable items in diagnosis -- nothing to revise')
+            sys.exit(0)
     elif args.structural:
         plan_rows = _generate_structural_plan(project_dir, csv_plan_file)
     elif os.path.isfile(csv_plan_file):

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -203,6 +203,28 @@ def _count_passes(rows):
     return len(rows)
 
 
+def _collect_upstream_scenes(plan_rows: list) -> tuple:
+    """Scan plan for pending upstream passes and collect all target scenes.
+
+    Returns (scene_ids, upstream_pass_count). Used to defer redrafting
+    until all upstream CSV fixes are complete.
+    """
+    scenes = set()
+    count = 0
+    for row in plan_rows:
+        if row.get('fix_location') not in ('brief', 'intent'):
+            continue
+        if row.get('status') == 'completed':
+            continue
+        count += 1
+        targets = row.get('targets', '')
+        for sid in targets.split(';'):
+            sid = sid.strip()
+            if sid:
+                scenes.add(sid)
+    return scenes, count
+
+
 def _read_pass_field(rows, pass_num, field):
     """Read a field from a pass (1-indexed)."""
     idx = pass_num - 1
@@ -1796,6 +1818,14 @@ def main(argv=None):
         total_forecast = per_pass * pending
         log(f'Cost forecast: ~${total_forecast:.2f} ({pending} passes @ ~${per_pass:.2f})')
 
+    # Check for deferred redrafting (multiple upstream passes)
+    deferred_scenes, upstream_count = _collect_upstream_scenes(plan_rows)
+    defer_redraft = upstream_count >= 1 and len(deferred_scenes) > 0
+    if defer_redraft:
+        log(f'Deferred redrafting enabled: {upstream_count} upstream passes, '
+            f'{len(deferred_scenes)} scenes will be redrafted after all CSV fixes')
+    redraft_needed = set()
+
     # ---- MAIN PASS LOOP ----
     for pass_num in range(start_pass, total_passes + 1):
         pass_name = _read_pass_field(plan_rows, pass_num, 'name')
@@ -1915,10 +1945,14 @@ def main(argv=None):
             scenes_changed = hone_result.get('scenes_rewritten', 0)
             log(f'  Upstream: {scenes_changed} scenes, {fields_changed} fields rewritten')
 
-            # Redraft affected scenes in full coaching mode
+            # Track or execute redraft
             if effective_coaching == 'full' and targets:
                 affected = [t.strip() for t in targets.split(';') if t.strip()]
-                _redraft_from_briefs(project_dir, affected, pass_model, log_dir)
+                if defer_redraft:
+                    redraft_needed.update(affected)
+                    log(f'  Deferred redraft for {len(affected)} scenes (will batch after all upstream passes)')
+                else:
+                    _redraft_from_briefs(project_dir, affected, pass_model, log_dir)
 
             # Log usage (hone handles its own API logging; pass empty string)
             _log_usage(project_dir, '', 'revise', pass_name, pass_model, duration)
@@ -2213,6 +2247,12 @@ Rules:
             if next_status != 'completed':
                 log('Pausing 10s before next pass...')
                 time.sleep(10)
+
+    # Batch redraft deferred scenes
+    if defer_redraft and redraft_needed:
+        log(f'\n=== Batch Redraft: {len(redraft_needed)} scenes ===')
+        pass_model = select_revision_model('redraft', 'redraft from corrected briefs')
+        _redraft_from_briefs(project_dir, sorted(redraft_needed), pass_model, log_dir)
 
     # ---- SESSION SUMMARY ----
     completed = sum(

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -1871,6 +1871,8 @@ def is_full_llm_cycle(cycle_dir: str) -> bool:
     """Check if a scoring cycle contains full LLM results (not deterministic-only).
 
     A full LLM cycle has scores for principles beyond the 6 deterministic ones.
+    Handles both wide format (principles as column headers) and long format
+    (principle column with one row per scene-principle pair).
     """
     scores_file = os.path.join(cycle_dir, 'scene-scores.csv')
     if not os.path.isfile(scores_file):
@@ -1878,10 +1880,24 @@ def is_full_llm_cycle(cycle_dir: str) -> bool:
 
     with open(scores_file, newline='', encoding='utf-8') as f:
         reader = csv.DictReader(f, delimiter='|')
-        for row in reader:
-            principle = row.get('principle', '').strip()
-            if principle and principle not in _DETERMINISTIC_PRINCIPLES:
+        if reader.fieldnames is None:
+            return False
+
+        # Wide format: principles are column names (e.g., id|avoid_passive|prose_naturalness|...)
+        # Check if any column header is a non-deterministic principle
+        skip_cols = {'id', 'scene_id', 'principle', 'score', 'rationale'}
+        for col in reader.fieldnames:
+            col = col.strip()
+            if col and col not in skip_cols and col not in _DETERMINISTIC_PRINCIPLES:
                 return True
+
+        # Long format fallback: look for a 'principle' column with non-deterministic values
+        if 'principle' in reader.fieldnames:
+            for row in reader:
+                principle = row.get('principle', '').strip()
+                if principle and principle not in _DETERMINISTIC_PRINCIPLES:
+                    return True
+
     return False
 
 
@@ -1911,18 +1927,27 @@ def check_eval_staleness(project_dir: str) -> dict:
         result['reasons'].append('no evaluation found')
         return result
 
-    eval_dirs = sorted([
+    eval_dirs = [
         d for d in os.listdir(eval_base)
         if d.startswith('eval-') and os.path.isdir(os.path.join(eval_base, d))
-    ])
+    ]
     if not eval_dirs:
         result['stale'] = True
         result['reasons'].append('no evaluation found')
         return result
 
+    # Sort by modification time (most recent last) — handles non-standard names
+    eval_dirs.sort(key=lambda d: os.path.getmtime(os.path.join(eval_base, d)))
     latest_eval = eval_dirs[-1]
     result['eval_dir'] = os.path.join(eval_base, latest_eval)
-    result['eval_date'] = latest_eval.removeprefix('eval-')[:8]
+    # Extract date: try YYYYMMDD after 'eval-', fall back to dir mtime
+    date_part = latest_eval.removeprefix('eval-')
+    if len(date_part) >= 8 and date_part[:8].isdigit():
+        result['eval_date'] = date_part[:8]
+    else:
+        from datetime import datetime
+        mtime = os.path.getmtime(os.path.join(eval_base, latest_eval))
+        result['eval_date'] = datetime.fromtimestamp(mtime).strftime('%Y%m%d')
 
     # Count full LLM scoring runs since eval
     scores_base = os.path.join(project_dir, 'working', 'scores')

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -4,6 +4,7 @@ Replaces scripts/lib/scoring.sh — provides score parsing, CSV merging,
 weighted-text generation, diagnosis, and proposal generation.
 """
 
+import csv
 import math
 import os
 import re
@@ -1858,6 +1859,30 @@ def main():
     else:
         print(f'Unknown command: {command}', file=sys.stderr)
         sys.exit(1)
+
+
+_DETERMINISTIC_PRINCIPLES = frozenset([
+    'prose_repetition', 'avoid_passive', 'avoid_adverbs',
+    'no_weather_dreams', 'sentence_as_thought', 'economy_clarity',
+])
+
+
+def is_full_llm_cycle(cycle_dir: str) -> bool:
+    """Check if a scoring cycle contains full LLM results (not deterministic-only).
+
+    A full LLM cycle has scores for principles beyond the 6 deterministic ones.
+    """
+    scores_file = os.path.join(cycle_dir, 'scene-scores.csv')
+    if not os.path.isfile(scores_file):
+        return False
+
+    with open(scores_file, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f, delimiter='|')
+        for row in reader:
+            principle = row.get('principle', '').strip()
+            if principle and principle not in _DETERMINISTIC_PRINCIPLES:
+                return True
+    return False
 
 
 if __name__ == '__main__':

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -1885,5 +1885,100 @@ def is_full_llm_cycle(cycle_dir: str) -> bool:
     return False
 
 
+STALENESS_WORD_DELTA_THRESHOLD = 0.20  # 20% cumulative word delta
+STALENESS_SCORE_RUNS_THRESHOLD = 2     # 2+ full LLM scoring runs
+
+
+def check_eval_staleness(project_dir: str) -> dict:
+    """Check whether the latest evaluation is stale relative to current manuscript state.
+
+    Returns dict with keys: stale, reasons, eval_dir, eval_date,
+    word_delta_pct, score_runs_since.
+    """
+    result = {
+        'stale': False,
+        'reasons': [],
+        'eval_dir': None,
+        'eval_date': None,
+        'word_delta_pct': 0.0,
+        'score_runs_since': 0,
+    }
+
+    # Find latest evaluation
+    eval_base = os.path.join(project_dir, 'working', 'evaluations')
+    if not os.path.isdir(eval_base):
+        result['stale'] = True
+        result['reasons'].append('no evaluation found')
+        return result
+
+    eval_dirs = sorted([
+        d for d in os.listdir(eval_base)
+        if d.startswith('eval-') and os.path.isdir(os.path.join(eval_base, d))
+    ])
+    if not eval_dirs:
+        result['stale'] = True
+        result['reasons'].append('no evaluation found')
+        return result
+
+    latest_eval = eval_dirs[-1]
+    result['eval_dir'] = os.path.join(eval_base, latest_eval)
+    result['eval_date'] = latest_eval.removeprefix('eval-')[:8]
+
+    # Count full LLM scoring runs since eval
+    scores_base = os.path.join(project_dir, 'working', 'scores')
+    if os.path.isdir(scores_base):
+        for name in sorted(os.listdir(scores_base)):
+            if not name.startswith('cycle-'):
+                continue
+            cycle_dir = os.path.join(scores_base, name)
+            if not os.path.isdir(cycle_dir):
+                continue
+            if is_full_llm_cycle(cycle_dir):
+                result['score_runs_since'] += 1
+
+    if result['score_runs_since'] >= STALENESS_SCORE_RUNS_THRESHOLD:
+        result['stale'] = True
+        result['reasons'].append(
+            f'{result["score_runs_since"]} full score runs since evaluation')
+
+    # Compute word delta from snapshot
+    snapshot_file = os.path.join(result['eval_dir'], 'word-counts.csv')
+    if os.path.isfile(snapshot_file):
+        snapshot = {}
+        with open(snapshot_file, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f, delimiter='|')
+            for row in reader:
+                sid = row.get('id', '').strip()
+                wc = row.get('word_count', '0').strip()
+                if sid and wc and wc != '0':
+                    snapshot[sid] = int(wc)
+
+        # Read current word counts
+        from storyforge.csv_cli import get_column, list_ids
+        scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+        if os.path.isfile(scenes_csv) and snapshot:
+            ids = list_ids(scenes_csv)
+            wc_col = get_column(scenes_csv, 'word_count')
+            current = {}
+            for sid, wc in zip(ids, wc_col):
+                if wc and wc != '0':
+                    current[sid] = int(wc)
+
+            total_snapshot = sum(snapshot.values())
+            if total_snapshot > 0:
+                delta_sum = sum(
+                    abs(current.get(sid, 0) - snapshot.get(sid, 0))
+                    for sid in set(snapshot) | set(current)
+                )
+                result['word_delta_pct'] = delta_sum / total_snapshot
+
+                if result['word_delta_pct'] >= STALENESS_WORD_DELTA_THRESHOLD:
+                    result['stale'] = True
+                    pct = result['word_delta_pct'] * 100
+                    result['reasons'].append(f'{pct:.0f}% word delta since evaluation')
+
+    return result
+
+
 if __name__ == '__main__':
     main()

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revise
-description: Plan and execute revision — analyze evaluation findings, create upstream + craft passes, execute them, and review results. Use when the author has evaluation results and wants to revise, or after scoring reveals issues, or when the author asks to polish prose.
+description: Plan and execute revision — analyze evaluation findings or scoring data, create upstream + craft passes, execute them, and review results. Automatically detects stale evaluations and shifts to score-driven mode. Use when the author has evaluation results and wants to revise, after scoring reveals issues, or when the author asks to polish prose.
 ---
 
 # Storyforge Revise
@@ -23,12 +23,47 @@ Store this resolved plugin path for use throughout the session.
 6. Existing revision plan: `working/plans/revision-plan.csv`
 7. Latest review: `working/reviews/` (most recent)
 
+### Staleness Check
+
+After reading project state, check whether the evaluation findings are still current:
+
+```bash
+python3 -c "
+from storyforge.scoring import check_eval_staleness
+import json
+result = check_eval_staleness('PROJECT_DIR')
+print(json.dumps(result, indent=2))
+"
+```
+
+Replace `PROJECT_DIR` with the actual project directory path.
+
+**If `stale: true`:** The evaluation findings are historical context only. Do NOT use them to generate specific scene targets or structural recommendations. Base all revision planning on current scores (`diagnosis.csv`). Present a staleness notice to the author:
+
+> **Note:** The evaluation from {eval_date} has been superseded by significant changes ({reasons}). Recommendations below are based on current scores. Evaluation findings are shown as historical context.
+
+**If `stale: false`:** Evaluation findings are current and actionable. Use them alongside scores as normal.
+
+**If `eval_dir: null`:** No evaluation exists. Use scores only — do not recommend evaluation-based revision.
+
 ## Step 2: Determine Mode
 
 Based on the author's request and project state:
 
 ### "Revise" / "Fix the issues" / "Plan revision"
-→ Full revision cycle: analyze findings, plan passes, execute, review.
+→ Full revision cycle: analyze findings, plan passes, execute, review. **If evaluation is stale**, recommend score-driven mode instead (see below).
+
+### "Fix scores" / "Improve scores" / "Score-driven revision"
+→ Score-driven revision: generate a plan purely from `diagnosis.csv` — upstream brief fixes for brief-root-cause items, targeted craft polish for craft-root-cause items. Equivalent to `./storyforge revise --scores`. **This is the recommended mode when the evaluation is stale.** Also use when the author explicitly wants to work from scoring data rather than evaluation findings.
+
+#### When Evaluation Is Stale
+
+When the staleness check fires, present these options instead of the standard revision options:
+
+1. **Score-driven revision** (`storyforge revise --scores`) — Upstream brief fixes + targeted craft polish based on current diagnosis. **Recommended.**
+2. **Polish loop** (`storyforge revise --polish --loop`) — Craft-only convergence from current scores.
+3. **Re-evaluate first** — Run `storyforge evaluate` before planning revision.
+4. **Use evaluation anyway** — Treat stale evaluation findings as still actionable (author override).
 
 ### "Polish" / "Clean up the prose" / "Polish pass"
 → Craft-only revision: skip planning, target scenes with low craft scores. Equivalent to `./storyforge revise --polish`.
@@ -135,6 +170,7 @@ Offer two options:
 > ```bash
 > cd [project_dir] && [plugin_path]/scripts/storyforge-revise [flags]
 > ```
+> For score-driven (upstream + craft from diagnosis): `./storyforge revise --scores`
 > For craft-only: `./storyforge revise --polish`
 > For autonomous polish loop (score→polish→re-score until stable): `./storyforge revise --polish --loop`
 > For AI pattern removal: `./storyforge revise --naturalness`

--- a/tests/test_deferred_redraft.py
+++ b/tests/test_deferred_redraft.py
@@ -1,0 +1,63 @@
+"""Tests for deferred redrafting in revision pass execution."""
+
+import os
+import pytest
+
+
+class TestDeferredRedraft:
+    def test_collect_upstream_scenes(self):
+        """_collect_upstream_scenes should gather all scenes from upstream passes."""
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-fix-1', 'fix_location': 'brief',
+             'targets': 's01;s02;s03', 'status': 'pending'},
+            {'pass': '2', 'name': 'intent-fix', 'fix_location': 'intent',
+             'targets': 's02;s04', 'status': 'pending'},
+            {'pass': '3', 'name': 'craft-polish', 'fix_location': 'craft',
+             'targets': 's01;s05', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == {'s01', 's02', 's03', 's04'}
+        assert count == 2
+
+    def test_no_upstream_passes_returns_empty(self):
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'craft', 'fix_location': 'craft',
+             'targets': 's01', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == set()
+        assert count == 0
+
+    def test_skips_completed_passes(self):
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-1', 'fix_location': 'brief',
+             'targets': 's01', 'status': 'completed'},
+            {'pass': '2', 'name': 'brief-2', 'fix_location': 'brief',
+             'targets': 's02', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == {'s02'}
+        assert count == 1
+
+    def test_single_upstream_pass_still_defers(self):
+        from storyforge.cmd_revise import _collect_upstream_scenes
+
+        plan_rows = [
+            {'pass': '1', 'name': 'brief-fix', 'fix_location': 'brief',
+             'targets': 's01;s02', 'status': 'pending'},
+            {'pass': '2', 'name': 'craft', 'fix_location': 'craft',
+             'targets': '', 'status': 'pending'},
+        ]
+
+        scenes, count = _collect_upstream_scenes(plan_rows)
+        assert scenes == {'s01', 's02'}
+        assert count == 1

--- a/tests/test_eval_staleness.py
+++ b/tests/test_eval_staleness.py
@@ -261,3 +261,110 @@ class TestCheckEvalStaleness:
         result = check_eval_staleness(project_dir)
         assert result['word_delta_pct'] == 0.0
         assert result['stale'] is False
+
+    def test_nonstandard_eval_name_picks_most_recent(self, tmp_path):
+        """Non-standard eval names (eval-manual-*) should not break sorting."""
+        from storyforge.scoring import check_eval_staleness
+        import time
+
+        project_dir = str(tmp_path / 'project')
+        eval_base = os.path.join(project_dir, 'working', 'evaluations')
+        ref_dir = os.path.join(project_dir, 'reference')
+        os.makedirs(eval_base)
+        os.makedirs(os.path.join(project_dir, 'working', 'scores'))
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|S1|1|A|drafted|3000|3000\n')
+
+        # Create an older standard eval
+        older = os.path.join(eval_base, 'eval-20260408-190141')
+        os.makedirs(older)
+        with open(os.path.join(older, 'synthesis.md'), 'w') as f:
+            f.write('older')
+
+        # Small delay to ensure different mtime
+        time.sleep(0.05)
+
+        # Create a newer non-standard eval (lexicographically after the standard one)
+        newer = os.path.join(eval_base, 'eval-manual-line-editor-20260331')
+        os.makedirs(newer)
+        with open(os.path.join(newer, 'synthesis.md'), 'w') as f:
+            f.write('newer')
+
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
+
+        result = check_eval_staleness(project_dir)
+        # Should pick the newer one by mtime, not the lexicographically last one
+        assert result['eval_dir'] == newer
+
+    def test_nonstandard_eval_name_extracts_date_from_mtime(self, tmp_path):
+        """Eval names without a YYYYMMDD prefix should get date from mtime."""
+        from storyforge.scoring import check_eval_staleness
+
+        project_dir = str(tmp_path / 'project')
+        eval_base = os.path.join(project_dir, 'working', 'evaluations')
+        ref_dir = os.path.join(project_dir, 'reference')
+        os.makedirs(eval_base)
+        os.makedirs(os.path.join(project_dir, 'working', 'scores'))
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|S1|1|A|drafted|3000|3000\n')
+
+        eval_dir = os.path.join(eval_base, 'eval-manual-custom-name')
+        os.makedirs(eval_dir)
+        with open(os.path.join(eval_dir, 'synthesis.md'), 'w') as f:
+            f.write('test')
+
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
+
+        result = check_eval_staleness(project_dir)
+        # Date should be extracted from mtime, should be 8 digits
+        assert result['eval_date'] is not None
+        assert len(result['eval_date']) == 8
+        assert result['eval_date'].isdigit()
+
+    def test_wide_format_cycles_detected(self, tmp_path):
+        """Full LLM cycles in wide format (principles as columns) should be counted."""
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000}
+        project_dir = str(tmp_path / 'project')
+        eval_base = os.path.join(project_dir, 'working', 'evaluations')
+        scores_base = os.path.join(project_dir, 'working', 'scores')
+        ref_dir = os.path.join(project_dir, 'reference')
+        os.makedirs(eval_base)
+        os.makedirs(scores_base)
+        os.makedirs(ref_dir)
+
+        # Create eval with snapshot
+        eval_dir = os.path.join(eval_base, 'eval-20260408-120000')
+        os.makedirs(eval_dir)
+        with open(os.path.join(eval_dir, 'synthesis.md'), 'w') as f:
+            f.write('Eval')
+        with open(os.path.join(eval_dir, 'word-counts.csv'), 'w') as f:
+            f.write('id|word_count\ns01|3000\n')
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|S1|1|A|drafted|3000|3000\n')
+
+        # Create 2 full LLM cycles in wide format
+        for c in (1, 2):
+            cycle_dir = os.path.join(scores_base, f'cycle-{c}')
+            os.makedirs(cycle_dir)
+            with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+                f.write('id|avoid_passive|prose_naturalness|dialogue_authenticity\n')
+                f.write('s01|3.5|2.8|3.2\n')
+
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
+
+        result = check_eval_staleness(project_dir)
+        assert result['score_runs_since'] == 2
+        assert result['stale'] is True

--- a/tests/test_eval_staleness.py
+++ b/tests/test_eval_staleness.py
@@ -50,3 +50,58 @@ class TestIsFullLlmCycle:
             f.write('scene_id|principle|score\n')
 
         assert is_full_llm_cycle(cycle_dir) is False
+
+
+class TestWordCountSnapshot:
+    def test_write_snapshot(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+        ref_dir = str(tmp_path / 'reference')
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|First|1|Alice|drafted|2847|3000\n')
+            f.write('s02|2|Second|1|Bob|drafted|3102|3000\n')
+
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+
+        snapshot = os.path.join(eval_dir, 'word-counts.csv')
+        assert os.path.isfile(snapshot)
+
+        with open(snapshot) as f:
+            content = f.read()
+        assert 'id|word_count' in content
+        assert 's01|2847' in content
+        assert 's02|3102' in content
+
+    def test_write_snapshot_skips_zero_wordcount(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+        ref_dir = str(tmp_path / 'reference')
+        os.makedirs(ref_dir)
+
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            f.write('s01|1|First|1|Alice|drafted|2847|3000\n')
+            f.write('s02|2|Second|1|Bob|outline|0|3000\n')
+
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+
+        with open(os.path.join(eval_dir, 'word-counts.csv')) as f:
+            content = f.read()
+        assert 's01|2847' in content
+        assert 's02' not in content
+
+    def test_write_snapshot_no_scenes_csv(self, tmp_path):
+        from storyforge.cmd_evaluate import _write_word_count_snapshot
+
+        eval_dir = str(tmp_path / 'eval-20260415')
+        os.makedirs(eval_dir)
+
+        _write_word_count_snapshot(eval_dir, str(tmp_path))
+        assert not os.path.isfile(os.path.join(eval_dir, 'word-counts.csv'))

--- a/tests/test_eval_staleness.py
+++ b/tests/test_eval_staleness.py
@@ -105,3 +105,136 @@ class TestWordCountSnapshot:
 
         _write_word_count_snapshot(eval_dir, str(tmp_path))
         assert not os.path.isfile(os.path.join(eval_dir, 'word-counts.csv'))
+
+
+class TestCheckEvalStaleness:
+    def _setup_project(self, tmp_path, eval_date='20260408-120000',
+                       snapshot_words=None, current_words=None,
+                       full_cycles_after_eval=0, det_cycles_after_eval=0):
+        """Build a minimal project with eval dir and scoring cycles."""
+        project_dir = str(tmp_path / 'project')
+        eval_base = os.path.join(project_dir, 'working', 'evaluations')
+        scores_base = os.path.join(project_dir, 'working', 'scores')
+        ref_dir = os.path.join(project_dir, 'reference')
+        os.makedirs(eval_base)
+        os.makedirs(scores_base)
+        os.makedirs(ref_dir)
+
+        # Create eval dir with optional word count snapshot
+        eval_dir = os.path.join(eval_base, f'eval-{eval_date}')
+        os.makedirs(eval_dir)
+        with open(os.path.join(eval_dir, 'synthesis.md'), 'w') as f:
+            f.write('Evaluation summary')
+
+        if snapshot_words:
+            with open(os.path.join(eval_dir, 'word-counts.csv'), 'w') as f:
+                f.write('id|word_count\n')
+                for sid, wc in snapshot_words.items():
+                    f.write(f'{sid}|{wc}\n')
+
+        # Create current scenes.csv
+        words = current_words or snapshot_words or {'s01': 3000}
+        with open(os.path.join(ref_dir, 'scenes.csv'), 'w') as f:
+            f.write('id|seq|title|part|pov|status|word_count|target_words\n')
+            for i, (sid, wc) in enumerate(words.items(), 1):
+                f.write(f'{sid}|{i}|Scene {i}|1|Alice|drafted|{wc}|3000\n')
+
+        # Create scoring cycles (deterministic-only)
+        for c in range(1, det_cycles_after_eval + 1):
+            cycle_dir = os.path.join(scores_base, f'cycle-{c}')
+            os.makedirs(cycle_dir)
+            with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+                f.write('scene_id|principle|score\n')
+                f.write('s01|avoid_passive|3.5\n')
+
+        # Create full LLM cycles (numbered after deterministic)
+        offset = det_cycles_after_eval
+        for c in range(1, full_cycles_after_eval + 1):
+            cycle_dir = os.path.join(scores_base, f'cycle-{offset + c}')
+            os.makedirs(cycle_dir)
+            with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+                f.write('scene_id|principle|score\n')
+                f.write('s01|avoid_passive|3.5\n')
+                f.write('s01|prose_naturalness|2.8\n')
+
+        # storyforge.yaml
+        with open(os.path.join(project_dir, 'storyforge.yaml'), 'w') as f:
+            f.write('project:\n  title: Test\n')
+
+        return project_dir
+
+    def test_no_eval_is_stale(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(os.path.join(project_dir, 'working', 'evaluations'))
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert 'no evaluation found' in result['reasons']
+
+    def test_fresh_eval_no_changes(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000, 's02': 2500}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['word_delta_pct'] == 0.0
+        assert result['score_runs_since'] == 0
+
+    def test_stale_by_word_delta(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        snapshot = {'s01': 3000, 's02': 2500, 's03': 2000}  # total 7500
+        current = {'s01': 4000, 's02': 3500, 's03': 2000}   # delta=2000, 26.7%
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=snapshot, current_words=current)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert result['word_delta_pct'] > 0.20
+        assert any('word delta' in r for r in result['reasons'])
+
+    def test_not_stale_below_word_threshold(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        snapshot = {'s01': 3000, 's02': 2500}  # total 5500
+        current = {'s01': 3200, 's02': 2600}   # delta=300, 5.5%
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=snapshot, current_words=current)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['word_delta_pct'] < 0.20
+
+    def test_stale_by_full_score_runs(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words,
+            full_cycles_after_eval=2)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is True
+        assert result['score_runs_since'] >= 2
+        assert any('score runs' in r for r in result['reasons'])
+
+    def test_deterministic_cycles_dont_count(self, tmp_path):
+        from storyforge.scoring import check_eval_staleness
+
+        words = {'s01': 3000}
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=words, current_words=words,
+            det_cycles_after_eval=5, full_cycles_after_eval=1)
+        result = check_eval_staleness(project_dir)
+        assert result['stale'] is False
+        assert result['score_runs_since'] == 1
+
+    def test_no_snapshot_still_works(self, tmp_path):
+        """Old evals without word-counts.csv should not crash."""
+        from storyforge.scoring import check_eval_staleness
+
+        project_dir = self._setup_project(tmp_path,
+            snapshot_words=None, current_words={'s01': 3000})
+        result = check_eval_staleness(project_dir)
+        assert result['word_delta_pct'] == 0.0
+        assert result['stale'] is False

--- a/tests/test_eval_staleness.py
+++ b/tests/test_eval_staleness.py
@@ -51,6 +51,29 @@ class TestIsFullLlmCycle:
 
         assert is_full_llm_cycle(cycle_dir) is False
 
+    def test_wide_format_full_llm(self, tmp_path):
+        """Wide format: principles as column headers, not a 'principle' column."""
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-5')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('id|avoid_passive|prose_naturalness|dialogue_authenticity\n')
+            f.write('s01|3.5|2.8|3.2\n')
+
+        assert is_full_llm_cycle(cycle_dir) is True
+
+    def test_wide_format_deterministic_only(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-6')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('id|avoid_passive|avoid_adverbs|economy_clarity|prose_repetition|no_weather_dreams|sentence_as_thought\n')
+            f.write('s01|3.5|4.0|3.8|4.2|5.0|3.9\n')
+
+        assert is_full_llm_cycle(cycle_dir) is False
+
 
 class TestWordCountSnapshot:
     def test_write_snapshot(self, tmp_path):

--- a/tests/test_eval_staleness.py
+++ b/tests/test_eval_staleness.py
@@ -1,0 +1,52 @@
+"""Tests for evaluation staleness detection."""
+
+import os
+import pytest
+
+
+class TestIsFullLlmCycle:
+    def test_deterministic_only_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-1')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+            f.write('s01|avoid_passive|3.5\n')
+            f.write('s01|avoid_adverbs|4.0\n')
+            f.write('s01|economy_clarity|3.8\n')
+            f.write('s01|prose_repetition|4.2\n')
+            f.write('s01|no_weather_dreams|5.0\n')
+            f.write('s01|sentence_as_thought|3.9\n')
+
+        assert is_full_llm_cycle(cycle_dir) is False
+
+    def test_full_llm_returns_true(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-2')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+            f.write('s01|avoid_passive|3.5\n')
+            f.write('s01|prose_naturalness|2.8\n')
+            f.write('s01|dialogue_authenticity|3.2\n')
+
+        assert is_full_llm_cycle(cycle_dir) is True
+
+    def test_missing_scores_file_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-3')
+        os.makedirs(cycle_dir)
+        assert is_full_llm_cycle(cycle_dir) is False
+
+    def test_empty_scores_file_returns_false(self, tmp_path):
+        from storyforge.scoring import is_full_llm_cycle
+
+        cycle_dir = str(tmp_path / 'cycle-4')
+        os.makedirs(cycle_dir)
+        with open(os.path.join(cycle_dir, 'scene-scores.csv'), 'w') as f:
+            f.write('scene_id|principle|score\n')
+
+        assert is_full_llm_cycle(cycle_dir) is False

--- a/tests/test_revise_scores.py
+++ b/tests/test_revise_scores.py
@@ -1,0 +1,117 @@
+"""Tests for revise --scores mode."""
+
+import os
+import pytest
+
+
+class TestScoresFlag:
+    def test_parse_scores_flag(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--scores'])
+        assert args.scores is True
+
+    def test_scores_default_false(self):
+        from storyforge.cmd_revise import parse_args
+        args = parse_args(['--polish'])
+        assert args.scores is False
+
+    def test_scores_mutually_exclusive_with_polish(self):
+        from storyforge.cmd_revise import main
+        with pytest.raises(SystemExit):
+            main(['--scores', '--polish'])
+
+    def test_scores_mutually_exclusive_with_structural(self):
+        from storyforge.cmd_revise import main
+        with pytest.raises(SystemExit):
+            main(['--scores', '--structural'])
+
+
+class TestGenerateScoresPlan:
+    def test_generates_brief_pass_from_diagnosis(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01;s03;s05', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'economy_clarity', 'scale': 'scene', 'avg_score': '2.5',
+             'worst_items': 's01;s02', 'priority': 'high', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert len(rows) >= 1
+        brief_passes = [r for r in rows if r['fix_location'] == 'brief']
+        assert len(brief_passes) >= 1
+        all_targets = ';'.join(r['targets'] for r in brief_passes)
+        assert 's01' in all_targets
+
+    def test_generates_craft_pass_for_craft_root_cause(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01', 'priority': 'high', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        craft_passes = [r for r in rows if r['fix_location'] == 'craft']
+        assert len(craft_passes) >= 1
+
+    def test_brief_passes_come_before_craft(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '2.1',
+             'worst_items': 's01', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'dialogue_authenticity', 'scale': 'scene', 'avg_score': '2.5',
+             'worst_items': 's02', 'priority': 'high', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        brief_idx = next(i for i, r in enumerate(rows) if r['fix_location'] == 'brief')
+        craft_idx = next(i for i, r in enumerate(rows) if r['fix_location'] == 'craft')
+        assert brief_idx < craft_idx
+
+    def test_no_actionable_items_returns_empty(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'prose_naturalness', 'scale': 'scene', 'avg_score': '4.5',
+             'worst_items': '', 'priority': 'low', 'root_cause': 'craft'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert rows == []
+
+    def test_scenes_ranked_by_frequency(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'p1', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01;s02;s03', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'p2', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01;s03', 'priority': 'high', 'root_cause': 'brief'},
+            {'principle': 'p3', 'scale': 'scene', 'avg_score': '2.0',
+             'worst_items': 's01', 'priority': 'medium', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        brief_passes = [r for r in rows if r['fix_location'] == 'brief']
+        all_targets = ';'.join(r['targets'] for r in brief_passes)
+        assert 's01' in all_targets
+
+    def test_excludes_act_scale(self, tmp_path):
+        from storyforge.cmd_revise import _generate_scores_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        diag_rows = [
+            {'principle': 'genre_contract', 'scale': 'act', 'avg_score': '1.5',
+             'worst_items': '', 'priority': 'high', 'root_cause': 'brief'},
+        ]
+
+        rows = _generate_scores_plan(plan_file, diag_rows)
+        assert rows == []


### PR DESCRIPTION
## Summary

- Evaluation staleness detection: `check_eval_staleness()` compares word count deltas (>=20%) and full LLM scoring runs (>=2) since the last evaluation to determine if findings are outdated
- New `revise --scores` mode generates revision plans purely from `diagnosis.csv` — upstream brief fixes for brief-root-cause items, targeted craft polish for craft-root-cause items
- Deferred redrafting: when multiple upstream passes target overlapping scenes, redrafts are batched after all CSV fixes complete instead of after each pass
- Word count snapshots written at end of evaluations for future staleness comparison
- Revise skill updated to detect stale evaluations and recommend score-driven mode

Closes #180

## Test Plan

- [x] 3289/3289 tests pass, 74.67% coverage
- [x] 14 staleness detection tests (word delta, score runs, no eval, no snapshot fallback)
- [x] 10 `--scores` tests (plan generation, mutual exclusivity, ordering, ranking)
- [x] 4 deferred redraft tests (upstream collection, completed pass skipping)
- [ ] Run `storyforge revise --scores` on a project with scoring data
- [ ] Verify evaluation staleness detection on a project with old eval + recent scores
- [ ] Verify deferred redrafting with multi-pass upstream revision plan