### PR TITLE
Fix batch API cost logging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/api.py
+++ b/scripts/lib/python/storyforge/api.py
@@ -207,10 +207,11 @@ def extract_usage(response: dict) -> dict:
     }
 
 
-def calculate_cost_from_usage(usage: dict, model: str) -> float:
+def calculate_cost_from_usage(usage: dict, model: str, batch: bool = False) -> float:
     """Calculate cost in USD from a usage dict (as returned by extract_usage).
 
     Thin wrapper around costs.calculate_cost for backward compatibility.
+    If batch=True, applies the Anthropic Batch API 50% discount.
     """
     return calculate_cost(
         model,
@@ -218,6 +219,7 @@ def calculate_cost_from_usage(usage: dict, model: str) -> float:
         usage['output_tokens'],
         cache_read=usage.get('cache_read', 0),
         cache_create=usage.get('cache_create', 0),
+        batch=batch,
     )
 
 

--- a/scripts/lib/python/storyforge/cmd_evaluate.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate.py
@@ -723,8 +723,12 @@ def _estimate_avg_words(project_dir, scene_files):
 # Log usage from API response
 # ============================================================================
 
-def _log_usage(project_dir, log_file_or_response, operation, target, model, duration_s=0):
-    """Log usage from an API response file or dict."""
+def _log_usage(project_dir, log_file_or_response, operation, target, model,
+               duration_s=0, batch=False):
+    """Log usage from an API response file or dict.
+
+    If batch=True, applies the Anthropic Batch API 50% discount to cost.
+    """
     if isinstance(log_file_or_response, dict):
         usage = extract_usage(log_file_or_response)
     elif os.path.isfile(log_file_or_response):
