### PR TITLE
Fix hone findings CSV corruption from enriched guidance

### DIFF
--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -167,14 +167,16 @@ def _write_hone_findings(path, fix_location, targets, guidance):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     target_file = 'scene-briefs.csv' if fix_location == 'brief' else 'scene-intent.csv'
     scene_ids = [t.strip() for t in targets.split(';') if t.strip()] if targets else []
+    # Sanitize guidance: pipes break CSV columns, newlines break rows
+    safe_guidance = guidance.replace('|', ',').replace('\n', ' ').replace('\r', '')
     with open(path, 'w') as f:
         f.write('scene_id|target_file|fields|guidance\n')
         if not scene_ids:
             # Global scope — write a single row with empty scene_id
-            f.write(f'|{target_file}||{guidance}\n')
+            f.write(f'|{target_file}||{safe_guidance}\n')
         else:
             for sid in scene_ids:
-                f.write(f'{sid}|{target_file}||{guidance}\n')
+                f.write(f'{sid}|{target_file}||{safe_guidance}\n')
 
 
 def _redraft_from_briefs(project_dir, scene_ids, model, log_dir):

--- a/tests/test_findings_guidance.py
+++ b/tests/test_findings_guidance.py
@@ -220,3 +220,36 @@ class TestScoresPlanWithFindings:
 
         rows = _generate_scores_plan(plan_file, diag_rows, findings_dir=str(tmp_path))
         assert len(rows) >= 1
+
+
+class TestWriteHoneFindings:
+    def test_sanitizes_pipes_and_newlines_in_guidance(self, tmp_path):
+        """Guidance with pipes and newlines must not corrupt the hone findings CSV."""
+        import csv
+        from storyforge.cmd_revise import _write_hone_findings
+
+        findings_path = str(tmp_path / 'findings.csv')
+        # Guidance with pipes (from detail fields) and newlines (from multi-line findings)
+        guidance = (
+            'Score-driven fixes.\n'
+            'Cross-scene patterns:\n'
+            '  - "the edge of the" (21x|signature_phrase) — reduce to 4\n'
+            '  Scene s01: avoid_passive: 5/20 passive (25%)|cluster=True'
+        )
+
+        _write_hone_findings(findings_path, 'brief', 's01;s02', guidance)
+
+        with open(findings_path, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f, delimiter='|')
+            rows = list(reader)
+
+        # Should parse cleanly — exactly 4 columns per row
+        assert len(rows) == 2
+        for row in rows:
+            assert set(row.keys()) == {'scene_id', 'target_file', 'fields', 'guidance'}
+            assert None not in row.values()
+            assert row['scene_id'] in ('s01', 's02')
+            assert row['target_file'] == 'scene-briefs.csv'
+            # Pipes and newlines should be sanitized
+            assert '|' not in row['guidance']
+            assert '\n' not in row['guidance']


### PR DESCRIPTION
## Summary

- `_write_hone_findings` now sanitizes pipes and newlines in the guidance string before writing to CSV
- The enriched guidance from `_build_findings_guidance` (which contains multi-line repetition patterns and per-scene detail strings) was being written raw into the pipe-delimited findings file, causing `load_external_findings` in hone.py to crash on `row.get('target_file', '').strip()` because the pipes split the row into too many columns

## Root Cause

The `--scores` plan generator injects detailed findings (repetition phrases, scene-specific passive/adverb/economy data) into the `guidance` field. When this guidance is passed through `_write_hone_findings` to create the hone delegation file, embedded `|` and `\n` characters corrupt the CSV structure.

## Test Plan

- [x] 3340/3340 tests pass
- [x] Regression test: guidance with pipes and newlines produces valid 4-column CSV
- [ ] Run `storyforge revise --scores` on thornwall to verify the fix