### PR TITLE
Fix CSV plan corruption from enriched guidance

### DIFF
--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -89,6 +89,11 @@ CSV_PLAN_FIELDS = ['pass', 'name', 'purpose', 'scope', 'targets', 'guidance',
                    'protection', 'findings', 'status', 'model_tier', 'fix_location']
 
 
+def _sanitize_csv_field(value: str) -> str:
+    """Sanitize a value for pipe-delimited CSV: replace pipes and newlines."""
+    return value.replace('|', ',').replace('\n', ' ').replace('\r', '')
+
+
 def _read_csv_plan(plan_file):
     """Read the CSV revision plan. Returns list of row dicts.
 
@@ -111,7 +116,10 @@ def _write_csv_plan(plan_file, rows):
     with open(plan_file, 'w') as f:
         f.write('|'.join(CSV_PLAN_FIELDS) + '\n')
         for row in rows:
-            f.write('|'.join(row.get(field, '') for field in CSV_PLAN_FIELDS) + '\n')
+            f.write('|'.join(
+                _sanitize_csv_field(row.get(field, ''))
+                for field in CSV_PLAN_FIELDS
+            ) + '\n')
 
 
 def _next_plan_number(plans_dir):
@@ -167,8 +175,7 @@ def _write_hone_findings(path, fix_location, targets, guidance):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     target_file = 'scene-briefs.csv' if fix_location == 'brief' else 'scene-intent.csv'
     scene_ids = [t.strip() for t in targets.split(';') if t.strip()] if targets else []
-    # Sanitize guidance: pipes break CSV columns, newlines break rows
-    safe_guidance = guidance.replace('|', ',').replace('\n', ' ').replace('\r', '')
+    safe_guidance = _sanitize_csv_field(guidance)
     with open(path, 'w') as f:
         f.write('scene_id|target_file|fields|guidance\n')
         if not scene_ids:

--- a/tests/test_findings_guidance.py
+++ b/tests/test_findings_guidance.py
@@ -222,6 +222,68 @@ class TestScoresPlanWithFindings:
         assert len(rows) >= 1
 
 
+class TestWriteCsvPlanSanitization:
+    def test_plan_csv_survives_enriched_guidance(self, tmp_path):
+        """Plan rows with pipes and newlines in guidance must round-trip cleanly."""
+        import csv
+        from storyforge.cmd_revise import _write_csv_plan, _read_csv_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        rows = [{
+            'pass': '1',
+            'name': 'score-driven-briefs',
+            'purpose': 'Fix briefs for 40 scenes',
+            'scope': 'scene-level',
+            'targets': 's01;s02',
+            'guidance': (
+                'Score-driven fixes.\n'
+                'Cross-scene patterns:\n'
+                '  - "chin on her paws" (16x|character_tell) — reduce to 3\n'
+                '  Scene s01: avoid_passive: 5/20 passive (25%)|cluster=True'
+            ),
+            'protection': 'voice-quality',
+            'findings': 'scores',
+            'status': 'pending',
+            'model_tier': 'sonnet',
+            'fix_location': 'brief',
+        }]
+
+        _write_csv_plan(plan_file, rows)
+
+        # Read back — should parse as exactly 1 row with correct fields
+        read_back = _read_csv_plan(plan_file)
+        assert len(read_back) == 1
+        assert read_back[0]['name'] == 'score-driven-briefs'
+        assert read_back[0]['fix_location'] == 'brief'
+        # Guidance content preserved (minus pipes/newlines)
+        assert 'chin on her paws' in read_back[0]['guidance']
+        assert 'reduce to 3' in read_back[0]['guidance']
+
+    def test_plan_csv_no_corruption_with_multiple_rows(self, tmp_path):
+        """Multi-row plan with enriched guidance should not have row bleeding."""
+        from storyforge.cmd_revise import _write_csv_plan, _read_csv_plan
+
+        plan_file = str(tmp_path / 'revision-plan.csv')
+        rows = [
+            {'pass': '1', 'name': 'brief-fix', 'purpose': 'Fix briefs',
+             'scope': 'full', 'targets': 's01', 'guidance': 'Line 1\nLine 2\nLine 3',
+             'protection': '', 'findings': '', 'status': 'pending',
+             'model_tier': 'sonnet', 'fix_location': 'brief'},
+            {'pass': '2', 'name': 'craft-polish', 'purpose': 'Polish prose',
+             'scope': 'full', 'targets': 's02', 'guidance': 'Simple guidance',
+             'protection': '', 'findings': '', 'status': 'pending',
+             'model_tier': 'opus', 'fix_location': 'craft'},
+        ]
+
+        _write_csv_plan(plan_file, rows)
+        read_back = _read_csv_plan(plan_file)
+
+        assert len(read_back) == 2
+        assert read_back[0]['name'] == 'brief-fix'
+        assert read_back[1]['name'] == 'craft-polish'
+        assert read_back[1]['fix_location'] == 'craft'
+
+
 class TestWriteHoneFindings:
     def test_sanitizes_pipes_and_newlines_in_guidance(self, tmp_path):
         """Guidance with pipes and newlines must not corrupt the hone findings CSV."""


### PR DESCRIPTION
## Summary

- Extract shared `_sanitize_csv_field()` that replaces pipes and newlines for pipe-delimited CSV writes
- Apply sanitization in `_write_csv_plan` (revision plan CSV) — was writing enriched guidance with newlines and pipes raw, corrupting multi-row plans
- Refactor `_write_hone_findings` to use the same shared function (replacing the inline sanitization from PR #190)
- Two regression tests: single-row round-trip with enriched guidance, multi-row plan with newlines verifying no row bleeding

Follow-up to PR #190 review finding.

## Test Plan

- [x] 3342/3342 tests pass, 74.87% coverage
- [x] Plan CSV round-trips cleanly with pipes and newlines in guidance
- [x] Multi-row plans don't bleed rows when guidance contains newlines