@@ -736,7 +740,7 @@ def _log_usage(project_dir, log_file_or_response, operation, target, model, dura
     else:
         return
 
-    cost = calculate_cost_from_usage(usage, model)
+    cost = calculate_cost_from_usage(usage, model, batch=batch)
     log_operation(
         project_dir, operation, model,
         usage['input_tokens'], usage['output_tokens'], cost,
@@ -1075,7 +1079,8 @@ def main(argv=None):
             eval_txt = os.path.join(log_dir, f'{name}.txt')
 
             if os.path.isfile(eval_json):
-                _log_usage(project_dir, eval_json, 'evaluate', name, eval_models[i])
+                _log_usage(project_dir, eval_json, 'evaluate', name, eval_models[i],
+                           batch=True)
 
             if os.path.isfile(status_file) and open(status_file).read().strip() == 'ok':
                 if os.path.isfile(eval_txt):

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -851,8 +851,8 @@ def _log_api_usage(log_file: str, operation: str, target: str, model: str,
             cache_read=usage.get('cache_read', 0),
             cache_create=usage.get('cache_create', 0),
         )
-    except Exception:
-        pass
+    except Exception as e:
+        log(f'WARNING: Failed to log usage for {target}: {e}')
 
 
 # ============================================================================

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -834,13 +834,16 @@ def _parse_scene_evaluation(text_content: str, output_scores: str,
 
 
 def _log_api_usage(log_file: str, operation: str, target: str, model: str,
-                   project_dir: str) -> None:
-    """Log API usage/cost from a JSON response file."""
+                   project_dir: str, batch: bool = False) -> None:
+    """Log API usage/cost from a JSON response file.
+
+    If batch=True, applies the Anthropic Batch API 50% discount to cost.
+    """
     try:
         with open(log_file) as f:
             response = json.load(f)
         usage = extract_usage(response)
-        cost = calculate_cost_from_usage(usage, model)
+        cost = calculate_cost_from_usage(usage, model, batch=batch)
         log_operation(
             project_dir, operation, model,
             usage['input_tokens'], usage['output_tokens'], cost,
@@ -904,10 +907,11 @@ def _score_batch(scene_ids, eval_model, eval_template, evaluation_criteria,
                      os.path.isfile(text_file))
 
         if status_ok:
-            # Log usage
+            # Log usage (batch=True for 50% discount pricing)
             if os.path.isfile(json_file):
                 _log_api_usage(json_file, 'score', sid, eval_model,
-                               os.path.dirname(os.path.dirname(cycle_dir)))
+                               os.path.dirname(os.path.dirname(cycle_dir)),
+                               batch=True)
 
             text_content = open(text_file).read()
             tmp_scores = os.path.join(cycle_dir, f'.tmp-scores-{sid}.csv')
@@ -1071,6 +1075,14 @@ def _run_fidelity_scoring(filtered_ids, project_dir, scenes_dir, log_dir,
                                sonnet_model, project_dir)
             except Exception:
                 log(f'  WARNING: Fidelity scoring failed for {sid}')
+
+    # Log batch fidelity costs
+    if score_mode == 'batch':
+        for sid in filtered_ids:
+            json_file = os.path.join(log_dir, f'fidelity-{sid}.json')
+            if os.path.isfile(json_file):
+                _log_api_usage(json_file, 'score-fidelity', sid,
+                               sonnet_model, project_dir, batch=True)
 
     # Process results
     results = []

--- a/scripts/lib/python/storyforge/cmd_write.py
+++ b/scripts/lib/python/storyforge/cmd_write.py
@@ -488,9 +488,10 @@ def _run_batch_mode(pending_ids, project_dir, scenes_dir, log_dir,
         if os.path.isfile(scene_json):
             _extract_scene_from_response(scene_json, scene_file)
 
-        # Log usage
+        # Log usage (batch=True for 50% discount pricing)
         if os.path.isfile(scene_json):
-            _log_api_usage(scene_json, 'draft', scene_id, model, project_dir)
+            _log_api_usage(scene_json, 'draft', scene_id, model, project_dir,
+                           batch=True)
 
         # Verify and commit
         wc, ok = _verify_and_commit_scene(
@@ -614,13 +615,16 @@ def _invoke_interactive(prompt: str, model: str, project_dir: str) -> int:
 
 
 def _log_api_usage(log_file: str, operation: str, target: str, model: str,
-                   project_dir: str) -> None:
-    """Log API usage/cost from a JSON response file."""
+                   project_dir: str, batch: bool = False) -> None:
+    """Log API usage/cost from a JSON response file.
+
+    If batch=True, applies the Anthropic Batch API 50% discount to cost.
+    """
     try:
         with open(log_file) as f:
             response = json.load(f)
         usage = extract_usage(response)
-        cost = calculate_cost_from_usage(usage, model)
+        cost = calculate_cost_from_usage(usage, model, batch=batch)
         log_operation(
             project_dir, operation, model,
             usage['input_tokens'], usage['output_tokens'], cost,

--- a/scripts/lib/python/storyforge/costs.py
+++ b/scripts/lib/python/storyforge/costs.py
@@ -59,18 +59,26 @@ def _get_price(model: str, token_type: str) -> float:
 # Core functions
 # ============================================================================
 
+BATCH_DISCOUNT = 0.50  # Anthropic Batch API charges 50% of standard pricing
+
+
 def calculate_cost(model: str, input_tokens: int, output_tokens: int,
-                   cache_read: int = 0, cache_create: int = 0) -> float:
+                   cache_read: int = 0, cache_create: int = 0,
+                   batch: bool = False) -> float:
     """Calculate cost in USD from token counts.
 
     Cache tokens are folded into the cost but not tracked separately
     in the ledger — they affect the dollar amount only.
+
+    If batch=True, applies the Anthropic Batch API 50% discount.
     """
     cost = 0.0
     cost += input_tokens * _get_price(model, 'input') / 1_000_000
     cost += output_tokens * _get_price(model, 'output') / 1_000_000
     cost += cache_read * _get_price(model, 'cache_read') / 1_000_000
     cost += cache_create * _get_price(model, 'cache_create') / 1_000_000
+    if batch:
+        cost *= BATCH_DISCOUNT
     return cost
 
 

--- a/tests/test_batch_costs.py
+++ b/tests/test_batch_costs.py
@@ -1,0 +1,108 @@
+"""Tests for batch API cost logging."""
+
+import os
+import json
+import pytest
+
+
+class TestBatchDiscount:
+    def test_calculate_cost_standard(self):
+        from storyforge.costs import calculate_cost
+
+        # Sonnet: $3/M input, $15/M output
+        cost = calculate_cost('claude-sonnet-4-6', 1_000_000, 1_000_000)
+        assert abs(cost - 18.0) < 0.01
+
+    def test_calculate_cost_batch(self):
+        from storyforge.costs import calculate_cost
+
+        # Batch: 50% of standard
+        cost = calculate_cost('claude-sonnet-4-6', 1_000_000, 1_000_000, batch=True)
+        assert abs(cost - 9.0) < 0.01
+
+    def test_batch_flag_default_false(self):
+        from storyforge.costs import calculate_cost
+
+        standard = calculate_cost('claude-sonnet-4-6', 100_000, 100_000)
+        explicit_false = calculate_cost('claude-sonnet-4-6', 100_000, 100_000, batch=False)
+        assert standard == explicit_false
+
+    def test_calculate_cost_from_usage_batch(self):
+        from storyforge.api import calculate_cost_from_usage
+
+        usage = {'input_tokens': 1_000_000, 'output_tokens': 1_000_000,
+                 'cache_read': 0, 'cache_create': 0}
+
+        standard = calculate_cost_from_usage(usage, 'claude-sonnet-4-6')
+        batch = calculate_cost_from_usage(usage, 'claude-sonnet-4-6', batch=True)
+
+        assert abs(batch - standard * 0.5) < 0.01
+
+
+class TestLogApiUsageBatch:
+    def test_logs_with_batch_discount(self, tmp_path):
+        from storyforge.cmd_score import _log_api_usage
+        from storyforge.costs import LEDGER_HEADER
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(os.path.join(project_dir, 'working', 'costs'))
+
+        # Create a fake API response JSON
+        json_file = str(tmp_path / 'response.json')
+        with open(json_file, 'w') as f:
+            json.dump({
+                'usage': {
+                    'input_tokens': 10000,
+                    'output_tokens': 1000,
+                    'cache_read_input_tokens': 0,
+                    'cache_creation_input_tokens': 0,
+                }
+            }, f)
+
+        _log_api_usage(json_file, 'score', 'test-scene', 'claude-sonnet-4-6',
+                       project_dir, batch=True)
+
+        ledger = os.path.join(project_dir, 'working', 'costs', 'ledger.csv')
+        assert os.path.isfile(ledger)
+
+        with open(ledger) as f:
+            lines = f.readlines()
+
+        # Header + 1 data row
+        assert len(lines) == 2
+        row = lines[1].strip().split('|')
+        cost = float(row[8])  # cost_usd column
+
+        # Standard: (10000 * 3 + 1000 * 15) / 1M = 0.045
+        # Batch (50%): 0.0225
+        assert abs(cost - 0.0225) < 0.001
+
+    def test_logs_without_batch_at_standard_rate(self, tmp_path):
+        from storyforge.cmd_score import _log_api_usage
+
+        project_dir = str(tmp_path / 'project')
+        os.makedirs(os.path.join(project_dir, 'working', 'costs'))
+
+        json_file = str(tmp_path / 'response.json')
+        with open(json_file, 'w') as f:
+            json.dump({
+                'usage': {
+                    'input_tokens': 10000,
+                    'output_tokens': 1000,
+                    'cache_read_input_tokens': 0,
+                    'cache_creation_input_tokens': 0,
+                }
+            }, f)
+
+        _log_api_usage(json_file, 'score', 'test-scene', 'claude-sonnet-4-6',
+                       project_dir, batch=False)
+
+        ledger = os.path.join(project_dir, 'working', 'costs', 'ledger.csv')
+        with open(ledger) as f:
+            lines = f.readlines()
+
+        row = lines[1].strip().split('|')
+        cost = float(row[8])
+
+        # Standard: 0.045
+        assert abs(cost - 0.045) < 0.001


### PR DESCRIPTION
## Summary

- Add 50% batch discount to cost calculation: `calculate_cost()` and `calculate_cost_from_usage()` accept `batch=True` parameter
- Scene-level batch scoring now logs costs at batch pricing (was logging at standard rates)
- Fidelity batch scoring now logs costs (was not logging at all in batch mode)
- `_log_api_usage` accepts `batch` parameter to propagate discount through the logging chain

Closes #187

## Test Plan

- [x] 3339/3339 tests pass, 74.86% coverage
- [x] 6 new tests: batch discount calculation, batch vs standard rate comparison, ledger row verification
- [ ] Run `storyforge score` in batch mode and verify ledger shows per-scene entries at 50% rates