### PR TITLE
Add prompt caching and session-scoped cost summaries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/docs/superpowers/plans/2026-04-15-prompt-caching-and-cost-summary.md
+++ b/docs/superpowers/plans/2026-04-15-prompt-caching-and-cost-summary.md
@@ -1,0 +1,1309 @@
+# Prompt Caching and Cost Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable Anthropic prompt caching across all API calls (batch and direct) to reduce cost and latency, and show per-session + cumulative cost summaries with human-readable durations.
+
+**Architecture:** A shared context helper (`build_shared_context`) assembles project reference materials into two-tier cacheable system blocks. The API layer (`invoke`, `invoke_to_file`, `build_batch_request`) passes these as the `system` parameter. Prompt builders stop inlining shared material. Cost summaries gain session-scoped filtering and formatted durations.
+
+**Tech Stack:** Python 3.11+, Anthropic Messages API, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-15-prompt-caching-and-cost-summary-design.md`
+
+---
+
+## File Map
+
+**Modify:**
+- `scripts/lib/python/storyforge/costs.py` — add `format_duration()`, session-scoped `print_summary`
+- `scripts/lib/python/storyforge/api.py` — add `system` param to `invoke()` family, add `build_batch_request()`
+- `scripts/lib/python/storyforge/common.py` — add `build_shared_context()`
+- `scripts/lib/python/storyforge/prompts.py` — remove shared content inlining from `build_scene_prompt()`
+- `scripts/lib/python/storyforge/prompts_elaborate.py` — remove shared content inlining from stage prompts
+- `scripts/lib/python/storyforge/revision.py` — remove shared content inlining from `build_revision_prompt()`
+- `scripts/lib/python/storyforge/scoring.py` — remove shared content inlining from scoring prompts
+- `scripts/lib/python/storyforge/extract.py` — remove shared content inlining from extraction prompts
+- `scripts/lib/python/storyforge/cmd_write.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_score.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_evaluate.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_extract.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_revise.py` — pass system context to direct calls, session cost
+- `scripts/lib/python/storyforge/cmd_elaborate.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_enrich.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_timeline.py` — use `build_batch_request`, pass system context, session cost
+- `scripts/lib/python/storyforge/cmd_scenes_setup.py` — use `build_batch_request`, pass system context, session cost
+
+**Create:**
+- `tests/test_prompt_caching.py` — tests for `build_shared_context` and `build_batch_request`
+
+**Extend:**
+- `tests/test_costs.py` — tests for `format_duration` and session-scoped `print_summary`
+- `tests/test_api.py` — tests for `invoke()` with system parameter
+
+---
+
+### Task 1: format_duration() + tests
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/costs.py`
+- Extend: `tests/test_costs.py`
+
+- [ ] **Step 1: Write failing tests for format_duration**
+
+Add to `tests/test_costs.py`:
+
+```python
+from storyforge.costs import format_duration
+
+
+class TestFormatDuration:
+    def test_zero(self):
+        assert format_duration(0) == '0s'
+
+    def test_seconds_only(self):
+        assert format_duration(45) == '45s'
+
+    def test_minutes_and_seconds(self):
+        assert format_duration(180) == '3m 0s'
+
+    def test_minutes_and_nonzero_seconds(self):
+        assert format_duration(185) == '3m 5s'
+
+    def test_hours_minutes_seconds(self):
+        assert format_duration(3661) == '1h 1m 1s'
+
+    def test_large_duration(self):
+        assert format_duration(27888) == '7h 44m 48s'
+
+    def test_exact_hour(self):
+        assert format_duration(3600) == '1h 0m 0s'
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_costs.py::TestFormatDuration -v`
+Expected: FAIL — `ImportError: cannot import name 'format_duration'`
+
+- [ ] **Step 3: Implement format_duration**
+
+Add to `scripts/lib/python/storyforge/costs.py` after the `check_threshold` function (after line 216):
+
+```python
+def format_duration(seconds: int) -> str:
+    """Format seconds as Xh Xm Xs, omitting zero leading components."""
+    if seconds < 60:
+        return f'{seconds}s'
+    if seconds < 3600:
+        m, s = divmod(seconds, 60)
+        return f'{m}m {s}s'
+    h, remainder = divmod(seconds, 3600)
+    m, s = divmod(remainder, 60)
+    return f'{h}h {m}m {s}s'
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_costs.py::TestFormatDuration -v`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Update print_summary to use format_duration**
+
+In `scripts/lib/python/storyforge/costs.py`, change line 206 from:
+
+```python
+    print(f'Total time:    {total_dur}s')
+```
+
+To:
+
+```python
+    print(f'Total time:    {format_duration(total_dur)}')
+```
+
+- [ ] **Step 6: Run full cost test suite**
+
+Run: `python3 -m pytest tests/test_costs.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/costs.py tests/test_costs.py
+git commit -m "Add format_duration for human-readable time in cost summaries"
+git push
+```
+
+---
+
+### Task 2: Session-scoped print_summary + tests
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/costs.py`
+- Extend: `tests/test_costs.py`
+
+- [ ] **Step 1: Write failing tests for session-scoped print_summary**
+
+Add to `tests/test_costs.py`:
+
+```python
+import os
+from storyforge.costs import log_operation, print_summary, LEDGER_HEADER
+
+
+class TestSessionScopedSummary:
+    def _make_ledger(self, project_dir, rows):
+        """Write a ledger with the given rows (list of pipe-delimited strings)."""
+        ledger_dir = os.path.join(project_dir, 'working', 'costs')
+        os.makedirs(ledger_dir, exist_ok=True)
+        with open(os.path.join(ledger_dir, 'ledger.csv'), 'w') as f:
+            f.write(LEDGER_HEADER + '\n')
+            for row in rows:
+                f.write(row + '\n')
+
+    def test_no_session_start_shows_cumulative_only(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T10:00:00|revise|scene-2|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+        ])
+        print_summary(project_dir, 'revise')
+        out = capsys.readouterr().out
+        assert 'This session' not in out
+        assert 'Project total' not in out
+        assert '--- Cost Summary: revise ---' in out
+        assert 'Invocations:   2' in out
+
+    def test_session_start_shows_both_sections(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T10:00:00|revise|scene-2|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+            '2026-04-15T11:00:00|revise|scene-3|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T09:00:00')
+        out = capsys.readouterr().out
+        assert '--- This session: revise (2 invocations) ---' in out
+        assert '--- Project total: revise (3 invocations) ---' in out
+
+    def test_session_filters_by_timestamp(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T14:00:00|revise|scene-2|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T00:00:00')
+        out = capsys.readouterr().out
+        # Session section should only have 1 invocation (the one after session_start)
+        assert '1 invocations' in out or '1 invocation' in out
+
+    def test_session_with_no_matching_rows(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T00:00:00')
+        out = capsys.readouterr().out
+        # Should still show project total even if session is empty
+        assert 'Project total' in out
+
+    def test_duration_uses_format_duration(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-15T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|3661',
+        ])
+        print_summary(project_dir, 'revise')
+        out = capsys.readouterr().out
+        assert '1h 1m 1s' in out
+        assert '3661s' not in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_costs.py::TestSessionScopedSummary -v`
+Expected: FAIL — `print_summary() got an unexpected keyword argument 'session_start'`
+
+- [ ] **Step 3: Rewrite print_summary with session support**
+
+Replace the `print_summary` function in `scripts/lib/python/storyforge/costs.py` (lines 125-206) with:
+
+```python
+def print_summary(project_dir: str, operation: str | None = None,
+                  session_start: str | None = None) -> None:
+    """Print cost totals from the ledger, optionally filtered by operation.
+
+    When session_start is provided (ISO timestamp), shows two sections:
+    1. This session — rows with timestamp >= session_start
+    2. Project total — all matching rows
+    """
+    ledger_file = os.path.join(project_dir, 'working', 'costs', 'ledger.csv')
+
+    if not os.path.exists(ledger_file):
+        print('No cost data available.')
+        return
+
+    with open(ledger_file) as f:
+        header_line = f.readline().strip()
+        if not header_line:
+            print('No cost data available.')
+            return
+        headers = header_line.split('|')
+        col_map = {name: idx for idx, name in enumerate(headers)}
+
+        if 'operation' not in col_map:
+            print('No cost data available.')
+            return
+
+        rows = []
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split('|')
+
+            op_idx = col_map['operation']
+            if op_idx >= len(parts):
+                continue
+            if operation and parts[op_idx] != operation:
+                continue
+
+            rows.append(parts)
+
+    if not rows and not session_start:
+        label = f' for operation: {operation}' if operation else ''
+        print(f'No cost data{label}.')
+        return
+
+    def _accumulate(row_list):
+        count = len(row_list)
+        total_input = total_output = total_cache_r = total_cache_c = total_dur = 0
+        total_cost = 0.0
+        field_map = {
+            'input_tokens': 'input', 'output_tokens': 'output',
+            'cache_read': 'cache_r', 'cache_create': 'cache_c',
+            'duration_s': 'dur',
+        }
+        for parts in row_list:
+            for col_name in ('input_tokens', 'output_tokens', 'cache_read',
+                             'cache_create', 'duration_s'):
+                if col_name in col_map and col_map[col_name] < len(parts):
+                    val = parts[col_map[col_name]]
+                    if val:
+                        if col_name == 'input_tokens':
+                            total_input += int(val)
+                        elif col_name == 'output_tokens':
+                            total_output += int(val)
+                        elif col_name == 'cache_read':
+                            total_cache_r += int(val)
+                        elif col_name == 'cache_create':
+                            total_cache_c += int(val)
+                        elif col_name == 'duration_s':
+                            total_dur += int(val)
+            if 'cost_usd' in col_map and col_map['cost_usd'] < len(parts):
+                val = parts[col_map['cost_usd']]
+                if val:
+                    total_cost += float(val)
+        return count, total_input, total_output, total_cache_r, total_cache_c, total_cost, total_dur
+
+    def _print_section(label, count, inp, out, cr, cc, cost, dur):
+        inv_word = 'invocation' if count == 1 else 'invocations'
+        print(f'--- {label} ({count} {inv_word}) ---')
+        print(f'Input tokens:  {inp:,}')
+        print(f'Output tokens: {out:,}')
+        print(f'Cache read:    {cr:,}')
+        print(f'Cache create:  {cc:,}')
+        print(f'Cost:          ${cost:.4f}')
+        print(f'Time:          {format_duration(dur)}')
+
+    label = operation or 'all operations'
+
+    if session_start:
+        ts_idx = col_map.get('timestamp', -1)
+        session_rows = []
+        if ts_idx >= 0:
+            session_rows = [r for r in rows
+                            if ts_idx < len(r) and r[ts_idx] >= session_start]
+
+        if session_rows:
+            _print_section(f'This session: {label}', *_accumulate(session_rows))
+            print()
+
+        if rows:
+            _print_section(f'Project total: {label}', *_accumulate(rows))
+    else:
+        if not rows:
+            label_str = f' for operation: {operation}' if operation else ''
+            print(f'No cost data{label_str}.')
+            return
+        count, inp, out, cr, cc, cost, dur = _accumulate(rows)
+        print(f'--- Cost Summary: {label} ---')
+        print(f'Invocations:   {count}')
+        print(f'Input tokens:  {inp:,}')
+        print(f'Output tokens: {out:,}')
+        print(f'Cache read:    {cr:,}')
+        print(f'Cache create:  {cc:,}')
+        print(f'Total cost:    ${cost:.4f}')
+        print(f'Total time:    {format_duration(dur)}')
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_costs.py -v`
+Expected: All tests PASS (including existing tests — the no-session_start path preserves old format)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/costs.py tests/test_costs.py
+git commit -m "Add session-scoped cost summary with human-readable durations"
+git push
+```
+
+---
+
+### Task 3: Add system parameter to API invoke family + tests
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/api.py`
+- Extend: `tests/test_api.py`
+
+- [ ] **Step 1: Write failing tests for invoke with system parameter**
+
+Add to `tests/test_api.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+
+
+class TestInvokeSystemParam:
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_invoke_without_system_omits_key(self, mock_key, mock_req):
+        from storyforge.api import invoke
+        mock_req.return_value = {
+            'content': [{'type': 'text', 'text': 'ok'}],
+            'usage': {'input_tokens': 10, 'output_tokens': 5},
+        }
+        invoke('hello', 'claude-sonnet-4-6', max_tokens=100)
+        body = mock_req.call_args[0][1]
+        assert 'system' not in body
+        assert body['messages'] == [{'role': 'user', 'content': 'hello'}]
+
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_invoke_with_system_includes_key(self, mock_key, mock_req):
+        from storyforge.api import invoke
+        mock_req.return_value = {
+            'content': [{'type': 'text', 'text': 'ok'}],
+            'usage': {'input_tokens': 10, 'output_tokens': 5},
+        }
+        system_blocks = [
+            {'type': 'text', 'text': 'You are helpful.'},
+            {'type': 'text', 'text': 'Reference material here.',
+             'cache_control': {'type': 'ephemeral'}},
+        ]
+        invoke('hello', 'claude-sonnet-4-6', max_tokens=100, system=system_blocks)
+        body = mock_req.call_args[0][1]
+        assert body['system'] == system_blocks
+        assert body['messages'] == [{'role': 'user', 'content': 'hello'}]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_api.py::TestInvokeSystemParam -v`
+Expected: FAIL — `invoke() got an unexpected keyword argument 'system'`
+
+- [ ] **Step 3: Add system parameter to invoke()**
+
+In `scripts/lib/python/storyforge/api.py`, change the `invoke` function signature and body (lines 111-135):
+
+Replace:
+
+```python
+def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
+           timeout: int = API_TIMEOUT) -> dict:
+    """Call the Anthropic Messages API.
+
+    Args:
+        prompt: The user message text.
+        model: Model ID (e.g., 'claude-opus-4-6').
+        max_tokens: Maximum output tokens.
+        label: Optional label for heartbeat messages (e.g., 'revision pass 3').
+        timeout: Socket timeout in seconds (default API_TIMEOUT).
+
+    Returns:
+        Full API response dict.
+    """
+    body = {
+        'model': model,
+        'max_tokens': max_tokens,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }
+```
+
+With:
+
+```python
+def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
+           timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> dict:
+    """Call the Anthropic Messages API.
+
+    Args:
+        prompt: The user message text.
+        model: Model ID (e.g., 'claude-opus-4-6').
+        max_tokens: Maximum output tokens.
+        label: Optional label for heartbeat messages (e.g., 'revision pass 3').
+        timeout: Socket timeout in seconds (default API_TIMEOUT).
+        system: Optional list of system content blocks with cache_control.
+
+    Returns:
+        Full API response dict.
+    """
+    body = {
+        'model': model,
+        'max_tokens': max_tokens,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }
+    if system:
+        body['system'] = system
+```
+
+- [ ] **Step 4: Add system parameter to invoke_to_file()**
+
+Change the signature and call (lines 138-153):
+
+Replace:
+
+```python
+def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 4096, label: str = '',
+                   timeout: int = API_TIMEOUT) -> dict:
+    """Call the API and write the response to a JSON file.
+
+    Args:
+        prompt: The user message text.
+        model: Model ID.
+        log_file: Path to write the JSON response.
+        max_tokens: Maximum output tokens.
+        label: Optional label for heartbeat messages.
+        timeout: Socket timeout in seconds (default API_TIMEOUT).
+
+    Returns:
+        Full API response dict.
+    """
+    response = invoke(prompt, model, max_tokens, label=label, timeout=timeout)
+```
+
+With:
+
+```python
+def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 4096, label: str = '',
+                   timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> dict:
+    """Call the API and write the response to a JSON file.
+
+    Args:
+        prompt: The user message text.
+        model: Model ID.
+        log_file: Path to write the JSON response.
+        max_tokens: Maximum output tokens.
+        label: Optional label for heartbeat messages.
+        timeout: Socket timeout in seconds (default API_TIMEOUT).
+        system: Optional list of system content blocks with cache_control.
+
+    Returns:
+        Full API response dict.
+    """
+    response = invoke(prompt, model, max_tokens, label=label, timeout=timeout, system=system)
+```
+
+- [ ] **Step 5: Add system parameter to invoke_api()**
+
+Change the signature and call (lines 160-173):
+
+Replace:
+
+```python
+def invoke_api(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
+               timeout: int = API_TIMEOUT) -> str:
+```
+
+With:
+
+```python
+def invoke_api(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
+               timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> str:
+```
+
+And change the invoke call inside it from:
+
+```python
+        response = invoke(prompt, model, max_tokens, label=label, timeout=timeout)
+```
+
+To:
+
+```python
+        response = invoke(prompt, model, max_tokens, label=label, timeout=timeout, system=system)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_api.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/api.py tests/test_api.py
+git commit -m "Add system parameter to invoke family for prompt caching"
+git push
+```
+
+---
+
+### Task 4: build_batch_request() helper + tests
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/api.py`
+- Create: `tests/test_prompt_caching.py`
+
+- [ ] **Step 1: Write failing tests for build_batch_request**
+
+Create `tests/test_prompt_caching.py`:
+
+```python
+"""Tests for prompt caching infrastructure."""
+
+import json
+
+
+class TestBuildBatchRequest:
+    def test_without_system(self):
+        from storyforge.api import build_batch_request
+        result = build_batch_request('scene-1', 'Write a scene.', 'claude-opus-4-6', 8192)
+        assert result['custom_id'] == 'scene-1'
+        assert result['params']['model'] == 'claude-opus-4-6'
+        assert result['params']['max_tokens'] == 8192
+        assert result['params']['messages'] == [{'role': 'user', 'content': 'Write a scene.'}]
+        assert 'system' not in result['params']
+
+    def test_with_system(self):
+        from storyforge.api import build_batch_request
+        system = [
+            {'type': 'text', 'text': 'Craft engine content here.'},
+            {'type': 'text', 'text': 'Voice guide here.',
+             'cache_control': {'type': 'ephemeral'}},
+        ]
+        result = build_batch_request('scene-1', 'Write a scene.', 'claude-opus-4-6', 8192,
+                                     system=system)
+        assert result['params']['system'] == system
+        assert result['params']['messages'] == [{'role': 'user', 'content': 'Write a scene.'}]
+
+    def test_serializes_to_valid_jsonl(self):
+        from storyforge.api import build_batch_request
+        system = [{'type': 'text', 'text': 'Context.',
+                   'cache_control': {'type': 'ephemeral'}}]
+        result = build_batch_request('s1', 'prompt', 'claude-sonnet-4-6', 4096, system=system)
+        line = json.dumps(result)
+        parsed = json.loads(line)
+        assert parsed['custom_id'] == 's1'
+        assert parsed['params']['system'][0]['cache_control']['type'] == 'ephemeral'
+
+    def test_default_max_tokens(self):
+        from storyforge.api import build_batch_request
+        result = build_batch_request('s1', 'prompt', 'claude-sonnet-4-6')
+        assert result['params']['max_tokens'] == 4096
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_prompt_caching.py::TestBuildBatchRequest -v`
+Expected: FAIL — `ImportError: cannot import name 'build_batch_request'`
+
+- [ ] **Step 3: Implement build_batch_request**
+
+Add to `scripts/lib/python/storyforge/api.py` before the `# ============================================================================` Batch API section comment (before line 226):
+
+```python
+def build_batch_request(custom_id: str, prompt: str, model: str,
+                        max_tokens: int = 4096,
+                        system: list[dict] | None = None) -> dict:
+    """Build a single batch request item (one JSONL line).
+
+    Args:
+        custom_id: Unique identifier for this request in the batch.
+        prompt: The user message text.
+        model: Model ID.
+        max_tokens: Maximum output tokens.
+        system: Optional list of system content blocks with cache_control.
+
+    Returns:
+        Dict suitable for JSON serialization as one JSONL line.
+    """
+    params = {
+        'model': model,
+        'max_tokens': max_tokens,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }
+    if system:
+        params['system'] = system
+    return {'custom_id': custom_id, 'params': params}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_prompt_caching.py::TestBuildBatchRequest -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/api.py tests/test_prompt_caching.py
+git commit -m "Add build_batch_request helper for standardized batch construction"
+git push
+```
+
+---
+
+### Task 5: build_shared_context() + tests
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/common.py`
+- Extend: `tests/test_prompt_caching.py`
+
+- [ ] **Step 1: Write failing tests for build_shared_context**
+
+Add to `tests/test_prompt_caching.py`:
+
+```python
+import os
+
+
+class TestBuildSharedContext:
+    def test_returns_list_of_dicts(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        assert isinstance(result, list)
+        assert len(result) > 0
+        for block in result:
+            assert block['type'] == 'text'
+            assert 'text' in block
+
+    def test_tier1_blocks_come_first(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        texts = [b['text'] for b in result]
+        # Craft engine is tier 1, character bible is tier 2
+        craft_idx = next((i for i, t in enumerate(texts) if 'Craft Engine' in t), None)
+        bible_idx = next((i for i, t in enumerate(texts) if 'Character Bible' in t), None)
+        assert craft_idx is not None
+        assert bible_idx is not None
+        assert craft_idx < bible_idx
+
+    def test_has_cache_control_breakpoints(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        blocks_with_cc = [b for b in result if 'cache_control' in b]
+        # Should have at least one breakpoint (possibly two if both tiers meet threshold)
+        assert len(blocks_with_cc) >= 1
+
+    def test_skips_missing_files(self, tmp_path):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        # Empty project dir with no reference files
+        project_dir = str(tmp_path / 'empty')
+        os.makedirs(os.path.join(project_dir, 'reference'), exist_ok=True)
+        result = build_shared_context(project_dir, model='claude-sonnet-4-6')
+        # Should still return blocks (tier 1 comes from plugin dir)
+        assert isinstance(result, list)
+
+    def test_in_process_cache(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result1 = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        result2 = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        assert result1 is result2  # Same object, not just equal
+
+    def test_includes_project_references(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        all_text = ' '.join(b['text'] for b in result)
+        # Fixture has these files
+        assert 'Voice Guide' in all_text or 'voice-guide' in all_text.lower()
+        assert 'Character Bible' in all_text or 'character-bible' in all_text.lower()
+
+    def test_tier1_breakpoint_has_1h_ttl(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        # Find the tier 1 breakpoint (last block before project-level content)
+        # It should have ttl if tier 1 meets threshold
+        tier1_labels = ('Craft Engine', 'Scoring Rubrics', 'AI-Tell Vocabulary')
+        tier1_end = -1
+        for i, b in enumerate(result):
+            if any(label in b['text'] for label in tier1_labels):
+                tier1_end = i
+        if tier1_end >= 0 and 'cache_control' in result[tier1_end]:
+            # Verify the breakpoint TTL is extended (not the default 5m)
+            assert result[tier1_end]['cache_control'].get('ttl') in (3600, '1h', None)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_prompt_caching.py::TestBuildSharedContext -v`
+Expected: FAIL — `ImportError: cannot import name 'build_shared_context'`
+
+- [ ] **Step 3: Implement build_shared_context**
+
+Add to `scripts/lib/python/storyforge/common.py` after the `extract_craft_sections` function (after line 238):
+
+```python
+# ============================================================================
+# Shared context for prompt caching
+# ============================================================================
+
+_shared_context_cache: dict[str, list[dict]] = {}
+
+# Minimum tokens per cache breakpoint (estimated at ~4 chars/token)
+_MIN_CACHE_CHARS = {
+    'opus': 4096 * 4,
+    'sonnet': 2048 * 4,
+    'haiku': 2048 * 4,
+}
+
+
+def _model_tier(model: str) -> str:
+    """Map model name to pricing tier for cache threshold."""
+    m = model.lower()
+    if 'opus' in m:
+        return 'opus'
+    if 'haiku' in m:
+        return 'haiku'
+    return 'sonnet'
+
+
+def _read_if_exists(path: str) -> str:
+    """Read a file if it exists, return empty string otherwise."""
+    if os.path.isfile(path):
+        with open(path) as f:
+            return f.read().strip()
+    return ''
+
+
+def build_shared_context(project_dir: str, model: str = '') -> list[dict]:
+    """Assemble project reference materials as cacheable system blocks.
+
+    Two-tier structure:
+    - Tier 1 (1h TTL): Plugin-level references (craft engine, rubrics, AI-tell words)
+    - Tier 2 (5m TTL): Project-level references (bibles, voice guide, registries)
+
+    Results are cached in-process so repeated calls don't re-read files.
+
+    Args:
+        project_dir: Path to the Storyforge project.
+        model: Model ID for determining minimum cache token threshold.
+
+    Returns:
+        List of content blocks for the API 'system' parameter.
+    """
+    cache_key = f'{project_dir}:{model}'
+    if cache_key in _shared_context_cache:
+        return _shared_context_cache[cache_key]
+
+    plugin_dir = get_plugin_dir()
+    min_chars = _MIN_CACHE_CHARS.get(_model_tier(model), 4096 * 4)
+
+    # --- Tier 1: Plugin-level (near-permanent) ---
+    tier1_sources = [
+        (os.path.join(plugin_dir, 'references', 'craft-engine.md'), 'Craft Engine'),
+        (os.path.join(plugin_dir, 'references', 'scoring-rubrics.md'), 'Scoring Rubrics'),
+        (os.path.join(plugin_dir, 'references', 'ai-tell-words.csv'), 'AI-Tell Vocabulary'),
+    ]
+
+    tier1_blocks = []
+    tier1_chars = 0
+    for path, label in tier1_sources:
+        content = _read_if_exists(path)
+        if content:
+            tier1_blocks.append({'type': 'text', 'text': f'=== {label} ===\n\n{content}'})
+            tier1_chars += len(content) + len(label) + 10
+
+    # --- Tier 2: Project-level (session-stable) ---
+    ref_dir = os.path.join(project_dir, 'reference')
+    tier2_sources = [
+        (os.path.join(ref_dir, 'character-bible.md'), 'Character Bible'),
+        (os.path.join(ref_dir, 'world-bible.md'), 'World Bible'),
+        (os.path.join(ref_dir, 'voice-guide.md'), 'Voice Guide'),
+        (os.path.join(ref_dir, 'voice-profile.csv'), 'Voice Profile'),
+        (os.path.join(ref_dir, 'characters.csv'), 'Character Registry'),
+        (os.path.join(ref_dir, 'locations.csv'), 'Location Registry'),
+        (os.path.join(ref_dir, 'mice-threads.csv'), 'MICE Thread Registry'),
+    ]
+
+    tier2_blocks = []
+    tier2_chars = 0
+    for path, label in tier2_sources:
+        content = _read_if_exists(path)
+        if content:
+            tier2_blocks.append({'type': 'text', 'text': f'=== {label} ===\n\n{content}'})
+            tier2_chars += len(content) + len(label) + 10
+
+    # --- Apply cache_control breakpoints ---
+    blocks = []
+
+    if tier1_blocks:
+        if tier1_chars >= min_chars:
+            # Tier 1 meets threshold — add breakpoint with extended TTL
+            tier1_blocks[-1]['cache_control'] = {'type': 'ephemeral', 'ttl': 3600}
+        blocks.extend(tier1_blocks)
+
+    if tier2_blocks:
+        cumulative_chars = tier1_chars + tier2_chars
+        if cumulative_chars >= min_chars:
+            # Cumulative prefix meets threshold — add breakpoint with default TTL
+            tier2_blocks[-1]['cache_control'] = {'type': 'ephemeral'}
+        blocks.extend(tier2_blocks)
+
+    _shared_context_cache[cache_key] = blocks
+    return blocks
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_prompt_caching.py::TestBuildSharedContext -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 2>&1 | tail -20`
+Expected: No regressions — `build_shared_context` is additive, no existing code calls it yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/common.py tests/test_prompt_caching.py
+git commit -m "Add build_shared_context for two-tier prompt caching"
+git push
+```
+
+---
+
+### Task 6: Integrate cmd_write (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_write.py`
+- Modify: `scripts/lib/python/storyforge/prompts.py`
+
+**Context:** `cmd_write.py` builds batch requests at line 432-439 and has a direct invoke path at line 566. The prompt is built by `_build_prompt()` which calls `build_scene_prompt()` from `prompts.py`. `build_scene_prompt()` inlines: craft engine (line 722), AI-tell words (line 729), voice profile (line 733), and all reference files in api_mode (lines 692-703).
+
+- [ ] **Step 1: Add system_context parameter to build_scene_prompt**
+
+In `scripts/lib/python/storyforge/prompts.py`, add `system_context: bool = False` to the `build_scene_prompt()` signature. When `True`, skip inlining:
+- Reference file reading loop (lines 692-703 where `api_mode` reads files with `=== FILE:` markers)
+- Craft engine sections via `extract_craft_sections()` (line 722)
+- AI-tell vocabulary loading via `load_ai_tell_words()` (line 729)
+- Voice profile loading via `load_voice_profile()` (line 733)
+
+Each of these sections should be wrapped in `if not system_context:` guards. The `build_weighted_directive()` call (craft-weights.csv) stays — it's project-specific weighted formatting, not raw reference material.
+
+- [ ] **Step 2: Add system_context parameter to build_scene_prompt_from_briefs if it exists**
+
+Check if `build_scene_prompt_from_briefs()` exists in prompts.py and apply the same pattern. If it delegates to `build_scene_prompt()`, the parameter just needs to be passed through.
+
+- [ ] **Step 3: Update _build_prompt in cmd_write.py**
+
+Find `_build_prompt()` in cmd_write.py and add a `system_context=False` parameter. Pass it through to `build_scene_prompt()` / `build_scene_prompt_from_briefs()`.
+
+- [ ] **Step 4: Update batch construction in _run_batch_mode**
+
+In `cmd_write.py`, in the `_run_batch_mode()` function:
+
+1. Before the scene loop, add:
+```python
+from storyforge.common import build_shared_context
+system = build_shared_context(project_dir, model=model)
+```
+
+2. Change the prompt building call to pass `system_context=True`:
+```python
+prompt = _build_prompt(scene_id, project_dir, coaching, use_briefs, system_context=True)
+```
+
+3. Replace the inline dict construction (lines 432-439):
+```python
+from storyforge.api import build_batch_request
+request = build_batch_request(scene_id, prompt, model, 8192, system=system)
+```
+
+- [ ] **Step 5: Update direct mode in _run_direct_mode**
+
+In the `_run_direct_mode()` function:
+
+1. Build shared context once before the loop:
+```python
+from storyforge.common import build_shared_context
+system = build_shared_context(project_dir, model=model)
+```
+
+2. Pass `system_context=True` to `_build_prompt()`.
+
+3. Pass `system=system` to the `invoke_to_file()` call (line 566).
+
+- [ ] **Step 6: Add session_start to main() and print_summary**
+
+In `cmd_write.py`:
+
+1. At the top of `main()` (after `args = parse_args(...)` and `project_dir = detect_project_root()`), add:
+```python
+from datetime import datetime
+session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+```
+
+2. Update the `print_summary` call (line 211) to:
+```python
+print_summary(project_dir, 'draft', session_start=session_start)
+```
+
+- [ ] **Step 7: Run tests and verify no regressions**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "write or prompt or draft" 2>&1 | tail -30`
+Expected: All existing tests PASS. The `system_context=False` default preserves old behavior for any test that calls `build_scene_prompt()` directly.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_write.py scripts/lib/python/storyforge/prompts.py
+git commit -m "Add prompt caching to cmd_write (batch + direct)"
+git push
+```
+
+---
+
+### Task 7: Integrate cmd_score (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_score.py`
+- Modify: `scripts/lib/python/storyforge/scoring.py`
+
+**Context:** `cmd_score.py` has two batch paths: craft scoring (line 876) and fidelity scoring (line 1044). It also has direct `invoke_to_file` calls for act-level (line 1186), novel-level (line 1264), and narrative scoring (line 1340). The prompts are built by functions in `scoring.py` and inline in `cmd_score.py`. `scoring.py` reads per-principle rubric sections from scoring-rubrics.md (line 784) — this per-principle extraction stays in the user message since it's specific to each scoring call; the full rubrics file is in shared context for general reference.
+
+- [ ] **Step 1: Add system parameter to batch construction for craft scoring**
+
+In `cmd_score.py`, in the craft scoring batch loop:
+
+1. Before the loop, add:
+```python
+from storyforge.common import build_shared_context
+system = build_shared_context(project_dir, model=eval_model)
+```
+
+2. Replace the inline batch dict (lines 876-883) with:
+```python
+from storyforge.api import build_batch_request
+request = build_batch_request(sid, prompt, eval_model, 4096, system=system)
+```
+
+- [ ] **Step 2: Add system parameter to fidelity scoring batch**
+
+Same pattern for the fidelity batch (lines 1044-1051):
+```python
+request = build_batch_request(f'fidelity-{sid}', prompt, sonnet_model, 2048, system=system)
+```
+
+- [ ] **Step 3: Pass system to direct invoke_to_file calls**
+
+For each direct `invoke_to_file` call in cmd_score.py (lines 961, 1073, 1186, 1264, 1340), add `system=system`.
+
+- [ ] **Step 4: Add session_start to main() and print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` call (line 413) to include `session_start=session_start`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "scor" 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_score.py
+git commit -m "Add prompt caching to cmd_score (batch + direct)"
+git push
+```
+
+---
+
+### Task 8: Integrate cmd_evaluate (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_evaluate.py`
+
+**Context:** `cmd_evaluate.py` has one batch path (line 1054) for evaluator panels, and direct calls for synthesis (line 1217) and assessment (line 1285). The evaluator prompts are built inline in the module.
+
+- [ ] **Step 1: Add system parameter to evaluator batch**
+
+1. Before the batch loop, call `build_shared_context(project_dir, model=eval_models[0])`.
+2. Replace inline dict (lines 1054-1061) with `build_batch_request()`.
+
+- [ ] **Step 2: Pass system to synthesis and assessment invoke_to_file calls**
+
+Add `system=system` to the `invoke_to_file` calls at lines 1217 and 1285.
+
+- [ ] **Step 3: Add session_start to main() and print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update the three `print_summary` calls (lines 1358-1360) to include `session_start=session_start`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "eval" 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_evaluate.py
+git commit -m "Add prompt caching to cmd_evaluate (batch + direct)"
+git push
+```
+
+---
+
+### Task 9: Integrate cmd_extract (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_extract.py`
+
+**Context:** `cmd_extract.py` has three batch phases: skeleton (line 371), intent (line 467), briefs (line 579). Direct calls for characterization (line 311), knowledge fixing (line 663), and physical state fixing (line 725). Prompts use `registries_text` parameter from `extract.py` — much of the shared content already flows as a parameter rather than being inlined by the builder.
+
+- [ ] **Step 1: Add system parameter to all three batch phases**
+
+For each phase batch loop:
+1. Call `build_shared_context(project_dir, model=model)` once before the phase.
+2. Replace inline dicts with `build_batch_request()`.
+
+Phase 1 (lines 371-378), Phase 2 (lines 467-474), Phase 3 (lines 579-586).
+
+- [ ] **Step 2: Pass system to direct invoke_to_file calls**
+
+Add `system=system` to calls at lines 311, 663, 725.
+
+- [ ] **Step 3: Add session_start to main() and print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` call (line 209) to include `session_start=session_start`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "extract" 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_extract.py
+git commit -m "Add prompt caching to cmd_extract (batch + direct)"
+git push
+```
+
+---
+
+### Task 10: Integrate cmd_revise (direct only)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_revise.py`
+- Modify: `scripts/lib/python/storyforge/revision.py`
+
+**Context:** `cmd_revise.py` uses direct API calls only (no batch). Main invoke points: line 204 (redraft), line 1548 and 2213 (revision steps), line 1149 and 1215 (interactive). `revision.py` builds prompts that inline craft-engine.md (line 232), scoring-rubrics.md (line 310), exemplars.csv (line 358), and reference files (lines 590-607).
+
+- [ ] **Step 1: Add system_context parameter to build_revision_prompt**
+
+In `scripts/lib/python/storyforge/revision.py`, add `system_context: bool = False` to `build_revision_prompt()`. When `True`, skip inlining:
+- `extract_craft_sections()` (craft engine)
+- `_load_rubric_sections()` (scoring rubrics)
+- Reference file reading loop (voice-guide.md, scenes.csv, intent.csv, knowledge.csv at lines 590-607)
+
+Keep: pass-specific configuration, scene prose, brief data, overrides, exemplars (these are per-pass/per-principle, not shared project context — the spec lists exemplars for removal but they're pass-filtered content that belongs in the user message).
+
+- [ ] **Step 2: Build shared context once per session**
+
+In `cmd_revise.py`, early in the revision orchestration (after project_dir is known):
+```python
+from storyforge.common import build_shared_context
+system = build_shared_context(project_dir, model=pass_model)
+```
+
+- [ ] **Step 3: Pass system to all invoke_to_file / invoke_api calls**
+
+Add `system=system` to the `invoke_to_file` calls at lines 204, 1548, 2213, and to `invoke_api` calls at lines 1149, 1215. Pass `system_context=True` to `build_revision_prompt()`.
+
+- [ ] **Step 4: Add session_start to main() and print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` call (line 2436) to include `session_start=session_start`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "revis" 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_revise.py scripts/lib/python/storyforge/revision.py
+git commit -m "Add prompt caching to cmd_revise (direct calls)"
+git push
+```
+
+---
+
+### Task 11: Integrate cmd_elaborate (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_elaborate.py`
+- Modify: `scripts/lib/python/storyforge/prompts_elaborate.py`
+
+**Context:** `cmd_elaborate.py` has direct invoke for stage prompts (line 578), gap-fill batch (line 300), MICE fill (line 161), and knowledge fixing (line 396). `prompts_elaborate.py` inlines via `_existing_refs()` (character bible, world bible, voice guide, story architecture at lines 48-64) and `_craft_principles()` (craft engine at lines 67-88).
+
+- [ ] **Step 1: Add system_context parameter to elaborate prompt builders**
+
+In `scripts/lib/python/storyforge/prompts_elaborate.py`:
+- Add `system_context: bool = False` to `build_spine_prompt()`, `build_architecture_prompt()`, `build_map_prompt()`, `build_briefs_prompt()`, `build_voice_prompt()`.
+- When `True`, skip calling `_existing_refs()` and `_craft_principles()`.
+
+- [ ] **Step 2: Update cmd_elaborate to use shared context**
+
+1. Build `system = build_shared_context(project_dir, model=stage_model)` before invoking.
+2. Pass `system_context=True` to prompt builders.
+3. Replace gap-fill batch inline dicts (line 300-307) with `build_batch_request()`.
+4. Pass `system=system` to all `invoke_to_file` and `invoke` calls.
+
+- [ ] **Step 3: Add session_start and update print_summary calls**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` calls (lines 489, 836) with `session_start=session_start`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "elaborate" 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/python/storyforge/cmd_elaborate.py scripts/lib/python/storyforge/prompts_elaborate.py
+git commit -m "Add prompt caching to cmd_elaborate (batch + direct)"
+git push
+```
+
+---
+
+### Task 12: Integrate cmd_enrich (batch)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_enrich.py`
+
+**Context:** `cmd_enrich.py` has batch requests at line 658 and a direct invoke at line 728.
+
+- [ ] **Step 1: Update batch and direct paths**
+
+1. Build `system = build_shared_context(project_dir, model=model)` once.
+2. Replace inline dict (lines 658-665) with `build_batch_request()`.
+3. Pass `system=system` to `invoke_to_file` (line 728).
+
+- [ ] **Step 2: Add session_start and update print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` call (line 863) with `session_start=session_start`.
+
+- [ ] **Step 3: Run tests and commit**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "enrich" 2>&1 | tail -30`
+
+```bash
+git add scripts/lib/python/storyforge/cmd_enrich.py
+git commit -m "Add prompt caching to cmd_enrich"
+git push
+```
+
+---
+
+### Task 13: Integrate cmd_timeline (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_timeline.py`
+
+**Context:** `cmd_timeline.py` has batch at line 321, direct invoke_to_file at lines 399, 490, and invoke_api at lines 411, 488.
+
+- [ ] **Step 1: Update batch and direct paths**
+
+1. Build `system = build_shared_context(project_dir, model=haiku_model)` once.
+2. Replace inline dict (lines 321-328) with `build_batch_request()`.
+3. Pass `system=system` to all `invoke_to_file` and `invoke_api` calls.
+
+- [ ] **Step 2: Add session_start and update print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` calls (lines 570, 645, 646) with `session_start=session_start`.
+
+- [ ] **Step 3: Run tests and commit**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "timeline" 2>&1 | tail -30`
+
+```bash
+git add scripts/lib/python/storyforge/cmd_timeline.py
+git commit -m "Add prompt caching to cmd_timeline"
+git push
+```
+
+---
+
+### Task 14: Integrate cmd_scenes_setup (batch + direct)
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/cmd_scenes_setup.py`
+
+**Context:** `cmd_scenes_setup.py` has batch at line 521 and direct invoke at line 317.
+
+- [ ] **Step 1: Update batch and direct paths**
+
+1. Build `system = build_shared_context(project_dir, model=model)` once.
+2. Replace inline dict (lines 521-528) with `build_batch_request()`.
+3. Pass `system=system` to `invoke_to_file` (line 317).
+
+- [ ] **Step 2: Add session_start and update print_summary**
+
+1. Record `session_start` at top of `main()`.
+2. Update `print_summary` calls (lines 865, 896) with `session_start=session_start`.
+
+- [ ] **Step 3: Run tests and commit**
+
+Run: `python3 -m pytest tests/ -v --timeout=30 -k "scene" 2>&1 | tail -30`
+
+```bash
+git add scripts/lib/python/storyforge/cmd_scenes_setup.py
+git commit -m "Add prompt caching to cmd_scenes_setup"
+git push
+```
+
+---
+
+### Task 15: Full regression test + version bump
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `python3 -m pytest tests/ -v --timeout=60 2>&1 | tail -40`
+Expected: All tests PASS with no regressions.
+
+- [ ] **Step 2: Bump version**
+
+In `.claude-plugin/plugin.json`, bump the minor version (e.g., `1.16.3` -> `1.17.0`) since this is a new feature.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "Bump version to 1.17.0"
+git push
+```

--- a/docs/superpowers/specs/2026-04-15-prompt-caching-and-cost-summary-design.md
+++ b/docs/superpowers/specs/2026-04-15-prompt-caching-and-cost-summary-design.md
@@ -1,0 +1,225 @@
+# Prompt Caching and Cost Summary Improvements
+
+## Problem
+
+Storyforge's API layer sends every request with the full prompt from scratch. Across a typical pipeline run (50+ API calls), 40-60% of input tokens are shared reference material (craft engine, voice guide, character bible, registries) that gets re-sent identically on every call. This wastes money and time.
+
+Additionally, the cost summary shown after autonomous passes (`print_summary`) reports cumulative totals across all sessions, not the current session. The user sees "$96.96" and thinks this run cost $97, when it actually cost $21.50 and $97 is the all-time total.
+
+## Scope
+
+Two changes:
+
+1. **Prompt caching** — use Anthropic's `system` parameter with `cache_control` blocks to cache shared project context across API calls (batch and direct).
+2. **Cost summary** — show per-session and cumulative totals after each autonomous pass, with human-readable time formatting.
+
+## Design
+
+### 1. Shared Context Helper
+
+A new function in `common.py`:
+
+```python
+def build_shared_context(project_dir: str, model: str = '') -> list[dict]:
+```
+
+Assembles project-level reference materials into an ordered list of system content blocks. The ordering is fixed so the cache prefix is stable across calls.
+
+**Two-tier structure with separate cache breakpoints:**
+
+**Tier 1 — Near-permanent** (TTL: 1 hour, cache creation cost 2x base):
+- Craft engine (sections 2-5 from `references/craft-engine.md` or project override)
+- Scoring rubrics (from `references/`)
+- AI-tell vocabulary (`references/ai-tell-words.csv`)
+- Schema definitions
+
+These change only when the plugin is updated. The 1h TTL means a `score` run followed by a `revise` run 20 minutes later still hits cache on this tier.
+
+**Tier 2 — Session-stable** (TTL: 5 minutes, cache creation cost 1.25x base):
+- Character bible (`reference/character-bible.md`)
+- World bible (`reference/world-bible.md`)
+- Voice guide (`reference/voice-guide.md`)
+- Voice profile CSV (`reference/voice-profile.csv`)
+- Registries: characters, locations, MICE threads (from `reference/` CSVs)
+
+These are stable within a session but may evolve between sessions as the author works.
+
+**Cache breakpoint placement:** The last block in each tier gets `cache_control: {"type": "ephemeral", "ttl": "1h"}` (tier 1) or `cache_control: {"type": "ephemeral"}` (tier 2, default 5m). This creates two cache breakpoints — the API caches the prefix up to each independently.
+
+**Minimum token threshold:** Each breakpoint requires a minimum token count (4,096 for Opus, 2,048 for Sonnet). If a tier's total content is below the threshold, its `cache_control` is omitted and the content simply flows into the next tier's prefix. The function accepts a `model` parameter to determine the threshold.
+
+**Missing files:** Silently skipped. Not every project has every reference file.
+
+**In-process caching:** The assembled blocks are cached in a module-level variable so repeated calls within the same process don't re-read files from disk.
+
+### 2. API Layer Changes
+
+#### `invoke()` — new `system` parameter
+
+```python
+def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
+           timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> dict:
+```
+
+When `system` is provided, the request body includes it:
+
+```python
+body = {
+    'model': model,
+    'max_tokens': max_tokens,
+    'system': system,
+    'messages': [{'role': 'user', 'content': prompt}],
+}
+```
+
+When `system` is `None` (default), the `system` key is omitted entirely. All existing callers work without modification.
+
+`invoke_to_file()` and `invoke_api()` pass `system` through to `invoke()`.
+
+#### `build_batch_request()` — new helper
+
+```python
+def build_batch_request(custom_id: str, prompt: str, model: str,
+                        max_tokens: int = 4096,
+                        system: list[dict] | None = None) -> dict:
+    """Build a single batch request item (one JSONL line)."""
+    params = {
+        'model': model,
+        'max_tokens': max_tokens,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }
+    if system:
+        params['system'] = system
+    return {'custom_id': custom_id, 'params': params}
+```
+
+Replaces the inline dict construction currently copy-pasted across 6+ command modules. Each batch item gets the same `system` blocks, so the API caches the prefix once and reads it for all subsequent items.
+
+### 3. Command Module Integration
+
+Each command module changes to:
+
+1. Call `build_shared_context(project_dir)` once before the batch/loop.
+2. Use `build_batch_request()` instead of inline dict construction.
+3. Pass `system` to `invoke_to_file()` for direct API calls.
+
+**Prompt builders stop inlining shared material.** Each builder currently reads craft engine, voice guide, etc. and concatenates them into the prompt string. Those sections are removed — the content now arrives via the `system` parameter.
+
+**Affected prompt builder modules:**
+- `prompts.py` — remove: craft engine, voice guide, character/world bible inlining
+- `prompts_elaborate.py` — remove: craft principles, existing refs (architecture, bibles, voice guide)
+- `revision.py` — remove: craft rubric, voice guide, exemplars
+- `scoring.py` — remove: craft rules, voice guide
+- `extract.py` — remove: registries, craft definitions
+- `hone.py` — remove: registries
+
+Each builder retains its per-item content: scene brief, prose, metadata, pass-specific instructions, continuity dependencies.
+
+**Command modules affected:**
+- `cmd_write.py` — batch construction loop
+- `cmd_score.py` — craft cycle batch + fidelity batch
+- `cmd_evaluate.py` — eval batch
+- `cmd_extract.py` — 3 extraction phase batches
+- `cmd_revise.py` — direct invoke per scene per pass
+- `cmd_elaborate.py` — direct invoke per stage + gap-fill batch
+- `cmd_hone.py` — direct invoke calls
+- `cmd_enrich.py` — per-domain batches
+- `cmd_timeline.py` — direct + batch calls
+- `cmd_scenes_setup.py` — batch calls
+
+### 4. Cost Summary Improvements
+
+#### Human-readable time formatting
+
+New helper in `costs.py`:
+
+```python
+def format_duration(seconds: int) -> str:
+    """Format seconds as Xh Xm Xs, omitting zero leading components."""
+```
+
+- `27888` -> `7h 44m 48s`
+- `180` -> `3m 0s`
+- `45` -> `45s`
+- `0` -> `0s`
+
+#### Session-scoped summaries
+
+`print_summary` gains an optional `session_start` parameter:
+
+```python
+def print_summary(project_dir: str, operation: str | None = None,
+                  session_start: str | None = None) -> None:
+```
+
+When `session_start` is provided (ISO timestamp string), the function makes two passes over the ledger:
+
+1. **This session** — rows where `timestamp >= session_start` and operation matches
+2. **Project total** — all rows where operation matches
+
+Output format:
+
+```
+--- This session: revise (6 invocations) ---
+Input tokens:  521,340
+Output tokens: 98,201
+Cache read:    412,800
+Cache create:  108,540
+Cost:          $14.22
+Time:          57m 0s
+
+--- Project total: revise (50 invocations) ---
+Input tokens:  4,339,621
+Output tokens: 823,482
+Cache read:    412,800
+Cache create:  108,540
+Cost:          $89.52
+Time:          7h 44m 48s
+```
+
+Each command module records its start time (`datetime.now().strftime('%Y-%m-%dT%H:%M:%S')`) at the top of `main()` and passes it to `print_summary` at the end.
+
+Callers that don't pass `session_start` get the current behavior (cumulative only) — backward compatible.
+
+### 5. Testing
+
+All in `tests/test_prompt_caching.py` and extended `tests/test_costs.py`.
+
+**`build_shared_context()` tests:**
+- Returns correct two-tier block structure with `cache_control` on breakpoint blocks
+- Skips missing reference files without error
+- Fixed ordering produces identical output across calls
+- In-process cache returns same object on second call
+- Tier merging when content is below minimum token threshold
+
+**`build_batch_request()` tests:**
+- Includes `system` in params when provided
+- Omits `system` key entirely when `None`
+- Correct JSONL structure (custom_id, params with model/max_tokens/messages)
+
+**`format_duration()` tests:**
+- `0` -> `0s`
+- `45` -> `45s`
+- `180` -> `3m 0s`
+- `3661` -> `1h 1m 1s`
+- `27888` -> `7h 44m 48s`
+
+**`print_summary` with `session_start` tests:**
+- Filters correctly: only rows after session_start in session section
+- Shows all rows in project total section
+- Works without `session_start` (backward compatible)
+- Handles empty ledger, no matching operation
+
+**Request shape tests:**
+- `invoke()` with `system` builds body with `system` key
+- `invoke()` without `system` builds body without `system` key
+- Batch JSONL file with system blocks is valid JSON per line
+
+No tests for actual cache hit behavior — that's Anthropic's responsibility.
+
+## Non-goals
+
+- Changing the Batch API submission flow (`submit_batch` / `poll_batch` / `download_batch_results`)
+- Per-command customization of which reference files are cached (all commands get the same shared context)
+- Prompt caching for the CLI interface (`python3 -m storyforge.api invoke`)
+- Changes to the ledger CSV schema

--- a/scripts/lib/python/storyforge/api.py
+++ b/scripts/lib/python/storyforge/api.py
@@ -109,7 +109,7 @@ def _api_request(path: str, body: dict | None = None, method: str = 'GET',
 
 
 def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
-           timeout: int = API_TIMEOUT) -> dict:
+           timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> dict:
     """Call the Anthropic Messages API.
 
     Args:
@@ -118,6 +118,7 @@ def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
         max_tokens: Maximum output tokens.
         label: Optional label for heartbeat messages (e.g., 'revision pass 3').
         timeout: Socket timeout in seconds (default API_TIMEOUT).
+        system: Optional list of system content blocks (supports cache_control).
 
     Returns:
         Full API response dict.
@@ -127,6 +128,8 @@ def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
         'max_tokens': max_tokens,
         'messages': [{'role': 'user', 'content': prompt}],
     }
+    if system:
+        body['system'] = system
     heartbeat = _Heartbeat(label or model)
     heartbeat.start()
     try:
@@ -136,7 +139,7 @@ def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
 
 
 def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 4096, label: str = '',
-                   timeout: int = API_TIMEOUT) -> dict:
+                   timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> dict:
     """Call the API and write the response to a JSON file.
 
     Args:
@@ -146,11 +149,12 @@ def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 409
         max_tokens: Maximum output tokens.
         label: Optional label for heartbeat messages.
         timeout: Socket timeout in seconds (default API_TIMEOUT).
+        system: Optional list of system content blocks (supports cache_control).
 
     Returns:
         Full API response dict.
     """
-    response = invoke(prompt, model, max_tokens, label=label, timeout=timeout)
+    response = invoke(prompt, model, max_tokens, label=label, timeout=timeout, system=system)
     os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
     with open(log_file, 'w') as f:
         json.dump(response, f)
@@ -158,14 +162,14 @@ def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 409
 
 
 def invoke_api(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
-               timeout: int = API_TIMEOUT) -> str:
+               timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> str:
     """High-level convenience: invoke API and return text response.
 
     Returns empty string on failure (logs warning but doesn't raise).
     Used by git.py review phase, runner.py healing zones, and command modules.
     """
     try:
-        response = invoke(prompt, model, max_tokens, label=label, timeout=timeout)
+        response = invoke(prompt, model, max_tokens, label=label, timeout=timeout, system=system)
         return extract_text(response)
     except Exception as e:
         from storyforge.common import log
@@ -221,6 +225,31 @@ def calculate_cost_from_usage(usage: dict, model: str, batch: bool = False) -> f
         cache_create=usage.get('cache_create', 0),
         batch=batch,
     )
+
+
+def build_batch_request(custom_id: str, prompt: str, model: str,
+                        max_tokens: int = 4096,
+                        system: list[dict] | None = None) -> dict:
+    """Build a single batch request item (one JSONL line).
+
+    Args:
+        custom_id: Unique identifier for this request in the batch.
+        prompt: The user message text.
+        model: Model ID.
+        max_tokens: Maximum output tokens.
+        system: Optional list of system content blocks with cache_control.
+
+    Returns:
+        Dict suitable for JSON serialization as one JSONL line.
+    """
+    params = {
+        'model': model,
+        'max_tokens': max_tokens,
+        'messages': [{'role': 'user', 'content': prompt}],
+    }
+    if system:
+        params['system'] = system
+    return {'custom_id': custom_id, 'params': params}
 
 
 # ============================================================================

--- a/scripts/lib/python/storyforge/cmd_elaborate.py
+++ b/scripts/lib/python/storyforge/cmd_elaborate.py
@@ -24,7 +24,7 @@ import time
 
 from storyforge.common import (
     detect_project_root, log, read_yaml_field, select_model,
-    install_signal_handlers, get_plugin_dir,
+    install_signal_handlers, get_plugin_dir, build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr,
@@ -118,6 +118,8 @@ def _run_mice_fill(project_dir: str, ref_dir: str, dry_run: bool,
     ensure_branch_pushed(project_dir)
 
     mice_model = select_model('evaluation')
+    # Build shared context once for all MICE fill API calls (prompt caching)
+    system = build_shared_context(project_dir, model=mice_model)
     grand_total = 0
     baseline_gaps = len(gaps)
 
@@ -159,7 +161,7 @@ def _run_mice_fill(project_dir: str, ref_dir: str, dry_run: bool,
 
             log_file = os.path.join(log_dir, f'mice-fill-{gap["thread_id"]}.json')
             invoke_to_file(prompt, mice_model, log_file, max_tokens=512,
-                           label=f'mice-fill {gap["thread_id"]}')
+                           label=f'mice-fill {gap["thread_id"]}', system=system)
             response = extract_text_from_file(log_file)
 
             scene_ids = parse_mice_fill_response(response)
@@ -214,7 +216,8 @@ def _run_mice_fill(project_dir: str, ref_dir: str, dry_run: bool,
 # Gap-fill
 # ============================================================================
 
-def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
+def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool,
+                  session_start: str | None = None) -> None:
     """Analyze gaps, batch-fill parallel fields, sequential knowledge fix."""
     scenes_dir = os.path.join(project_dir, 'scenes')
     gap_dir = os.path.join(project_dir, 'working', 'gap-fill')
@@ -225,7 +228,7 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
     log('Analyzing gaps...')
 
     from storyforge.elaborate import analyze_gaps, validate_structure, update_scene, get_scenes
-    from storyforge.api import submit_batch, poll_batch, download_batch_results, invoke, extract_text
+    from storyforge.api import submit_batch, poll_batch, download_batch_results, invoke, extract_text, build_batch_request
     from storyforge.prompts_elaborate import build_gap_fill_prompt, build_knowledge_fix_prompt, csv_block_to_rows
     from storyforge.enrich import format_registries_for_prompt, load_registry_alias_maps, normalize_fields
 
@@ -271,6 +274,9 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
         gap_model = select_model('evaluation')
         alias_maps = load_registry_alias_maps(project_dir)
 
+        # Build shared context once for all gap-fill API calls (prompt caching)
+        system = build_shared_context(project_dir, model=gap_model)
+
         # Parallel gap groups: build single batch
         parallel_groups = {k: v for k, v in groups.items() if v['batch_type'] == 'parallel'}
         parallel_count = sum(len(v['scenes']) for v in parallel_groups.values())
@@ -297,14 +303,8 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
                             registries_text=registries,
                         )
                         custom_id = f'{group_name}__{scene_id}'
-                        req = {
-                            'custom_id': custom_id,
-                            'params': {
-                                'model': gap_model,
-                                'max_tokens': 256,
-                                'messages': [{'role': 'user', 'content': prompt}],
-                            },
-                        }
+                        req = build_batch_request(custom_id, prompt, gap_model,
+                                                  max_tokens=256, system=system)
                         bf.write(json.dumps(req) + '\n')
 
             log('Submitting batch...')
@@ -393,7 +393,7 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
                         available_knowledge=available_knowledge,
                     )
 
-                    response = invoke(prompt, gap_model, max_tokens=512)
+                    response = invoke(prompt, gap_model, max_tokens=512, system=system)
                     klog_file = os.path.join(knowledge_log_dir, f'{sid}.json')
                     with open(klog_file, 'w') as f:
                         json.dump(response, f)
@@ -486,7 +486,7 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
         log(f'Validation: {validate_failures} issue(s) remaining — run again to continue')
     log('============================================')
 
-    print_summary(project_dir, 'elaborate-gap-fill')
+    print_summary(project_dir, 'elaborate-gap-fill', session_start=session_start)
 
 
 # ============================================================================
@@ -494,7 +494,8 @@ def _run_gap_fill(project_dir: str, ref_dir: str, dry_run: bool) -> None:
 # ============================================================================
 
 def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
-                    dry_run: bool, interactive: bool, seed: str) -> None:
+                    dry_run: bool, interactive: bool, seed: str,
+                    session_start: str | None = None) -> None:
     """Run a standard elaboration stage (spine/architecture/map/briefs)."""
     plugin_dir = get_plugin_dir()
     log_dir = os.path.join(project_dir, 'working', 'logs')
@@ -517,14 +518,21 @@ def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
 
     registries = format_registries_for_prompt(project_dir)
 
+    # Build shared context once for all stage API calls (prompt caching)
+    stage_model = select_model('drafting')  # Opus for creative work
+    system = build_shared_context(project_dir, model=stage_model)
+
     if stage == 'spine':
-        prompt = build_spine_prompt(project_dir, plugin_dir, seed)
+        prompt = build_spine_prompt(project_dir, plugin_dir, seed, system_context=True)
     elif stage == 'architecture':
-        prompt = build_architecture_prompt(project_dir, plugin_dir, registries_text=registries)
+        prompt = build_architecture_prompt(project_dir, plugin_dir, registries_text=registries,
+                                           system_context=True)
     elif stage == 'map':
-        prompt = build_map_prompt(project_dir, plugin_dir, registries_text=registries)
+        prompt = build_map_prompt(project_dir, plugin_dir, registries_text=registries,
+                                  system_context=True)
     elif stage == 'briefs':
-        prompt = build_briefs_prompt(project_dir, plugin_dir, registries_text=registries)
+        prompt = build_briefs_prompt(project_dir, plugin_dir, registries_text=registries,
+                                     system_context=True)
     else:
         log(f'ERROR: Unknown stage: {stage}')
         sys.exit(1)
@@ -554,7 +562,6 @@ def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
 
     # Invoke Claude
     stage_log = os.path.join(log_dir, f'elaborate-{stage}.log')
-    stage_model = select_model('drafting')  # Opus for creative work
 
     from storyforge.api import invoke_to_file, extract_text_from_file, invoke_api
     from storyforge.costs import log_operation
@@ -575,7 +582,7 @@ def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
     else:
         log(f'Invoking API for {stage} (model: {stage_model})...')
         try:
-            invoke_to_file(prompt, stage_model, stage_log, max_tokens=16384)
+            invoke_to_file(prompt, stage_model, stage_log, max_tokens=16384, system=system)
             claude_rc = 0
         except Exception as e:
             log(f'ERROR: API invocation failed: {e}')
@@ -833,7 +840,7 @@ def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
         log(f'Validation: {validate_failures} issue(s) — review before advancing')
     log('============================================')
 
-    print_summary(project_dir, f'elaborate-{stage}')
+    print_summary(project_dir, f'elaborate-{stage}', session_start=session_start)
 
 
 # ============================================================================
@@ -844,6 +851,10 @@ def main(argv=None):
     args = parse_args(argv or [])
 
     install_signal_handlers()
+
+    from datetime import datetime
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+
     project_dir = detect_project_root()
     ref_dir = os.path.join(project_dir, 'reference')
 
@@ -874,7 +885,8 @@ def main(argv=None):
     if args.stage == 'mice-fill':
         _run_mice_fill(project_dir, ref_dir, args.dry_run)
     elif args.stage == 'gap-fill':
-        _run_gap_fill(project_dir, ref_dir, args.dry_run)
+        _run_gap_fill(project_dir, ref_dir, args.dry_run, session_start=session_start)
     else:
         _run_main_stage(args.stage, project_dir, ref_dir,
-                        args.dry_run, args.interactive, args.seed)
+                        args.dry_run, args.interactive, args.seed,
+                        session_start=session_start)

--- a/scripts/lib/python/storyforge/cmd_elaborate.py
+++ b/scripts/lib/python/storyforge/cmd_elaborate.py
@@ -522,17 +522,18 @@ def _run_main_stage(stage: str, project_dir: str, ref_dir: str,
     stage_model = select_model('drafting')  # Opus for creative work
     system = build_shared_context(project_dir, model=stage_model)
 
+    has_system = bool(system)
     if stage == 'spine':
-        prompt = build_spine_prompt(project_dir, plugin_dir, seed, system_context=True)
+        prompt = build_spine_prompt(project_dir, plugin_dir, seed, system_context=has_system)
     elif stage == 'architecture':
         prompt = build_architecture_prompt(project_dir, plugin_dir, registries_text=registries,
-                                           system_context=True)
+                                           system_context=has_system)
     elif stage == 'map':
         prompt = build_map_prompt(project_dir, plugin_dir, registries_text=registries,
-                                  system_context=True)
+                                  system_context=has_system)
     elif stage == 'briefs':
         prompt = build_briefs_prompt(project_dir, plugin_dir, registries_text=registries,
-                                     system_context=True)
+                                     system_context=has_system)
     else:
         log(f'ERROR: Unknown stage: {stage}')
         sys.exit(1)

--- a/scripts/lib/python/storyforge/cmd_enrich.py
+++ b/scripts/lib/python/storyforge/cmd_enrich.py
@@ -21,10 +21,11 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 from storyforge.common import (
     detect_project_root, log, read_yaml_field, select_model,
-    install_signal_handlers,
+    install_signal_handlers, build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr,
@@ -34,7 +35,7 @@ from storyforge.costs import estimate_cost, check_threshold, print_summary
 from storyforge.api import (
     invoke_to_file, extract_text_from_file, submit_batch,
     poll_batch, download_batch_results, extract_usage,
-    calculate_cost_from_usage,
+    calculate_cost_from_usage, build_batch_request,
 )
 from storyforge.costs import log_operation
 
@@ -217,6 +218,7 @@ def parse_args(argv):
 
 def main(argv=None):
     args = parse_args(argv or [])
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     install_signal_handlers()
     project_dir = detect_project_root()
@@ -272,6 +274,7 @@ def main(argv=None):
         sys.exit(1)
 
     model = select_model('extraction')
+    system = build_shared_context(project_dir, model=model)
     log(f'Enrichment model: {model} (mode: {enrich_mode})')
 
     # ========================================================================
@@ -655,14 +658,8 @@ def main(argv=None):
             with open(batch_file, 'w') as bf:
                 for sid in claude_ids:
                     prompt = _build_prompt(sid)
-                    req = {
-                        'custom_id': sid,
-                        'params': {
-                            'model': model,
-                            'max_tokens': 4096,
-                            'messages': [{'role': 'user', 'content': prompt}],
-                        },
-                    }
+                    req = build_batch_request(sid, prompt, model, max_tokens=4096,
+                                             system=system)
                     bf.write(json.dumps(req) + '\n')
 
             log(f'Submitting batch ({os.path.getsize(batch_file)} bytes)...')
@@ -725,7 +722,8 @@ def main(argv=None):
                 result_file = os.path.join(enrich_dir, f'.enrich-{sid}.txt')
 
                 try:
-                    resp = invoke_to_file(prompt, model, log_file, max_tokens=4096)
+                    resp = invoke_to_file(prompt, model, log_file, max_tokens=4096,
+                                         system=system)
                     response_text = extract_text_from_file(log_file)
 
                     # Log usage
@@ -860,7 +858,7 @@ def main(argv=None):
     # Cost summary
     # ========================================================================
     print('')
-    print_summary(project_dir, 'enrich')
+    print_summary(project_dir, 'enrich', session_start=session_start)
 
     # ========================================================================
     # Seed alias CSVs from enriched data

--- a/scripts/lib/python/storyforge/cmd_evaluate.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from storyforge.common import (
     detect_project_root, log, set_log_file, read_yaml_field,
     select_model, get_plugin_dir, install_signal_handlers,
-    get_coaching_level,
+    get_coaching_level, build_shared_context,
 )
 from storyforge.costs import estimate_cost, log_operation, print_summary
 from storyforge.scene_filter import build_scene_list, apply_scene_filter
@@ -41,7 +41,7 @@ from storyforge.api import (
     invoke_to_file, extract_text, extract_text_from_file,
     extract_usage, calculate_cost_from_usage,
     submit_batch, poll_batch, download_batch_results,
-    get_api_key, invoke_api,
+    get_api_key, invoke_api, build_batch_request,
 )
 
 
@@ -975,7 +975,8 @@ def main(argv=None):
         return
 
     # ---- START REAL EXECUTION ----
-    session_start = time.time()
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    _wall_start = time.time()
 
     # Pipeline manifest
     cycle_id = '0'
@@ -1045,20 +1046,18 @@ def main(argv=None):
     succeeded = []
     failed = []
 
+    # Build shared context for prompt caching (batch + direct modes)
+    system = build_shared_context(project_dir, model=eval_models[0] if eval_models else '')
+
     if eval_mode == 'batch':
+
         # Build JSONL batch
         log(f'Building batch request for {len(eval_names)} evaluators...')
         batch_file = os.path.join(log_dir, f'eval-batch-{eval_timestamp}.jsonl')
         with open(batch_file, 'w') as f:
             for i, name in enumerate(eval_names):
-                request = {
-                    'custom_id': name,
-                    'params': {
-                        'model': eval_models[i],
-                        'max_tokens': 8192,
-                        'messages': [{'role': 'user', 'content': eval_prompts[i]}],
-                    },
-                }
+                request = build_batch_request(name, eval_prompts[i], eval_models[i], 8192,
+                                              system=system)
                 f.write(json.dumps(request) + '\n')
                 log(f'  Added to batch: {name} (model: {eval_models[i]})')
 
@@ -1116,7 +1115,8 @@ def main(argv=None):
             eval_log = os.path.join(log_dir, f'eval-{name}.log')
 
             try:
-                response = invoke_to_file(prompt, model, eval_log, max_tokens=8192)
+                response = invoke_to_file(prompt, model, eval_log, max_tokens=8192,
+                                          system=system)
                 text = extract_text(response)
                 if text:
                     os.makedirs(eval_dir, exist_ok=True)
@@ -1214,7 +1214,8 @@ def main(argv=None):
 
         if api_mode:
             log(f'Running synthesis via direct API (model: {synth_model})...')
-            response = invoke_to_file(synth_prompt, synth_model, synth_log, max_tokens=8192)
+            response = invoke_to_file(synth_prompt, synth_model, synth_log, max_tokens=8192,
+                                      system=system)
             synth_response = extract_text(response)
 
             if synth_response:
@@ -1282,7 +1283,8 @@ def main(argv=None):
 
             if api_mode:
                 log(f'Running assessment via direct API (model: {assess_model})...')
-                response = invoke_to_file(assess_prompt, assess_model, assess_log, max_tokens=8192)
+                response = invoke_to_file(assess_prompt, assess_model, assess_log, max_tokens=8192,
+                                          system=system)
                 assess_response = extract_text(response)
                 if assess_response:
                     with open(os.path.join(eval_dir, 'assessment.md'), 'w') as f:
@@ -1323,7 +1325,7 @@ def main(argv=None):
     )
 
     # ---- SESSION SUMMARY ----
-    session_duration = int(time.time() - session_start)
+    session_duration = int(time.time() - _wall_start)
     session_mins = session_duration // 60
     session_secs = session_duration % 60
 
@@ -1355,9 +1357,9 @@ def main(argv=None):
     _write_word_count_snapshot(eval_dir, project_dir)
 
     # Cost summary
-    print_summary(project_dir, 'evaluate')
-    print_summary(project_dir, 'synthesize')
-    print_summary(project_dir, 'assess')
+    print_summary(project_dir, 'evaluate', session_start=session_start)
+    print_summary(project_dir, 'synthesize', session_start=session_start)
+    print_summary(project_dir, 'assess', session_start=session_start)
 
     # Mark cycle complete
     if cycle_id != '0':

--- a/scripts/lib/python/storyforge/cmd_extract.py
+++ b/scripts/lib/python/storyforge/cmd_extract.py
@@ -18,12 +18,14 @@ import os
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 import argparse
 
 from storyforge.common import (
     detect_project_root, log, set_log_file, read_yaml_field, select_model,
     get_coaching_level, install_signal_handlers, get_plugin_dir,
+    build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr, commit_and_push,
@@ -32,6 +34,7 @@ from storyforge.git import (
 from storyforge.api import (
     invoke_to_file, extract_text, extract_text_from_file, extract_usage,
     calculate_cost_from_usage, submit_batch, poll_batch, download_batch_results,
+    build_batch_request,
 )
 from storyforge.costs import log_operation, print_summary
 
@@ -58,6 +61,7 @@ def parse_args(argv):
 
 def main(argv=None):
     args = parse_args(argv if argv is not None else sys.argv[1:])
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     install_signal_handlers()
 
@@ -118,6 +122,10 @@ def main(argv=None):
     # Profile file location
     profile_file = os.path.join(project_dir, 'working', 'extraction-profile.json')
 
+    # Shared context for prompt caching (built once, passed to all phases)
+    model = select_model('evaluation')
+    system = build_shared_context(project_dir, model=model)
+
     validate_passed = None
     validate_failures = 0
 
@@ -125,7 +133,7 @@ def main(argv=None):
         # Phase 0: Characterize
         if args.phase is None or args.phase == 0:
             _run_phase_0(project_dir, scenes_dir, log_dir, profile_file,
-                         args.dry_run)
+                         args.dry_run, system=system)
             if not args.dry_run:
                 commit_and_push(project_dir,
                                 'Extract: Phase 0 — manuscript characterization',
@@ -136,7 +144,7 @@ def main(argv=None):
         if args.phase is None or args.phase == 1:
             _run_phase_1(sorted_scene_ids, project_dir, scenes_dir, ref_dir,
                          log_dir, profile_file, plugin_dir, args.force,
-                         args.dry_run)
+                         args.dry_run, system=system)
             if not args.dry_run:
                 commit_and_push(project_dir,
                                 'Extract: Phase 1 — skeleton (scenes.csv)',
@@ -151,7 +159,7 @@ def main(argv=None):
         # Phase 2: Intent
         if args.phase is None or args.phase == 2:
             _run_phase_2(sorted_scene_ids, project_dir, scenes_dir, ref_dir,
-                         log_dir, profile_file, args.dry_run)
+                         log_dir, profile_file, args.dry_run, system=system)
             if not args.dry_run:
                 commit_and_push(project_dir,
                                 'Extract: Phase 2 — intent (scene-intent.csv)',
@@ -165,7 +173,8 @@ def main(argv=None):
         # Phase 3: Briefs
         if args.phase is None or args.phase == 3:
             _run_phase_3(sorted_scene_ids, project_dir, scenes_dir, ref_dir,
-                         log_dir, profile_file, args.force, args.dry_run)
+                         log_dir, profile_file, args.force, args.dry_run,
+                         system=system)
             if not args.dry_run:
                 update_pr_task('Phase 3: Extract briefs', project_dir)
 
@@ -206,7 +215,7 @@ def main(argv=None):
         log("  Next: run /storyforge:elaborate to fill structural gaps.")
     log('============================================')
 
-    print_summary(project_dir, 'extract')
+    print_summary(project_dir, 'extract', session_start=session_start)
 
 
 # ============================================================================
@@ -285,7 +294,8 @@ def _run_hone(plugin_dir: str, phase: int) -> None:
 # Phase 0: Characterize
 # ============================================================================
 
-def _run_phase_0(project_dir, scenes_dir, log_dir, profile_file, dry_run):
+def _run_phase_0(project_dir, scenes_dir, log_dir, profile_file, dry_run,
+                 system=None):
     log('')
     log('--- Phase 0: Characterize manuscript ---')
 
@@ -308,7 +318,7 @@ def _run_phase_0(project_dir, scenes_dir, log_dir, profile_file, dry_run):
 
     log(f'  Invoking {model} for manuscript characterization...')
 
-    response = invoke_to_file(prompt, model, char_log, 4096)
+    response = invoke_to_file(prompt, model, char_log, 4096, system=system)
     text = extract_text(response)
     _log_api_usage(char_log, 'extract-characterize', 'manuscript', model, project_dir)
 
@@ -326,7 +336,7 @@ def _run_phase_0(project_dir, scenes_dir, log_dir, profile_file, dry_run):
 # ============================================================================
 
 def _run_phase_1(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
-                 profile_file, plugin_dir, force, dry_run):
+                 profile_file, plugin_dir, force, dry_run, system=None):
     log('')
     log('--- Phase 1: Extract skeleton (scenes.csv) ---')
 
@@ -368,14 +378,8 @@ def _run_phase_1(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
 
         prompt = build_skeleton_prompt(scene_id, scene_text, profile,
                                         registries_text=registries)
-        request = {
-            'custom_id': scene_id,
-            'params': {
-                'model': model,
-                'max_tokens': 1024,
-                'messages': [{'role': 'user', 'content': prompt}],
-            },
-        }
+        request = build_batch_request(scene_id, prompt, model, 1024,
+                                      system=system)
         with open(batch_file, 'a') as f:
             f.write(json.dumps(request) + '\n')
 
@@ -433,7 +437,7 @@ def _run_phase_1(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
 # ============================================================================
 
 def _run_phase_2(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
-                 profile_file, dry_run):
+                 profile_file, dry_run, system=None):
     log('')
     log('--- Phase 2: Extract intent (scene-intent.csv) ---')
 
@@ -464,14 +468,8 @@ def _run_phase_2(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
 
         prompt = build_intent_prompt(scene_id, scene_text, profile, skeleton,
                                       registries_text=registries)
-        request = {
-            'custom_id': scene_id,
-            'params': {
-                'model': model,
-                'max_tokens': 1024,
-                'messages': [{'role': 'user', 'content': prompt}],
-            },
-        }
+        request = build_batch_request(scene_id, prompt, model, 1024,
+                                      system=system)
         with open(batch_file, 'a') as f:
             f.write(json.dumps(request) + '\n')
 
@@ -527,7 +525,7 @@ def _run_phase_2(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
 # ============================================================================
 
 def _run_phase_3(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
-                 profile_file, force, dry_run):
+                 profile_file, force, dry_run, system=None):
     """Run Phase 3a (parallel briefs) + 3b (knowledge chain) + 3c (physical state)."""
 
     # Phase 3a: Parallel brief fields
@@ -576,14 +574,8 @@ def _run_phase_3(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
         prompt = build_brief_parallel_prompt(scene_id, scene_text, profile,
                                               skeleton, intent,
                                               registries_text=registries)
-        request = {
-            'custom_id': scene_id,
-            'params': {
-                'model': model,
-                'max_tokens': 1024,
-                'messages': [{'role': 'user', 'content': prompt}],
-            },
-        }
+        request = build_batch_request(scene_id, prompt, model, 1024,
+                                      system=system)
         with open(batch_file, 'a') as f:
             f.write(json.dumps(request) + '\n')
 
@@ -660,7 +652,8 @@ def _run_phase_3(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
         knowledge_log = os.path.join(log_dir, f'extract-knowledge-{scene_id}.json')
 
         try:
-            response = invoke_to_file(prompt, knowledge_model, knowledge_log, 1024)
+            response = invoke_to_file(prompt, knowledge_model, knowledge_log,
+                                      1024, system=system)
             text = extract_text(response)
             _log_api_usage(knowledge_log, 'extract-knowledge', scene_id,
                            knowledge_model, project_dir)
@@ -722,7 +715,8 @@ def _run_phase_3(sorted_scene_ids, project_dir, scenes_dir, ref_dir, log_dir,
         phys_log = os.path.join(log_dir, f'extract-physical-{scene_id}.json')
 
         try:
-            response = invoke_to_file(prompt, phys_model, phys_log, 1024)
+            response = invoke_to_file(prompt, phys_model, phys_log, 1024,
+                                      system=system)
             text = extract_text(response)
             _log_api_usage(phys_log, 'extract-physical', scene_id,
                            phys_model, project_dir)

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -186,23 +186,29 @@ def _write_hone_findings(path, fix_location, targets, guidance):
                 f.write(f'{sid}|{target_file}||{safe_guidance}\n')
 
 
-def _redraft_from_briefs(project_dir, scene_ids, model, log_dir):
+def _redraft_from_briefs(project_dir, scene_ids, model, log_dir, system=None):
     """Re-draft scenes from their updated briefs."""
     from storyforge.cmd_write import _build_prompt, _extract_scene_from_response
     from storyforge.api import invoke_to_file as _invoke_to_file
+
+    # Build shared context for prompt caching if not provided
+    if system is None:
+        from storyforge.common import build_shared_context
+        system = build_shared_context(project_dir, model=model)
 
     log(f'  Redrafting {len(scene_ids)} scenes from updated briefs...')
     scenes_dir = os.path.join(project_dir, 'scenes')
 
     for i, sid in enumerate(scene_ids, 1):
         log(f'    [{i}/{len(scene_ids)}] Redrafting: {sid}')
-        prompt = _build_prompt(sid, project_dir, 'full', use_briefs=True)
+        prompt = _build_prompt(sid, project_dir, 'full', use_briefs=True,
+                               system_context=bool(system))
         if not prompt:
             log(f'    WARNING: Could not build prompt for {sid}, skipping')
             continue
         log_file = os.path.join(log_dir, f'redraft-{sid}.json')
         _invoke_to_file(prompt, model, log_file, max_tokens=16384,
-                        label=f'redraft {sid}')
+                        label=f'redraft {sid}', system=system or None)
         scene_file = os.path.join(scenes_dir, f'{sid}.md')
         _extract_scene_from_response(log_file, scene_file)
 
@@ -1190,13 +1196,16 @@ def _redraft_scenes(project_dir: str, scene_ids: list[str]) -> int:
     Returns number of scenes re-drafted.
     """
     from storyforge.prompts import build_scene_prompt
-    from storyforge.common import get_coaching_level
+    from storyforge.common import get_coaching_level, build_shared_context
     from storyforge.parsing import extract_single_scene
 
     scenes_dir = os.path.join(project_dir, 'scenes')
     coaching_level = get_coaching_level(project_dir)
     model = select_model('creative')
     count = 0
+
+    # Build shared context for prompt caching across all re-drafts
+    system = build_shared_context(project_dir, model=model)
 
     for scene_id in scene_ids:
         scene_file = os.path.join(scenes_dir, f'{scene_id}.md')
@@ -1207,12 +1216,14 @@ def _redraft_scenes(project_dir: str, scene_ids: list[str]) -> int:
         log(f'  Re-drafting scene: {scene_id}')
         try:
             prompt = build_scene_prompt(scene_id, project_dir,
-                                        coaching_level=coaching_level, api_mode=True)
+                                        coaching_level=coaching_level, api_mode=True,
+                                        system_context=bool(system))
         except Exception as e:
             log(f'  WARNING: Could not build prompt for {scene_id}: {e} — skipping')
             continue
 
-        response = invoke_api(prompt, model, max_tokens=16384)
+        response = invoke_api(prompt, model, max_tokens=16384,
+                              system=system or None)
         if not response:
             log(f'  WARNING: No response for {scene_id} re-draft — skipping')
             continue
@@ -1475,7 +1486,7 @@ def _execute_single_pass(project_dir: str, csv_plan_file: str,
                          plan_rows: list[dict], iteration: int,
                          model_override: str | None = None) -> None:
     """Execute a single revision pass from a plan. Subset of main pass loop."""
-    from storyforge.common import select_revision_model, get_coaching_level
+    from storyforge.common import select_revision_model, get_coaching_level, build_shared_context
     from storyforge.git import commit_and_push
     from storyforge.api import invoke_to_file, extract_text
 
@@ -1490,6 +1501,10 @@ def _execute_single_pass(project_dir: str, csv_plan_file: str,
 
     # Mark in_progress
     _update_pass_field(plan_rows, 1, 'status', 'in_progress', csv_plan_file)
+
+    # Build shared context for prompt caching
+    pass_model_early = model_override or select_revision_model(pass_name, pass_purpose)
+    system = build_shared_context(project_dir, model=pass_model_early)
 
     # Build prompt via the revision module (subprocess)
     plugin_dir = get_plugin_dir()
@@ -1529,6 +1544,8 @@ def _execute_single_pass(project_dir: str, csv_plan_file: str,
     ]
     if config_yaml:
         cmd.extend(['--config', config_yaml])
+    if system:
+        cmd.append('--system-context')
 
     log(f'  Building revision prompt...')
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -1548,7 +1565,8 @@ def _execute_single_pass(project_dir: str, csv_plan_file: str,
         invoke_to_file(prompt, pass_model, step_log,
                        max_tokens=max_output_tokens(pass_model),
                        label=f'polish loop {iteration} ({pass_name})',
-                       timeout=REVISION_TIMEOUT)
+                       timeout=REVISION_TIMEOUT,
+                       system=system or None)
     except Exception as e:
         log(f'  API call failed: {e}')
         return
@@ -1725,8 +1743,10 @@ def _register_new_scenes(project_dir, targets, pass_name):
 # ============================================================================
 
 def main(argv=None):
+    from datetime import datetime
     args = parse_args(argv or [])
     install_signal_handlers()
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     project_dir = detect_project_root()
 
@@ -1843,6 +1863,13 @@ def main(argv=None):
             sys.exit(1)
 
     os.makedirs(os.path.join(project_dir, 'working', 'coaching'), exist_ok=True)
+
+    # Build shared context once for prompt caching (direct API mode only)
+    system = None
+    if not args.dry_run and not args.interactive:
+        from storyforge.common import build_shared_context
+        revise_model = select_revision_model('prose', 'prose revision')
+        system = build_shared_context(project_dir, model=revise_model)
 
     # Determine start point
     start_pass = args.pass_num
@@ -2087,7 +2114,8 @@ def main(argv=None):
                     redraft_needed.update(affected)
                     log(f'  Deferred redraft for {len(affected)} scenes (will batch after all upstream passes)')
                 else:
-                    _redraft_from_briefs(project_dir, affected, pass_model, log_dir)
+                    _redraft_from_briefs(project_dir, affected, pass_model, log_dir,
+                                         system=system)
 
             # Log usage (hone handles its own API logging; pass empty string)
             _log_usage(project_dir, '', 'revise', pass_name, pass_model, duration)
@@ -2163,11 +2191,15 @@ Rules:
         else:
             # Standard prose revision -- use revision module
             try:
-                result = subprocess.run(
-                    [sys.executable, '-m', 'storyforge.revision', 'build-prompt',
+                cmd_args = [sys.executable, '-m', 'storyforge.revision', 'build-prompt',
                      pass_name, pass_purpose, effective_scope or pass_scope, project_dir,
                      '--config', pass_block, '--coaching', effective_coaching]
-                    + ([api_flag] if api_flag else []),
+                if api_flag:
+                    cmd_args.append(api_flag)
+                if system:
+                    cmd_args.append('--system-context')
+                result = subprocess.run(
+                    cmd_args,
                     capture_output=True, text=True, check=True,
                     env={**os.environ, 'PYTHONPATH': python_lib},
                 )
@@ -2213,7 +2245,8 @@ Rules:
                 response = invoke_to_file(prompt, pass_model, step_log,
                                          max_tokens=max_output_tokens(pass_model),
                                          label=f'pass {pass_num}/{total_passes} ({pass_name})',
-                                         timeout=REVISION_TIMEOUT)
+                                         timeout=REVISION_TIMEOUT,
+                                         system=system or None)
                 exit_code = 0
             except Exception as e:
                 log(f'  API call failed: {e}')
@@ -2387,7 +2420,8 @@ Rules:
     if defer_redraft and redraft_needed:
         log(f'\n=== Batch Redraft: {len(redraft_needed)} scenes ===')
         pass_model = select_revision_model('redraft', 'redraft from corrected briefs')
-        _redraft_from_briefs(project_dir, sorted(redraft_needed), pass_model, log_dir)
+        _redraft_from_briefs(project_dir, sorted(redraft_needed), pass_model, log_dir,
+                             system=system)
 
     # ---- SESSION SUMMARY ----
     completed = sum(
@@ -2433,7 +2467,7 @@ Rules:
 
     # Cost summary
     if not args.dry_run:
-        print_summary(project_dir, 'revise')
+        print_summary(project_dir, 'revise', session_start=session_start)
 
     if completed == total_passes:
         log('All revision passes are done!')

--- a/scripts/lib/python/storyforge/cmd_scenes_setup.py
+++ b/scripts/lib/python/storyforge/cmd_scenes_setup.py
@@ -18,10 +18,11 @@ import os
 import re
 import subprocess
 import sys
+from datetime import datetime
 
 from storyforge.common import (
     detect_project_root, log, read_yaml_field, select_model,
-    install_signal_handlers,
+    install_signal_handlers, build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr,
@@ -29,7 +30,7 @@ from storyforge.git import (
 )
 from storyforge.api import (
     invoke_to_file, extract_text, extract_usage, calculate_cost_from_usage,
-    submit_batch, poll_batch, download_batch_results,
+    submit_batch, poll_batch, download_batch_results, build_batch_request,
 )
 from storyforge.costs import (
     estimate_cost, check_threshold, print_summary, log_operation,
@@ -72,6 +73,7 @@ def parse_args(argv):
 
 def main(argv=None):
     args = parse_args(argv or [])
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     # Validate mode
     modes = sum([args.rename, args.split_chapters, args.split_manuscript])
@@ -115,6 +117,7 @@ def main(argv=None):
         log('Moved scenes/intent.csv -> reference/scene-intent.csv')
 
     model = select_model('evaluation')
+    system = build_shared_context(project_dir, model=model)
 
     # Track used slugs
     used_slugs = set()
@@ -314,7 +317,7 @@ def main(argv=None):
         prompt = build_boundary_prompt(chapter_text)
         lf = os.path.join(log_dir, f'scenes-setup-detect-{chapter_id}.json')
 
-        response_data = invoke_to_file(prompt, model, lf, max_tokens=4096)
+        response_data = invoke_to_file(prompt, model, lf, max_tokens=4096, system=system)
         response = extract_text(response_data)
 
         # Log usage
@@ -518,14 +521,8 @@ def main(argv=None):
                         with open(cf) as fh:
                             chapter_text = fh.read()
                         prompt = build_boundary_prompt(chapter_text)
-                        request = {
-                            'custom_id': ch_name,
-                            'params': {
-                                'model': model,
-                                'max_tokens': 4096,
-                                'messages': [{'role': 'user', 'content': prompt}],
-                            },
-                        }
+                        request = build_batch_request(ch_name, prompt, model,
+                                                      max_tokens=4096, system=system)
                         bf.write(json.dumps(request) + '\n')
 
                 batch_id = submit_batch(batch_file)
@@ -862,7 +859,7 @@ def main(argv=None):
 
             create_draft_pr('Scenes setup: split chapters into scenes',
                             pr_body, project_dir, 'drafting')
-            print_summary(project_dir, 'scene-detect')
+            print_summary(project_dir, 'scene-detect', session_start=session_start)
             log('Committed and pushed split results')
 
     elif args.split_manuscript:
@@ -893,7 +890,7 @@ def main(argv=None):
 
             create_draft_pr('Scenes setup: split manuscript into scenes',
                             pr_body, project_dir, 'drafting')
-            print_summary(project_dir, 'scene-detect')
+            print_summary(project_dir, 'scene-detect', session_start=session_start)
             log('Committed and pushed split results')
 
     log('============================================')

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -26,7 +26,7 @@ import time
 from storyforge.common import (
     detect_project_root, log, set_log_file, read_yaml_field, select_model,
     get_coaching_level, get_current_cycle, install_signal_handlers,
-    get_plugin_dir,
+    get_plugin_dir, build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr, commit_and_push,
@@ -36,6 +36,7 @@ from storyforge.cli import add_scene_filter_args, resolve_filter_args, apply_coa
 from storyforge.api import (
     invoke_to_file, extract_text, extract_text_from_file, extract_usage,
     calculate_cost_from_usage, submit_batch, poll_batch, download_batch_results,
+    build_batch_request,
 )
 from storyforge.costs import estimate_cost, check_threshold, log_operation, print_summary
 from storyforge.scene_filter import build_scene_list, apply_scene_filter
@@ -122,6 +123,9 @@ def main(argv=None):
 
     install_signal_handlers()
 
+    from datetime import datetime
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+
     # Resolve score mode
     if args.direct and args.deep:
         score_mode = 'direct-deep'
@@ -174,6 +178,9 @@ def main(argv=None):
         eval_model = opus_model
 
     log(f'Mode: {score_mode}, Model: {eval_model}')
+
+    # Build shared context once for all API calls (prompt caching)
+    system = build_shared_context(project_dir, model=eval_model)
 
     # Initialize craft weights
     from storyforge.scoring import init_craft_weights
@@ -336,14 +343,14 @@ def main(argv=None):
         scored, failed = _score_batch(
             scene_ids, eval_model, eval_template, evaluation_criteria,
             weighted_text_str, metadata_csv, intent_csv, scenes_dir,
-            cycle_dir, log_dir, diagnostics_csv, plugin_dir,
+            cycle_dir, log_dir, diagnostics_csv, plugin_dir, system=system,
         )
     else:
         scored, failed = _score_direct(
             scene_ids, eval_model, eval_template, evaluation_criteria,
             weighted_text_str, metadata_csv, intent_csv, scenes_dir,
             cycle_dir, log_dir, diagnostics_csv, plugin_dir,
-            args.parallel, score_start,
+            args.parallel, score_start, system=system,
         )
 
     log('')
@@ -357,7 +364,7 @@ def main(argv=None):
     if has_briefs and not targeted_principles:
         _run_fidelity_scoring(
             filtered_ids, project_dir, scenes_dir, log_dir, cycle_dir,
-            briefs_csv, score_mode, sonnet_model, plugin_dir,
+            briefs_csv, score_mode, sonnet_model, plugin_dir, system=system,
         )
 
     # =========================================================================
@@ -369,6 +376,7 @@ def main(argv=None):
         _run_act_scoring(
             scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
             prompts_dir, weights_file, sonnet_model, plugin_dir, args.dry_run,
+            system=system,
         )
         update_pr_task('Act-level scoring', project_dir)
 
@@ -381,7 +389,7 @@ def main(argv=None):
         _run_novel_scoring(
             scene_count, metadata_csv, intent_csv, project_dir, cycle_dir,
             log_dir, prompts_dir, weights_file, sonnet_model, plugin_dir,
-            args.dry_run,
+            args.dry_run, system=system,
         )
         update_pr_task('Novel-level scoring', project_dir)
 
@@ -397,7 +405,7 @@ def main(argv=None):
 
         _run_narrative_scoring(
             title, metadata_csv, project_dir, cycle_dir, log_dir, prompts_dir,
-            weights_file, args.dry_run,
+            weights_file, args.dry_run, system=system,
         )
 
     # Update latest symlink
@@ -410,7 +418,7 @@ def main(argv=None):
 
     # Cost summary
     print('')
-    print_summary(project_dir, 'score')
+    print_summary(project_dir, 'score', session_start=session_start)
 
     # Append to score history for cross-cycle tracking
     from storyforge.history import append_cycle
@@ -861,7 +869,7 @@ def _log_api_usage(log_file: str, operation: str, target: str, model: str,
 
 def _score_batch(scene_ids, eval_model, eval_template, evaluation_criteria,
                  weighted_text_str, metadata_csv, intent_csv, scenes_dir,
-                 cycle_dir, log_dir, diagnostics_csv, plugin_dir):
+                 cycle_dir, log_dir, diagnostics_csv, plugin_dir, system=None):
     """Batch mode scoring. Returns (scored, failed)."""
     log('')
     log(f'Building batch request for {len(scene_ids)} scenes...')
@@ -873,14 +881,7 @@ def _score_batch(scene_ids, eval_model, eval_template, evaluation_criteria,
         prompt = _build_scene_prompt(sid, eval_template, evaluation_criteria,
                                      weighted_text_str, metadata_csv, intent_csv,
                                      scenes_dir)
-        request = {
-            'custom_id': sid,
-            'params': {
-                'model': eval_model,
-                'max_tokens': 4096,
-                'messages': [{'role': 'user', 'content': prompt}],
-            },
-        }
+        request = build_batch_request(sid, prompt, eval_model, 4096, system=system)
         with open(batch_file, 'a') as f:
             f.write(json.dumps(request) + '\n')
 
@@ -940,7 +941,7 @@ def _score_batch(scene_ids, eval_model, eval_template, evaluation_criteria,
 def _score_direct(scene_ids, eval_model, eval_template, evaluation_criteria,
                   weighted_text_str, metadata_csv, intent_csv, scenes_dir,
                   cycle_dir, log_dir, diagnostics_csv, plugin_dir,
-                  parallel, score_start):
+                  parallel, score_start, system=None):
     """Direct mode scoring with parallel workers. Returns (scored, failed)."""
     from storyforge.runner import run_batched
     from storyforge.scoring import merge_score_files
@@ -958,7 +959,8 @@ def _score_direct(scene_ids, eval_model, eval_template, evaluation_criteria,
         log_file = os.path.join(log_dir, f'score-{sid}.json')
 
         try:
-            response = invoke_to_file(prompt, eval_model, log_file, 4096)
+            response = invoke_to_file(prompt, eval_model, log_file, 4096,
+                                      system=system)
             _log_api_usage(log_file, 'score', sid, eval_model, project_dir)
 
             text = extract_text(response)
@@ -1002,7 +1004,7 @@ def _score_direct(scene_ids, eval_model, eval_template, evaluation_criteria,
 
 def _run_fidelity_scoring(filtered_ids, project_dir, scenes_dir, log_dir,
                           cycle_dir, briefs_csv, score_mode, sonnet_model,
-                          plugin_dir):
+                          plugin_dir, system=None):
     """Run brief fidelity scoring."""
     # Count scenes with brief data
     brief_count = 0
@@ -1040,14 +1042,8 @@ def _run_fidelity_scoring(filtered_ids, project_dir, scenes_dir, log_dir,
             prompt = build_fidelity_prompt(sid, project_dir, plugin_dir)
             if not prompt:
                 continue
-            request = {
-                'custom_id': f'fidelity-{sid}',
-                'params': {
-                    'model': sonnet_model,
-                    'max_tokens': 2048,
-                    'messages': [{'role': 'user', 'content': prompt}],
-                },
-            }
+            request = build_batch_request(
+                f'fidelity-{sid}', prompt, sonnet_model, 2048, system=system)
             with open(fidelity_batch, 'a') as f:
                 f.write(json.dumps(request) + '\n')
 
@@ -1070,7 +1066,8 @@ def _run_fidelity_scoring(filtered_ids, project_dir, scenes_dir, log_dir,
                 continue
             fidelity_log = os.path.join(log_dir, f'fidelity-{sid}.json')
             try:
-                invoke_to_file(prompt, sonnet_model, fidelity_log, 2048)
+                invoke_to_file(prompt, sonnet_model, fidelity_log, 2048,
+                               system=system)
                 _log_api_usage(fidelity_log, 'score-fidelity', sid,
                                sonnet_model, project_dir)
             except Exception:
@@ -1122,7 +1119,7 @@ def _run_fidelity_scoring(filtered_ids, project_dir, scenes_dir, log_dir,
 
 def _run_act_scoring(scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
                      prompts_dir, weights_file, sonnet_model, plugin_dir,
-                     dry_run):
+                     dry_run, system=None):
     """Run act-level scoring."""
     act_template_file = os.path.join(prompts_dir, 'act-level.md')
     if not os.path.isfile(act_template_file):
@@ -1183,7 +1180,8 @@ def _run_act_scoring(scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
         project_dir = os.path.dirname(os.path.dirname(cycle_dir))
 
         try:
-            response = invoke_to_file(prompt, sonnet_model, log_file, 4096)
+            response = invoke_to_file(prompt, sonnet_model, log_file, 4096,
+                                      system=system)
             text = extract_text(response)
             _log_api_usage(log_file, 'score', act_id, sonnet_model, project_dir)
 
@@ -1208,7 +1206,7 @@ def _run_act_scoring(scene_ids, metadata_csv, scenes_dir, cycle_dir, log_dir,
 
 def _run_novel_scoring(scene_count, metadata_csv, intent_csv, project_dir,
                        cycle_dir, log_dir, prompts_dir, weights_file,
-                       sonnet_model, plugin_dir, dry_run):
+                       sonnet_model, plugin_dir, dry_run, system=None):
     """Run novel-level character + genre scoring."""
     novel_template_file = os.path.join(prompts_dir, 'novel-level.md')
     if not os.path.isfile(novel_template_file):
@@ -1261,7 +1259,8 @@ def _run_novel_scoring(scene_count, metadata_csv, intent_csv, project_dir,
     log_file = os.path.join(log_dir, 'score-novel-level.json')
 
     try:
-        response = invoke_to_file(prompt, sonnet_model, log_file, 4096)
+        response = invoke_to_file(prompt, sonnet_model, log_file, 4096,
+                                  system=system)
         text = extract_text(response)
         _log_api_usage(log_file, 'score', 'novel-level', sonnet_model, project_dir)
 
@@ -1290,7 +1289,8 @@ def _run_novel_scoring(scene_count, metadata_csv, intent_csv, project_dir,
 
 
 def _run_narrative_scoring(title, metadata_csv, project_dir, cycle_dir,
-                           log_dir, prompts_dir, weights_file, dry_run):
+                           log_dir, prompts_dir, weights_file, dry_run,
+                           system=None):
     """Run novel-level narrative framework scoring."""
     narrative_template_file = os.path.join(prompts_dir, 'novel-narrative.md')
     if not os.path.isfile(narrative_template_file):
@@ -1337,7 +1337,8 @@ def _run_narrative_scoring(title, metadata_csv, project_dir, cycle_dir,
     narr_rationale = os.path.join(cycle_dir, 'narrative-rationale.csv')
 
     try:
-        response = invoke_to_file(prompt, narrative_model, log_file, 4096)
+        response = invoke_to_file(prompt, narrative_model, log_file, 4096,
+                                  system=system)
         text = extract_text(response)
         _log_api_usage(log_file, 'score', 'narrative', narrative_model, project_dir)
 

--- a/scripts/lib/python/storyforge/cmd_timeline.py
+++ b/scripts/lib/python/storyforge/cmd_timeline.py
@@ -17,12 +17,13 @@ import json
 import os
 import sys
 import time
+from datetime import datetime
 
 from storyforge.common import (
     detect_project_root, log, read_yaml_field, select_model,
     install_signal_handlers, is_shutting_down,
     show_interactive_banner, offer_interactive,
-    build_interactive_system_prompt,
+    build_interactive_system_prompt, build_shared_context,
 )
 from storyforge.cli import add_scene_filter_args, resolve_filter_args
 from storyforge.scene_filter import build_scene_list, apply_scene_filter
@@ -35,7 +36,7 @@ from storyforge.git import (
 from storyforge.api import (
     invoke_api, invoke_to_file, extract_text_from_file,
     submit_batch, poll_batch, download_batch_results,
-    extract_usage, calculate_cost_from_usage,
+    extract_usage, calculate_cost_from_usage, build_batch_request,
 )
 from storyforge.costs import log_operation
 from storyforge.timeline import (
@@ -76,6 +77,7 @@ def parse_args(argv):
 
 def main(argv=None):
     args = parse_args(argv or [])
+    session_start = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     install_signal_handlers()
     project_dir = detect_project_root()
@@ -134,6 +136,7 @@ def main(argv=None):
     # Model selection
     haiku_model = select_model('extraction')
     sonnet_model = select_model('evaluation')
+    system = build_shared_context(project_dir, model=haiku_model)
 
     log('============================================')
     log('Storyforge Timeline')
@@ -318,14 +321,8 @@ def main(argv=None):
                     skipped_ids.append(sid)
                     continue
                 import json as _json
-                request = {
-                    'custom_id': sid,
-                    'params': {
-                        'model': haiku_model,
-                        'max_tokens': 1024,
-                        'messages': [{'role': 'user', 'content': prompt}],
-                    },
-                }
+                request = build_batch_request(sid, prompt, haiku_model,
+                                              max_tokens=1024, system=system)
                 bf.write(_json.dumps(request) + '\n')
 
         # Count API requests
@@ -396,7 +393,8 @@ def main(argv=None):
             lf = os.path.join(log_dir, f'timeline-phase1-{sid}.json')
 
             if timeline_mode == 'direct':
-                response_data = invoke_to_file(prompt, haiku_model, lf, max_tokens=1024)
+                response_data = invoke_to_file(prompt, haiku_model, lf, max_tokens=1024,
+                                               system=system)
                 from storyforge.api import extract_text
                 response = extract_text(response_data)
                 usage = extract_usage(response_data)
@@ -408,7 +406,8 @@ def main(argv=None):
                               cache_create=usage.get('cache_create', 0))
             else:
                 # Interactive mode -- use invoke_api (simplified)
-                response = invoke_api(prompt, haiku_model, max_tokens=1024)
+                response = invoke_api(prompt, haiku_model, max_tokens=1024,
+                                     system=system)
 
             indicators = parse_indicators(response, sid)
             _save_indicators(sid, indicators)
@@ -485,9 +484,10 @@ def main(argv=None):
         log(f'Sending {scene_count} scene summaries to Sonnet...')
 
         if timeline_mode == 'interactive':
-            response = invoke_api(prompt, sonnet_model, max_tokens=4096)
+            response = invoke_api(prompt, sonnet_model, max_tokens=4096, system=system)
         else:
-            response_data = invoke_to_file(prompt, sonnet_model, tl_log, max_tokens=4096)
+            response_data = invoke_to_file(prompt, sonnet_model, tl_log, max_tokens=4096,
+                                           system=system)
             from storyforge.api import extract_text
             response = extract_text(response_data)
             usage = extract_usage(response_data)
@@ -567,7 +567,7 @@ def main(argv=None):
         log('Review and edit indicator files as needed, then run Phase 2:')
         log('  storyforge timeline --skip-phase1 [same scene filters]')
         if not args.embedded:
-            print_summary(project_dir, 'timeline-phase1')
+            print_summary(project_dir, 'timeline-phase1', session_start=session_start)
             try:
                 os.remove(interactive_file)
             except FileNotFoundError:
@@ -642,5 +642,5 @@ def main(argv=None):
     log('============================================')
 
     if not args.embedded:
-        print_summary(project_dir, 'timeline-phase1')
-        print_summary(project_dir, 'timeline-phase2')
+        print_summary(project_dir, 'timeline-phase1', session_start=session_start)
+        print_summary(project_dir, 'timeline-phase2', session_start=session_start)

--- a/scripts/lib/python/storyforge/cmd_write.py
+++ b/scripts/lib/python/storyforge/cmd_write.py
@@ -133,7 +133,9 @@ def main(argv=None):
             return
 
     # Session start
+    from datetime import datetime
     session_start = time.time()
+    session_start_iso = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
     # Branch + PR setup
     if not args.dry_run:
@@ -208,7 +210,7 @@ def main(argv=None):
     log('============================================')
 
     if not args.dry_run and drafted_count > 0:
-        print_summary(project_dir, 'draft')
+        print_summary(project_dir, 'draft', session_start=session_start_iso)
         run_review_phase('drafting', project_dir)
 
 
@@ -305,8 +307,17 @@ def _detect_briefs(project_dir: str) -> bool:
 
 
 def _build_prompt(scene_id: str, project_dir: str, coaching: str,
-                  use_briefs: bool) -> str:
-    """Build the drafting prompt for a scene."""
+                  use_briefs: bool, system_context: bool = False) -> str:
+    """Build the drafting prompt for a scene.
+
+    Args:
+        scene_id: Scene identifier.
+        project_dir: Project root directory.
+        coaching: Coaching level (full/coach/strict).
+        use_briefs: Whether to use brief-aware prompts.
+        system_context: When True, shared reference material is provided via
+            the API system parameter and should not be inlined in the prompt.
+    """
     from storyforge.common import get_plugin_dir
     plugin_dir = get_plugin_dir()
 
@@ -317,11 +328,13 @@ def _build_prompt(scene_id: str, project_dir: str, coaching: str,
         deps = scene.get('continuity_deps', '') if scene else ''
         dep_scenes = [d.strip() for d in deps.split(';') if d.strip()] if deps else None
         return build_scene_prompt_from_briefs(scene_id, project_dir, plugin_dir,
-                                              coaching, dep_scenes=dep_scenes)
+                                              coaching, dep_scenes=dep_scenes,
+                                              system_context=system_context)
     else:
         from storyforge.prompts import build_scene_prompt
         return build_scene_prompt(scene_id, project_dir, coaching,
-                                  api_mode=True)
+                                  api_mode=True,
+                                  system_context=system_context)
 
 
 def _extract_scene_from_response(log_file: str, scene_file: str) -> None:
@@ -412,6 +425,11 @@ def _run_batch_mode(pending_ids, project_dir, scenes_dir, log_dir,
     model = select_model('drafting')
     batch_scene_ids = []
 
+    # Build shared context once for prompt caching across all scenes
+    from storyforge.common import build_shared_context
+    from storyforge.api import build_batch_request
+    system = build_shared_context(project_dir, model=model)
+
     for scene_id in pending_ids:
         scene_file = os.path.join(scenes_dir, f'{scene_id}.md')
 
@@ -423,20 +441,15 @@ def _run_batch_mode(pending_ids, project_dir, scenes_dir, log_dir,
                 log(f'Scene {scene_id} already has {existing_wc} words, skipping')
                 continue
 
-        prompt = _build_prompt(scene_id, project_dir, coaching, use_briefs)
+        prompt = _build_prompt(scene_id, project_dir, coaching, use_briefs,
+                               system_context=bool(system))
         if not prompt:
             log(f'ERROR: Failed to build prompt for scene {scene_id}')
             sys.exit(1)
 
-        # Build JSONL line
-        request = {
-            'custom_id': scene_id,
-            'params': {
-                'model': model,
-                'max_tokens': 8192,
-                'messages': [{'role': 'user', 'content': prompt}],
-            },
-        }
+        # Build JSONL line using batch request helper (includes system blocks)
+        request = build_batch_request(scene_id, prompt, model, 8192,
+                                      system=system or None)
         with open(batch_file, 'a') as f:
             f.write(json.dumps(request) + '\n')
         batch_scene_ids.append(scene_id)
@@ -517,6 +530,14 @@ def _run_direct_mode(pending_ids, project_dir, scenes_dir, log_dir,
     total_words = 0
     from storyforge.git import _git
 
+    # Build shared context once for prompt caching across all scenes
+    # (only used in direct API mode, not interactive/dry-run)
+    system = None
+    if write_mode == 'direct' and not dry_run:
+        from storyforge.common import build_shared_context
+        model = select_model('drafting')
+        system = build_shared_context(project_dir, model=model)
+
     for i, scene_id in enumerate(pending_ids):
         scene_file = os.path.join(scenes_dir, f'{scene_id}.md')
         scene_num = i + 1
@@ -531,7 +552,8 @@ def _run_direct_mode(pending_ids, project_dir, scenes_dir, log_dir,
                 log(f'Scene file already has {existing_wc} words, skipping')
                 continue
 
-        prompt = _build_prompt(scene_id, project_dir, coaching, use_briefs)
+        prompt = _build_prompt(scene_id, project_dir, coaching, use_briefs,
+                               system_context=bool(system))
         if not prompt:
             log(f'ERROR: Failed to build prompt for scene {scene_id}')
             log('Stopping — prompt generation failed.')
@@ -564,7 +586,8 @@ def _run_direct_mode(pending_ids, project_dir, scenes_dir, log_dir,
             try:
                 max_tokens = 16384 if write_mode != 'direct' else 8192
                 invoke_to_file(prompt, model, scene_log, max_tokens,
-                               label=f'drafting {scene_id}')
+                               label=f'drafting {scene_id}',
+                               system=system or None)
                 _extract_scene_from_response(scene_log, scene_file)
                 _log_api_usage(scene_log, 'draft', scene_id, model, project_dir)
                 exit_code = 0

--- a/scripts/lib/python/storyforge/common.py
+++ b/scripts/lib/python/storyforge/common.py
@@ -244,6 +244,16 @@ def extract_craft_sections(*section_nums: int) -> str:
 
 _shared_context_cache: dict[str, list[dict]] = {}
 
+
+def clear_shared_context_cache() -> None:
+    """Clear the in-process shared context cache.
+
+    Call after operations that modify reference files (commits, hone passes)
+    so the next build_shared_context reads fresh data.
+    """
+    _shared_context_cache.clear()
+
+
 # Minimum tokens per cache breakpoint (estimated at ~4 chars/token)
 _MIN_CACHE_CHARS = {
     'opus': 4096 * 4,
@@ -264,10 +274,14 @@ def _model_tier(model: str) -> str:
 
 def _read_if_exists(path: str) -> str:
     """Read a file if it exists, return empty string otherwise."""
-    if os.path.isfile(path):
+    if not os.path.isfile(path):
+        return ''
+    try:
         with open(path) as f:
             return f.read().strip()
-    return ''
+    except (OSError, UnicodeDecodeError) as e:
+        log(f'WARNING: Could not read {path}: {e}')
+        return ''
 
 
 def build_shared_context(project_dir: str, model: str = '') -> list[dict]:

--- a/scripts/lib/python/storyforge/common.py
+++ b/scripts/lib/python/storyforge/common.py
@@ -239,6 +239,116 @@ def extract_craft_sections(*section_nums: int) -> str:
 
 
 # ============================================================================
+# Shared context for prompt caching
+# ============================================================================
+
+_shared_context_cache: dict[str, list[dict]] = {}
+
+# Minimum tokens per cache breakpoint (estimated at ~4 chars/token)
+_MIN_CACHE_CHARS = {
+    'opus': 4096 * 4,
+    'sonnet': 2048 * 4,
+    'haiku': 2048 * 4,
+}
+
+
+def _model_tier(model: str) -> str:
+    """Map model name to pricing tier for cache threshold."""
+    m = model.lower()
+    if 'opus' in m:
+        return 'opus'
+    if 'haiku' in m:
+        return 'haiku'
+    return 'sonnet'
+
+
+def _read_if_exists(path: str) -> str:
+    """Read a file if it exists, return empty string otherwise."""
+    if os.path.isfile(path):
+        with open(path) as f:
+            return f.read().strip()
+    return ''
+
+
+def build_shared_context(project_dir: str, model: str = '') -> list[dict]:
+    """Assemble project reference materials as cacheable system blocks.
+
+    Two-tier structure:
+    - Tier 1 (1h TTL): Plugin-level references (craft engine, rubrics, AI-tell words)
+    - Tier 2 (5m TTL): Project-level references (bibles, voice guide, registries)
+
+    Results are cached in-process so repeated calls don't re-read files.
+
+    Args:
+        project_dir: Path to the Storyforge project.
+        model: Model ID for determining minimum cache token threshold.
+
+    Returns:
+        List of content blocks for the API 'system' parameter.
+    """
+    cache_key = f'{project_dir}:{model}'
+    if cache_key in _shared_context_cache:
+        return _shared_context_cache[cache_key]
+
+    plugin_dir = get_plugin_dir()
+    min_chars = _MIN_CACHE_CHARS.get(_model_tier(model), 4096 * 4)
+
+    # --- Tier 1: Plugin-level (near-permanent) ---
+    tier1_sources = [
+        (os.path.join(plugin_dir, 'references', 'craft-engine.md'), 'Craft Engine'),
+        (os.path.join(plugin_dir, 'references', 'scoring-rubrics.md'), 'Scoring Rubrics'),
+        (os.path.join(plugin_dir, 'references', 'ai-tell-words.csv'), 'AI-Tell Vocabulary'),
+    ]
+
+    tier1_blocks = []
+    tier1_chars = 0
+    for path, label in tier1_sources:
+        content = _read_if_exists(path)
+        if content:
+            tier1_blocks.append({'type': 'text', 'text': f'=== {label} ===\n\n{content}'})
+            tier1_chars += len(content) + len(label) + 10
+
+    # --- Tier 2: Project-level (session-stable) ---
+    ref_dir = os.path.join(project_dir, 'reference')
+    tier2_sources = [
+        (os.path.join(ref_dir, 'character-bible.md'), 'Character Bible'),
+        (os.path.join(ref_dir, 'world-bible.md'), 'World Bible'),
+        (os.path.join(ref_dir, 'voice-guide.md'), 'Voice Guide'),
+        (os.path.join(ref_dir, 'voice-profile.csv'), 'Voice Profile'),
+        (os.path.join(ref_dir, 'characters.csv'), 'Character Registry'),
+        (os.path.join(ref_dir, 'locations.csv'), 'Location Registry'),
+        (os.path.join(ref_dir, 'mice-threads.csv'), 'MICE Thread Registry'),
+    ]
+
+    tier2_blocks = []
+    tier2_chars = 0
+    for path, label in tier2_sources:
+        content = _read_if_exists(path)
+        if content:
+            tier2_blocks.append({'type': 'text', 'text': f'=== {label} ===\n\n{content}'})
+            tier2_chars += len(content) + len(label) + 10
+
+    # --- Apply cache_control breakpoints ---
+    blocks = []
+
+    if tier1_blocks:
+        if tier1_chars >= min_chars:
+            # Tier 1 meets threshold — add breakpoint with extended TTL
+            tier1_blocks[-1]['cache_control'] = {'type': 'ephemeral', 'ttl': 3600}
+        blocks.extend(tier1_blocks)
+
+    if tier2_blocks:
+        cumulative_chars = tier1_chars + tier2_chars
+        if cumulative_chars >= min_chars:
+            # Cumulative prefix meets threshold — add breakpoint with default TTL
+            tier2_blocks[-1]['cache_control'] = {'type': 'ephemeral'}
+        blocks.extend(tier2_blocks)
+
+    _shared_context_cache[cache_key] = blocks
+    return blocks
+
+
+# ============================================================================
 # Pipeline manifest
 # ============================================================================
 

--- a/scripts/lib/python/storyforge/costs.py
+++ b/scripts/lib/python/storyforge/costs.py
@@ -203,7 +203,19 @@ def print_summary(project_dir: str, operation: str | None = None) -> None:
     print(f'Cache read:    {total_cache_r}')
     print(f'Cache create:  {total_cache_c}')
     print(f'Total cost:    ${total_cost:.4f}')
-    print(f'Total time:    {total_dur}s')
+    print(f'Total time:    {format_duration(total_dur)}')
+
+
+def format_duration(seconds: int) -> str:
+    """Format seconds as Xh Xm Xs, omitting zero leading components."""
+    if seconds < 60:
+        return f'{seconds}s'
+    if seconds < 3600:
+        m, s = divmod(seconds, 60)
+        return f'{m}m {s}s'
+    h, remainder = divmod(seconds, 3600)
+    m, s = divmod(remainder, 60)
+    return f'{h}h {m}m {s}s'
 
 
 def check_threshold(estimated_cost: float, threshold: float = 100.0) -> bool:

--- a/scripts/lib/python/storyforge/costs.py
+++ b/scripts/lib/python/storyforge/costs.py
@@ -122,21 +122,86 @@ def estimate_cost(operation: str, scope_count: int, avg_words: int,
     return (input_tokens * price_in + output_tokens * price_out) / 1_000_000
 
 
-def print_summary(project_dir: str, operation: str | None = None) -> None:
-    """Print cost totals from the ledger, optionally filtered by operation."""
-    ledger_file = os.path.join(project_dir, 'working', 'costs', 'ledger.csv')
-
-    if not os.path.exists(ledger_file):
-        print('No cost data available.')
-        return
-
-    count = 0
+def _accumulate(rows: list, col_map: dict) -> dict:
+    """Sum up token counts, cost, and duration from a list of row-part lists."""
     total_input = 0
     total_output = 0
     total_cache_r = 0
     total_cache_c = 0
     total_cost = 0.0
     total_dur = 0
+
+    for parts in rows:
+        for col_name, target in [
+            ('input_tokens', 'input'),
+            ('output_tokens', 'output'),
+            ('cache_read', 'cache_r'),
+            ('cache_create', 'cache_c'),
+            ('duration_s', 'dur'),
+        ]:
+            if col_name in col_map and col_map[col_name] < len(parts):
+                val = parts[col_map[col_name]]
+                if val:
+                    if col_name == 'input_tokens':
+                        total_input += int(val)
+                    elif col_name == 'output_tokens':
+                        total_output += int(val)
+                    elif col_name == 'cache_read':
+                        total_cache_r += int(val)
+                    elif col_name == 'cache_create':
+                        total_cache_c += int(val)
+                    elif col_name == 'duration_s':
+                        total_dur += int(val)
+        if 'cost_usd' in col_map and col_map['cost_usd'] < len(parts):
+            val = parts[col_map['cost_usd']]
+            if val:
+                total_cost += float(val)
+
+    return {
+        'input': total_input,
+        'output': total_output,
+        'cache_r': total_cache_r,
+        'cache_c': total_cache_c,
+        'cost': total_cost,
+        'dur': total_dur,
+    }
+
+
+def _print_section(label: str, count: int, totals: dict, session_mode: bool) -> None:
+    """Print one summary section. session_mode uses Cost:/Time: labels; otherwise Total cost:/Total time:."""
+    inv_word = 'invocation' if count == 1 else 'invocations'
+    if session_mode:
+        print(f'--- {label} ({count} {inv_word}) ---')
+        print(f'Input tokens:  {totals["input"]:,}')
+        print(f'Output tokens: {totals["output"]:,}')
+        print(f'Cache read:    {totals["cache_r"]:,}')
+        print(f'Cache create:  {totals["cache_c"]:,}')
+        print(f'Cost:          ${totals["cost"]:.4f}')
+        print(f'Time:          {format_duration(totals["dur"])}')
+    else:
+        print(f'--- Cost Summary: {label} ---')
+        print(f'Invocations:   {count}')
+        print(f'Input tokens:  {totals["input"]:,}')
+        print(f'Output tokens: {totals["output"]:,}')
+        print(f'Cache read:    {totals["cache_r"]:,}')
+        print(f'Cache create:  {totals["cache_c"]:,}')
+        print(f'Total cost:    ${totals["cost"]:.4f}')
+        print(f'Total time:    {format_duration(totals["dur"])}')
+
+
+def print_summary(project_dir: str, operation: str | None = None,
+                  session_start: str | None = None) -> None:
+    """Print cost totals from the ledger, optionally filtered by operation.
+
+    If session_start (ISO timestamp string) is provided, shows two sections:
+    "This session" (rows at or after session_start) and "Project total" (all rows).
+    When session_start is None, shows the existing single-section format.
+    """
+    ledger_file = os.path.join(project_dir, 'working', 'costs', 'ledger.csv')
+
+    if not os.path.exists(ledger_file):
+        print('No cost data available.')
+        return
 
     with open(ledger_file) as f:
         header_line = f.readline().strip()
@@ -146,64 +211,47 @@ def print_summary(project_dir: str, operation: str | None = None) -> None:
         headers = header_line.split('|')
         col_map = {name: idx for idx, name in enumerate(headers)}
 
-        # Require at least the operation column to function
         if 'operation' not in col_map:
             print('No cost data available.')
             return
 
+        all_rows = []
         for line in f:
             line = line.strip()
             if not line:
                 continue
             parts = line.split('|')
-
             op_idx = col_map['operation']
             if op_idx >= len(parts):
                 continue
-            row_op = parts[op_idx]
-            if operation and row_op != operation:
+            if operation and parts[op_idx] != operation:
                 continue
+            all_rows.append(parts)
 
-            count += 1
-            for col_name, accumulate in [
-                ('input_tokens', lambda v: v),
-                ('output_tokens', lambda v: v),
-                ('cache_read', lambda v: v),
-                ('cache_create', lambda v: v),
-                ('duration_s', lambda v: v),
-            ]:
-                if col_name in col_map and col_map[col_name] < len(parts):
-                    val = parts[col_map[col_name]]
-                    if val:
-                        if col_name == 'input_tokens':
-                            total_input += int(val)
-                        elif col_name == 'output_tokens':
-                            total_output += int(val)
-                        elif col_name == 'cache_read':
-                            total_cache_r += int(val)
-                        elif col_name == 'cache_create':
-                            total_cache_c += int(val)
-                        elif col_name == 'duration_s':
-                            total_dur += int(val)
-            if 'cost_usd' in col_map and col_map['cost_usd'] < len(parts):
-                val = parts[col_map['cost_usd']]
-                if val:
-                    total_cost += float(val)
-
-    if count == 0:
+    if not all_rows:
         label = f' for operation: {operation}' if operation else ''
         print(f'No cost data{label}.')
         return
 
-    label = operation or 'all operations'
-    print(f'--- Cost Summary: {label} ---')
-    print(f'Invocations:   {count}')
-    print(f'Input tokens:  {total_input}')
-    print(f'Output tokens: {total_output}')
-    print(f'Cache read:    {total_cache_r}')
-    print(f'Cache create:  {total_cache_c}')
-    print(f'Total cost:    ${total_cost:.4f}')
-    print(f'Total time:    {format_duration(total_dur)}')
+    op_label = operation or 'all operations'
+
+    if session_start is not None:
+        ts_idx = col_map.get('timestamp', -1)
+        if ts_idx >= 0:
+            session_rows = [p for p in all_rows if ts_idx < len(p) and p[ts_idx] >= session_start]
+        else:
+            session_rows = []
+
+        if session_rows:
+            session_totals = _accumulate(session_rows, col_map)
+            _print_section(f'This session: {op_label}', len(session_rows), session_totals, session_mode=True)
+            print()
+
+        project_totals = _accumulate(all_rows, col_map)
+        _print_section(f'Project total: {op_label}', len(all_rows), project_totals, session_mode=True)
+    else:
+        totals = _accumulate(all_rows, col_map)
+        _print_section(op_label, len(all_rows), totals, session_mode=False)
 
 
 def format_duration(seconds: int) -> str:

--- a/scripts/lib/python/storyforge/prompts.py
+++ b/scripts/lib/python/storyforge/prompts.py
@@ -636,7 +636,8 @@ def _get_scene_overrides(scene_id: str, project_dir: str) -> str:
 
 def build_scene_prompt(scene_id: str, project_dir: str,
                        coaching_level: str = 'full',
-                       api_mode: bool = False) -> str:
+                       api_mode: bool = False,
+                       system_context: bool = False) -> str:
     """Assemble the complete drafting prompt for a single scene.
 
     Args:
@@ -645,6 +646,11 @@ def build_scene_prompt(scene_id: str, project_dir: str,
         coaching_level: One of ``full``, ``coach``, ``strict``.
         api_mode: When True, inline reference file contents directly into
             the prompt. When False, emit file paths for ``claude -p``.
+        system_context: When True, shared reference material (reference files,
+            craft engine, AI-tell vocabulary, voice profile) is provided via
+            the API ``system`` parameter and should NOT be inlined in the
+            user prompt. Project-specific weighted directives, scene briefs,
+            and per-scene overrides are still included.
 
     Returns:
         The assembled prompt string.
@@ -693,14 +699,15 @@ def build_scene_prompt(scene_id: str, project_dir: str,
 
     ref_list = ''
     ref_inline = ''
-    for rf in ref_files:
-        ref_list += f'\n- {rf}'
-        if api_mode:
-            full_path = os.path.join(project_dir, rf)
-            if os.path.isfile(full_path):
-                with open(full_path) as f:
-                    content = f.read()
-                ref_inline += f'\n=== FILE: {rf} ===\n{content}\n=== END FILE ===\n'
+    if not system_context:
+        for rf in ref_files:
+            ref_list += f'\n- {rf}'
+            if api_mode:
+                full_path = os.path.join(project_dir, rf)
+                if os.path.isfile(full_path):
+                    with open(full_path) as f:
+                        content = f.read()
+                    ref_inline += f'\n=== FILE: {rf} ===\n{content}\n=== END FILE ===\n'
 
     # --- Previous scene content (API mode) ---
     prev_scene_content = ''
@@ -717,8 +724,9 @@ def build_scene_prompt(scene_id: str, project_dir: str,
 
     # --- Craft principles ---
     craft_sections = build_weighted_directive(project_dir)
-    if not craft_sections:
-        # Fallback: extract from craft engine
+    if not craft_sections and not system_context:
+        # Fallback: extract from craft engine (skipped when system_context
+        # provides the craft engine via the API system parameter)
         craft_sections = extract_craft_sections(plugin_dir, 2, 3, 4, 5)
 
     overrides = _get_scene_overrides(scene_id, project_dir)
@@ -726,11 +734,16 @@ def build_scene_prompt(scene_id: str, project_dir: str,
         craft_sections += f'\n\n## Scene-Specific Notes\n{overrides}'
 
     # --- AI-tell vocabulary constraint ---
-    ai_tell_words = load_ai_tell_words(plugin_dir)
+    # When system_context is True, the AI-tell word list and voice profile
+    # are provided in the system parameter — skip inlining them here.
+    ai_tell_words = [] if system_context else load_ai_tell_words(plugin_dir)
     ai_tell_block = build_ai_tell_constraint(ai_tell_words)
 
     # --- Voice profile ---
-    voice_profile_project, voice_profile_chars = load_voice_profile(project_dir)
+    if system_context:
+        voice_profile_project, voice_profile_chars = {}, {}
+    else:
+        voice_profile_project, voice_profile_chars = load_voice_profile(project_dir)
     pov_char = ''
     if csv_file:
         pov_char = read_csv_field(csv_file, scene_id, 'pov')
@@ -788,7 +801,12 @@ def build_scene_prompt(scene_id: str, project_dir: str,
 
     # ===== STEP 1: REFERENCE MATERIALS =====
     lines.append('===== STEP 1: REFERENCE MATERIALS =====')
-    if api_mode:
+    if system_context:
+        lines.append('')
+        lines.append('Reference materials (world bible, character bible, voice guide, '
+                     'story architecture, craft engine, vocabulary constraints) have '
+                     'been provided in the system context. Internalize them before writing.')
+    elif api_mode:
         lines.append('')
         lines.append('The following reference materials contain the world bible, '
                      'character bible, story architecture, timeline, and all '
@@ -805,7 +823,7 @@ def build_scene_prompt(scene_id: str, project_dir: str,
                      'story architecture, timeline, and all other reference '
                      'material for the project. Internalize them before writing.')
 
-    if voice_guide:
+    if voice_guide and not system_context:
         lines.append('')
         lines.append('Pay special attention to the voice guide — this is the '
                      'voice and style guide. Follow it exactly.')
@@ -1319,6 +1337,7 @@ def build_scene_prompt_from_briefs(
     plugin_dir: str,
     coaching_level: str = 'full',
     dep_scenes: list[str] | None = None,
+    system_context: bool = False,
 ) -> str:
     """Build a drafting prompt from the three-file scene CSV model.
 
@@ -1334,6 +1353,9 @@ def build_scene_prompt_from_briefs(
         coaching_level: full/coach/strict.
         dep_scenes: Scene IDs this scene depends on (from continuity_deps).
                     Their brief rows are included for context.
+        system_context: When True, shared reference material (voice guide,
+            character bible, AI-tell vocabulary, voice profile) is provided
+            via the API ``system`` parameter and should NOT be inlined.
     """
     from .elaborate import get_scene, get_scenes
 
@@ -1378,22 +1400,24 @@ def build_scene_prompt_from_briefs(
         if dep_parts:
             dep_block = "## Dependency Scenes\n\nThese scenes happen before this one. Their outcomes and knowledge states are your starting context.\n\n" + '\n\n'.join(dep_parts)
 
-    # Voice guide
+    # Voice guide (skipped when system_context provides it)
     voice_guide = ''
-    voice_path = os.path.join(ref_dir, 'voice-guide.md')
-    if os.path.isfile(voice_path):
-        with open(voice_path) as f:
-            voice_guide = f"## Voice Guide\n\n{f.read().strip()}"
+    if not system_context:
+        voice_path = os.path.join(ref_dir, 'voice-guide.md')
+        if os.path.isfile(voice_path):
+            with open(voice_path) as f:
+                voice_guide = f"## Voice Guide\n\n{f.read().strip()}"
 
-    # Character bible entries for on-stage characters
+    # Character bible entries for on-stage characters (skipped when system_context)
     char_block = ''
-    char_path = os.path.join(ref_dir, 'character-bible.md')
-    if os.path.isfile(char_path):
-        on_stage = scene.get('on_stage', '')
-        if on_stage:
-            char_block = f"## Character Bible (on-stage: {on_stage})\n\n"
-            with open(char_path) as f:
-                char_block += f.read().strip()
+    if not system_context:
+        char_path = os.path.join(ref_dir, 'character-bible.md')
+        if os.path.isfile(char_path):
+            on_stage = scene.get('on_stage', '')
+            if on_stage:
+                char_block = f"## Character Bible (on-stage: {on_stage})\n\n"
+                with open(char_path) as f:
+                    char_block += f.read().strip()
 
     # Physical state context
     state_block = ''
@@ -1429,11 +1453,16 @@ def build_scene_prompt_from_briefs(
     craft_block = f"## Craft Principles\n\n{craft}" if craft else ''
 
     # --- AI-tell vocabulary constraint ---
-    ai_tell_words = load_ai_tell_words(plugin_dir)
+    # When system_context is True, AI-tell words and voice profile are in the
+    # system parameter — skip inlining them here.
+    ai_tell_words = [] if system_context else load_ai_tell_words(plugin_dir)
     ai_tell_block = build_ai_tell_constraint(ai_tell_words)
 
     # --- Voice profile ---
-    voice_profile_project, voice_profile_chars = load_voice_profile(project_dir)
+    if system_context:
+        voice_profile_project, voice_profile_chars = {}, {}
+    else:
+        voice_profile_project, voice_profile_chars = load_voice_profile(project_dir)
     pov_char = scene.get('pov', '')
 
     # Merge banned words: project profile + universal AI-tell list

--- a/scripts/lib/python/storyforge/prompts_elaborate.py
+++ b/scripts/lib/python/storyforge/prompts_elaborate.py
@@ -92,7 +92,8 @@ def _craft_principles(project_dir: str, plugin_dir: str) -> str:
 # Stage 1: Spine
 # ============================================================================
 
-def build_spine_prompt(project_dir: str, plugin_dir: str, seed: str = '') -> str:
+def build_spine_prompt(project_dir: str, plugin_dir: str, seed: str = '',
+                       system_context: bool = False) -> str:
     """Build the prompt for the spine stage.
 
     Args:
@@ -100,13 +101,16 @@ def build_spine_prompt(project_dir: str, plugin_dir: str, seed: str = '') -> str
         plugin_dir: Path to the Storyforge plugin root.
         seed: Author-provided seed text (logline, concepts, constraints).
               If empty, reads from storyforge.yaml logline.
+        system_context: If True, skip _existing_refs() (already in system prompt).
     """
     context = _project_context(project_dir)
-    refs = _existing_refs(project_dir)
+    refs = '' if system_context else _existing_refs(project_dir)
 
     yaml_path = os.path.join(project_dir, 'storyforge.yaml')
     if not seed:
         seed = read_yaml_field(yaml_path, 'project.logline') or ''
+
+    refs_section = f'\n## Existing Reference Materials\n\n{refs}\n' if refs else ''
 
     return f"""You are building the spine of a novel — the 5-10 irreducible story events that must happen.
 
@@ -115,11 +119,7 @@ def build_spine_prompt(project_dir: str, plugin_dir: str, seed: str = '') -> str
 ## Author's Seed
 
 {seed if seed else '(Use the logline above as the seed.)'}
-
-## Existing Reference Materials
-
-{refs}
-
+{refs_section}
 ## Instructions
 
 Produce the following deliverables:
@@ -189,15 +189,17 @@ id|function
 # ============================================================================
 
 def build_architecture_prompt(project_dir: str, plugin_dir: str,
-                              registries_text: str = '') -> str:
+                              registries_text: str = '',
+                              system_context: bool = False) -> str:
     """Build the prompt for the architecture stage."""
     context = _project_context(project_dir)
-    refs = _existing_refs(project_dir)
+    refs = '' if system_context else _existing_refs(project_dir)
     ref_dir = os.path.join(project_dir, 'reference')
     scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
     intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
 
     registries_section = f'\n\n{registries_text}\n' if registries_text else ''
+    refs_section = f'\n## Reference Materials\n\n{refs}\n' if refs else ''
 
     return f"""You are building the architecture of a novel — expanding the spine into a full structural plan.
 
@@ -214,11 +216,7 @@ def build_architecture_prompt(project_dir: str, plugin_dir: str,
 ```
 {intent}
 ```
-
-## Reference Materials
-
-{refs}
-{registries_section}
+{refs_section}{registries_section}
 ## Instructions
 
 Expand the spine (5-10 events) into 15-25 scenes. For each scene:
@@ -295,15 +293,17 @@ def _scene_count_range(project_dir: str) -> tuple[int, int]:
 
 
 def build_map_prompt(project_dir: str, plugin_dir: str,
-                     registries_text: str = '') -> str:
+                     registries_text: str = '',
+                     system_context: bool = False) -> str:
     """Build the prompt for the scene map stage."""
     context = _project_context(project_dir)
-    refs = _existing_refs(project_dir)
+    refs = '' if system_context else _existing_refs(project_dir)
     ref_dir = os.path.join(project_dir, 'reference')
     scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
     intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
 
     registries_section = f'\n\n{registries_text}\n' if registries_text else ''
+    refs_section = f'\n## Reference Materials\n\n{refs}\n' if refs else ''
 
     lo, hi = _scene_count_range(project_dir)
 
@@ -322,11 +322,7 @@ def build_map_prompt(project_dir: str, plugin_dir: str,
 ```
 {intent}
 ```
-
-## Reference Materials
-
-{refs}
-{registries_section}
+{refs_section}{registries_section}
 ## Instructions
 
 Expand the architecture into {lo}-{hi} scenes. Prefer **more, shorter scenes** (1500-2000 words each) over fewer, longer ones. This is important for drafting quality — Claude follows brief constraints more reliably in focused scenes under 2500 words, and scoring/revision are more precise on smaller units.
@@ -369,7 +365,8 @@ id|function|action_sequel|emotional_arc|value_at_stake|value_shift|turning_point
 
 def build_briefs_prompt(project_dir: str, plugin_dir: str,
                         scene_ids: list[str] | None = None,
-                        registries_text: str = '') -> str:
+                        registries_text: str = '',
+                        system_context: bool = False) -> str:
     """Build the prompt for the briefs stage.
 
     Args:
@@ -378,20 +375,24 @@ def build_briefs_prompt(project_dir: str, plugin_dir: str,
         scene_ids: If provided, only build briefs for these scenes.
                    If None, builds for all mapped scenes without briefs.
         registries_text: Optional formatted registry contents for prompt injection.
+        system_context: If True, skip _existing_refs() and _craft_principles()
+                        (already in system prompt).
     """
     context = _project_context(project_dir)
-    refs = _existing_refs(project_dir)
+    refs = '' if system_context else _existing_refs(project_dir)
     ref_dir = os.path.join(project_dir, 'reference')
     scenes = _read_csv_contents(os.path.join(ref_dir, 'scenes.csv'))
     intent = _read_csv_contents(os.path.join(ref_dir, 'scene-intent.csv'))
     briefs = _read_csv_contents(os.path.join(ref_dir, 'scene-briefs.csv'))
-    craft = _craft_principles(project_dir, plugin_dir)
+    craft = '' if system_context else _craft_principles(project_dir, plugin_dir)
 
     scope_note = ""
     if scene_ids:
         scope_note = f"\n**Scope:** Only write briefs for these scenes: {', '.join(scene_ids)}\n"
 
     registries_section = f'\n\n{registries_text}\n' if registries_text else ''
+    refs_section = f'\n## Reference Materials\n\n{refs}\n' if refs else ''
+    craft_section = f'\n## Craft Principles\n\n{craft}\n' if craft else ''
 
     return f"""You are writing the drafting contracts for a novel — the scene-level briefs that define exactly what happens in each scene, in enough detail that scenes can be drafted independently and still cohere.
 
@@ -414,15 +415,7 @@ def build_briefs_prompt(project_dir: str, plugin_dir: str,
 ```
 {briefs}
 ```
-
-## Reference Materials
-
-{refs}
-
-## Craft Principles
-
-{craft if craft else '(craft engine not available)'}
-{registries_section}
+{refs_section}{craft_section}{registries_section}
 ## Instructions
 
 For each scene that needs a brief, define the complete drafting contract:
@@ -478,7 +471,8 @@ id|status
 # Stage 5: Voice
 # ============================================================================
 
-def build_voice_prompt(project_dir: str, plugin_dir: str) -> str:
+def build_voice_prompt(project_dir: str, plugin_dir: str,
+                       system_context: bool = False) -> str:
     """Build the prompt for the voice stage.
 
     Produces reference/voice-guide.md and reference/voice-profile.csv.
@@ -486,20 +480,19 @@ def build_voice_prompt(project_dir: str, plugin_dir: str) -> str:
     Args:
         project_dir: Path to the book project.
         plugin_dir: Path to the Storyforge plugin root.
+        system_context: If True, skip _existing_refs() (already in system prompt).
     """
     context = _project_context(project_dir)
-    refs = _existing_refs(project_dir)
+    refs = '' if system_context else _existing_refs(project_dir)
     ref_dir = os.path.join(project_dir, 'reference')
     characters_csv = _read_csv_contents(os.path.join(ref_dir, 'characters.csv'))
+
+    refs_section = f'\n## Reference Materials\n\n{refs}\n' if refs else ''
 
     return f"""You are developing the voice of a novel — the prose register, per-character voice fingerprints, and style rules that every scene must embody.
 
 {context}
-
-## Reference Materials
-
-{refs}
-
+{refs_section}
 ## Characters
 
 ```

--- a/scripts/lib/python/storyforge/revision.py
+++ b/scripts/lib/python/storyforge/revision.py
@@ -482,6 +482,7 @@ def build_revision_prompt(
     pass_config: str = '',
     coaching_level: str = 'full',
     api_mode: bool = False,
+    system_context: bool = False,
 ) -> str:
     """Assemble the full revision prompt.
 
@@ -498,6 +499,11 @@ def build_revision_prompt(
         pass_config: Optional YAML block with pass configuration.
         coaching_level: One of "full", "coach", "strict".
         api_mode: If True, inline file content for API use.
+        system_context: When True, shared reference material (craft engine,
+            scoring rubrics, voice guide, CSV files) is provided via the API
+            system parameter for prompt caching. The prompt skips inlining
+            those materials. Per-pass content (config, scene prose, briefs,
+            exemplars) is still included.
 
     Returns:
         The assembled prompt as a string.
@@ -588,9 +594,9 @@ def build_revision_prompt(
             'markdown with no YAML frontmatter.\n'
         )
 
-    # Inline reference files for API mode
+    # Inline reference files for API mode (skip when system_context provides them)
     inline_references = ''
-    if api_mode:
+    if api_mode and not system_context:
         ref_files = [
             'reference/voice-guide.md',
             'reference/scenes.csv',
@@ -625,23 +631,24 @@ def build_revision_prompt(
     # Scoring overrides
     overrides_section = _build_overrides_section(project_dir, pass_config)
 
-    # Craft sections
-    craft_text = _select_craft_sections(pass_name, purpose)
+    # Craft sections (skip when system_context provides the full craft engine)
     craft_section = ''
-    if craft_text:
-        craft_section = (
-            '\n## Craft Principles for This Pass\n\n'
-            'The following craft principles are relevant to this revision pass. '
-            'Let them guide your edits — do not reproduce them in the output, '
-            'but let them inform every editorial decision.\n\n'
-            + craft_text
-        )
+    if not system_context:
+        craft_text = _select_craft_sections(pass_name, purpose)
+        if craft_text:
+            craft_section = (
+                '\n## Craft Principles for This Pass\n\n'
+                'The following craft principles are relevant to this revision pass. '
+                'Let them guide your edits — do not reproduce them in the output, '
+                'but let them inform every editorial decision.\n\n'
+                + craft_text
+            )
 
     # Scoring rubrics for targeted principles — shows what each score level
     # looks like with literary exemplars, so the reviser knows what to aim for
     targeted_principles = _extract_pass_principles(pass_config, purpose)
     rubric_section = ''
-    if targeted_principles:
+    if targeted_principles and not system_context:
         rubric_text = _load_rubric_sections(targeted_principles)
         if rubric_text:
             rubric_section = (
@@ -684,8 +691,13 @@ def build_revision_prompt(
 
     # Mode-specific instructions
     if api_mode:
+        if system_context:
+            ref_note = ('Reference materials (craft engine, scoring rubrics, '
+                        'voice guide, registries) are provided in the system context.')
+        else:
+            ref_note = inline_references
         parts.append(
-            f'\n## Reference Context\n\n{inline_references}\n'
+            f'\n## Reference Context\n\n{ref_note}\n'
             f'\n## Scene Content\n\n'
             'Below are the full contents of every in-scope scene file. '
             'Read them all before making changes.\n'
@@ -1061,6 +1073,7 @@ def main():
         --config <yaml_block>           Pass configuration YAML
         --coaching full|coach|strict    Coaching level (default: full)
         --api-mode                      Inline files for API use
+        --system-context                Shared refs provided via system param
     """
     if len(sys.argv) < 2:
         print('Usage: python3 -m storyforge.revision <command> [args]', file=sys.stderr)
@@ -1097,6 +1110,7 @@ def main():
         pass_config = ''
         coaching_level = 'full'
         api_mode = False
+        system_context = False
         i = 6
         while i < len(sys.argv):
             if sys.argv[i] == '--config' and i + 1 < len(sys.argv):
@@ -1108,6 +1122,9 @@ def main():
             elif sys.argv[i] == '--api-mode':
                 api_mode = True
                 i += 1
+            elif sys.argv[i] == '--system-context':
+                system_context = True
+                i += 1
             else:
                 print(f'Unknown option: {sys.argv[i]}', file=sys.stderr)
                 sys.exit(1)
@@ -1118,6 +1135,7 @@ def main():
                 pass_config=pass_config,
                 coaching_level=coaching_level,
                 api_mode=api_mode,
+                system_context=system_context,
             )
             print(prompt)
         except (FileNotFoundError, ValueError) as e:

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -227,18 +227,21 @@ def mock_api(monkeypatch):
                 'usage': {'input_tokens': 100, 'output_tokens': 50},
             }
 
-        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600):
+        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600,
+                    system=None):
             self.calls.append({
                 'fn': 'invoke', 'prompt': prompt, 'model': model,
                 'max_tokens': max_tokens, 'label': label, 'timeout': timeout,
+                'system': system,
             })
             return self._get_response_dict(prompt)
 
         def _invoke_to_file(self, prompt, model, log_file, max_tokens=4096,
-                           label='', timeout=600):
+                           label='', timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
                 'log_file': log_file, 'max_tokens': max_tokens,
+                'system': system,
             })
             response = self._get_response_dict(prompt)
             os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
@@ -247,9 +250,10 @@ def mock_api(monkeypatch):
             return response
 
         def _invoke_api(self, prompt, model, max_tokens=4096, label='',
-                       timeout=600):
+                       timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_api', 'prompt': prompt, 'model': model,
+                'system': system,
             })
             return self._get_response_text(prompt)
 
@@ -480,9 +484,10 @@ def mock_costs(monkeypatch):
         def _check_threshold(self, estimated_cost):
             return self.threshold_ok
 
-        def _print_summary(self, project_dir, operation=None):
+        def _print_summary(self, project_dir, operation=None, session_start=None):
             self.operations.append({
                 'fn': 'print_summary', 'operation': operation,
+                'session_start': session_start,
             })
 
     mock = CostsMock()

--- a/tests/commands/test_api.py
+++ b/tests/commands/test_api.py
@@ -226,7 +226,7 @@ class TestInvokeApi:
     def test_returns_text_on_success(self, monkeypatch):
         from storyforge import api
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             return {
                 'content': [{'type': 'text', 'text': 'Success text'}],
                 'usage': {'input_tokens': 10, 'output_tokens': 5},
@@ -239,7 +239,7 @@ class TestInvokeApi:
     def test_returns_empty_string_on_failure(self, monkeypatch):
         from storyforge import api
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             raise RuntimeError('network down')
 
         monkeypatch.setattr(api, 'invoke', mock_invoke)
@@ -251,7 +251,7 @@ class TestInvokeApi:
 
         captured = {}
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             captured['label'] = label
             captured['timeout'] = timeout
             return {'content': [{'type': 'text', 'text': 'ok'}], 'usage': {}}
@@ -275,7 +275,7 @@ class TestInvokeToFile:
             'usage': {'input_tokens': 10, 'output_tokens': 5},
         }
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             return fake_response
 
         monkeypatch.setattr(api, 'invoke', mock_invoke)
@@ -292,7 +292,7 @@ class TestInvokeToFile:
     def test_creates_parent_directories(self, tmp_path, monkeypatch):
         from storyforge import api
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             return {'content': [], 'usage': {}}
 
         monkeypatch.setattr(api, 'invoke', mock_invoke)
@@ -309,7 +309,7 @@ class TestInvokeToFile:
             'usage': {'input_tokens': 5, 'output_tokens': 3},
         }
 
-        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600):
+        def mock_invoke(prompt, model, max_tokens=4096, label='', timeout=600, system=None):
             return expected
 
         monkeypatch.setattr(api, 'invoke', mock_invoke)

--- a/tests/commands/test_costs.py
+++ b/tests/commands/test_costs.py
@@ -334,8 +334,8 @@ class TestPrintSummary:
         print_summary(project_dir)
         captured = capsys.readouterr()
         assert 'Invocations:   2' in captured.out
-        assert 'Input tokens:  3000' in captured.out
-        assert 'Output tokens: 1500' in captured.out
+        assert 'Input tokens:  3,000' in captured.out
+        assert 'Output tokens: 1,500' in captured.out
         assert '$0.7500' in captured.out
         assert '15s' in captured.out
         assert 'all operations' in captured.out
@@ -348,7 +348,7 @@ class TestPrintSummary:
         print_summary(project_dir, operation='draft')
         captured = capsys.readouterr()
         assert 'Invocations:   1' in captured.out
-        assert 'Input tokens:  1000' in captured.out
+        assert 'Input tokens:  1,000' in captured.out
         assert 'draft' in captured.out
 
     def test_no_matching_operation(self, tmp_path, capsys):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -175,18 +175,21 @@ def mock_api(monkeypatch):
                 'usage': {'input_tokens': 100, 'output_tokens': 50},
             }
 
-        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600):
+        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600,
+                    system=None):
             self.calls.append({
                 'fn': 'invoke', 'prompt': prompt, 'model': model,
                 'max_tokens': max_tokens, 'label': label, 'timeout': timeout,
+                'system': system,
             })
             return self._get_response_dict(prompt)
 
         def _invoke_to_file(self, prompt, model, log_file, max_tokens=4096,
-                           label='', timeout=600):
+                           label='', timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
                 'log_file': log_file, 'max_tokens': max_tokens,
+                'system': system,
             })
             response = self._get_response_dict(prompt)
             os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
@@ -195,9 +198,10 @@ def mock_api(monkeypatch):
             return response
 
         def _invoke_api(self, prompt, model, max_tokens=4096, label='',
-                       timeout=600):
+                       timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_api', 'prompt': prompt, 'model': model,
+                'system': system,
             })
             return self._get_response_text(prompt)
 
@@ -317,10 +321,11 @@ def mock_api_rich(monkeypatch):
                 )
             return self.default
 
-        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600):
+        def _invoke(self, prompt, model, max_tokens=4096, label='', timeout=600,
+                    system=None):
             self.calls.append({
                 'fn': 'invoke', 'prompt': prompt, 'model': model,
-                'max_tokens': max_tokens,
+                'max_tokens': max_tokens, 'system': system,
             })
             text = self._resolve(prompt)
             return {
@@ -329,10 +334,11 @@ def mock_api_rich(monkeypatch):
             }
 
         def _invoke_to_file(self, prompt, model, log_file, max_tokens=4096,
-                           label='', timeout=600):
+                           label='', timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_to_file', 'prompt': prompt, 'model': model,
                 'log_file': log_file, 'max_tokens': max_tokens,
+                'system': system,
             })
             # Resolve directly — don't call _invoke to avoid double-counting
             text = self._resolve(prompt)
@@ -346,9 +352,10 @@ def mock_api_rich(monkeypatch):
             return response
 
         def _invoke_api(self, prompt, model, max_tokens=4096, label='',
-                       timeout=600):
+                       timeout=600, system=None):
             self.calls.append({
                 'fn': 'invoke_api', 'prompt': prompt, 'model': model,
+                'system': system,
             })
             return self._resolve(prompt)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from unittest.mock import patch, MagicMock
 
 
 class TestExtractApiResponse:
@@ -60,6 +61,39 @@ class TestExtractApiUsage:
         result = extract_usage(response)
         assert result.get('cache_read_input_tokens', 0) == 0
         assert result.get('cache_creation_input_tokens', 0) == 0
+
+
+class TestInvokeSystemParam:
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_invoke_without_system_omits_key(self, mock_key, mock_req):
+        from storyforge.api import invoke
+        mock_req.return_value = {
+            'content': [{'type': 'text', 'text': 'ok'}],
+            'usage': {'input_tokens': 10, 'output_tokens': 5},
+        }
+        invoke('hello', 'claude-sonnet-4-6', max_tokens=100)
+        body = mock_req.call_args[0][1]
+        assert 'system' not in body
+        assert body['messages'] == [{'role': 'user', 'content': 'hello'}]
+
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_invoke_with_system_includes_key(self, mock_key, mock_req):
+        from storyforge.api import invoke
+        mock_req.return_value = {
+            'content': [{'type': 'text', 'text': 'ok'}],
+            'usage': {'input_tokens': 10, 'output_tokens': 5},
+        }
+        system_blocks = [
+            {'type': 'text', 'text': 'You are helpful.'},
+            {'type': 'text', 'text': 'Reference material here.',
+             'cache_control': {'type': 'ephemeral'}},
+        ]
+        invoke('hello', 'claude-sonnet-4-6', max_tokens=100, system=system_blocks)
+        body = mock_req.call_args[0][1]
+        assert body['system'] == system_blocks
+        assert body['messages'] == [{'role': 'user', 'content': 'hello'}]
 
 
 class TestLogApiUsage:

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,6 +1,7 @@
 """Tests for cost calculation (migrated from test-costs.sh)."""
 
-from storyforge.costs import calculate_cost, estimate_cost, format_duration, PRICING
+import os
+from storyforge.costs import calculate_cost, estimate_cost, format_duration, log_operation, print_summary, PRICING, LEDGER_HEADER
 
 
 class TestPricing:
@@ -74,3 +75,69 @@ class TestFormatDuration:
 
     def test_exact_hour(self):
         assert format_duration(3600) == '1h 0m 0s'
+
+
+class TestSessionScopedSummary:
+    def _make_ledger(self, project_dir, rows):
+        """Write a ledger with the given rows (list of pipe-delimited strings)."""
+        ledger_dir = os.path.join(project_dir, 'working', 'costs')
+        os.makedirs(ledger_dir, exist_ok=True)
+        with open(os.path.join(ledger_dir, 'ledger.csv'), 'w') as f:
+            f.write(LEDGER_HEADER + '\n')
+            for row in rows:
+                f.write(row + '\n')
+
+    def test_no_session_start_shows_cumulative_only(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T10:00:00|revise|scene-2|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+        ])
+        print_summary(project_dir, 'revise')
+        out = capsys.readouterr().out
+        assert 'This session' not in out
+        assert 'Project total' not in out
+        assert '--- Cost Summary: revise ---' in out
+        assert 'Invocations:   2' in out
+
+    def test_session_start_shows_both_sections(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T10:00:00|revise|scene-2|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+            '2026-04-15T11:00:00|revise|scene-3|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T09:00:00')
+        out = capsys.readouterr().out
+        assert '--- This session: revise (2 invocations) ---' in out
+        assert '--- Project total: revise (3 invocations) ---' in out
+
+    def test_session_filters_by_timestamp(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T14:00:00|revise|scene-2|claude-opus-4-6|200000|20000|0|0|10.500000|600',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T00:00:00')
+        out = capsys.readouterr().out
+        assert '1 invocation)' in out  # singular
+
+    def test_session_with_no_matching_rows(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-01T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+        ])
+        print_summary(project_dir, 'revise', session_start='2026-04-15T00:00:00')
+        out = capsys.readouterr().out
+        assert 'Project total' in out
+        assert 'This session' not in out
+
+    def test_duration_uses_format_duration(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-15T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|3661',
+        ])
+        print_summary(project_dir, 'revise')
+        out = capsys.readouterr().out
+        assert '1h 1m 1s' in out
+        assert '3661s' not in out

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,6 +1,6 @@
 """Tests for cost calculation (migrated from test-costs.sh)."""
 
-from storyforge.costs import calculate_cost, estimate_cost, PRICING
+from storyforge.costs import calculate_cost, estimate_cost, format_duration, PRICING
 
 
 class TestPricing:
@@ -51,3 +51,26 @@ class TestEstimateCost:
     def test_zero_scope(self):
         result = estimate_cost('draft', 0, 2000, 'claude-sonnet-4')
         assert result == 0.00
+
+
+class TestFormatDuration:
+    def test_zero(self):
+        assert format_duration(0) == '0s'
+
+    def test_seconds_only(self):
+        assert format_duration(45) == '45s'
+
+    def test_minutes_and_seconds(self):
+        assert format_duration(180) == '3m 0s'
+
+    def test_minutes_and_nonzero_seconds(self):
+        assert format_duration(185) == '3m 5s'
+
+    def test_hours_minutes_seconds(self):
+        assert format_duration(3661) == '1h 1m 1s'
+
+    def test_large_duration(self):
+        assert format_duration(27888) == '7h 44m 48s'
+
+    def test_exact_hour(self):
+        assert format_duration(3600) == '1h 0m 0s'

--- a/tests/test_csv_positional.py
+++ b/tests/test_csv_positional.py
@@ -112,7 +112,7 @@ class TestPrintSummaryColumnOrder:
 
         print_summary(project_dir)
         captured = capsys.readouterr()
-        assert 'Input tokens:  1000' in captured.out
+        assert 'Input tokens:  1,000' in captured.out
         assert 'Output tokens: 500' in captured.out
         assert 'Cache read:    100' in captured.out
         assert 'Cache create:  50' in captured.out
@@ -133,7 +133,7 @@ class TestPrintSummaryColumnOrder:
         print_summary(project_dir, 'evaluate')
         captured = capsys.readouterr()
         assert 'Invocations:   2' in captured.out
-        assert 'Input tokens:  1200' in captured.out
+        assert 'Input tokens:  1,200' in captured.out
         assert 'Output tokens: 600' in captured.out
 
     def test_standard_order_still_works(self, tmp_path, capsys):
@@ -145,12 +145,12 @@ class TestPrintSummaryColumnOrder:
 
         print_summary(project_dir)
         captured = capsys.readouterr()
-        assert 'Input tokens:  2000' in captured.out
-        assert 'Output tokens: 1000' in captured.out
+        assert 'Input tokens:  2,000' in captured.out
+        assert 'Output tokens: 1,000' in captured.out
         assert 'Cache read:    200' in captured.out
         assert 'Cache create:  100' in captured.out
         assert '$1.0000' in captured.out
-        assert '60s' in captured.out
+        assert '1m 0s' in captured.out
 
     def test_missing_optional_columns(self, tmp_path, capsys):
         """Ledger with fewer columns (e.g., no cache columns) still produces a summary."""
@@ -163,7 +163,7 @@ class TestPrintSummaryColumnOrder:
         print_summary(project_dir)
         captured = capsys.readouterr()
         assert 'Invocations:   1' in captured.out
-        assert 'Input tokens:  1000' in captured.out
+        assert 'Input tokens:  1,000' in captured.out
         assert 'Output tokens: 500' in captured.out
         assert 'Cache read:    0' in captured.out  # Missing columns default to 0
         assert '$0.5000' in captured.out
@@ -179,8 +179,8 @@ class TestPrintSummaryColumnOrder:
         print_summary(project_dir, 'evaluate')
         captured = capsys.readouterr()
         assert 'Invocations:   2' in captured.out
-        assert 'Input tokens:  8000' in captured.out
-        assert 'Output tokens: 3000' in captured.out
+        assert 'Input tokens:  8,000' in captured.out
+        assert 'Output tokens: 3,000' in captured.out
         assert 'Cache read:    100' in captured.out
         assert 'Cache create:  50' in captured.out
 

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,0 +1,41 @@
+"""Tests for prompt caching infrastructure."""
+
+import json
+
+
+class TestBuildBatchRequest:
+    def test_without_system(self):
+        from storyforge.api import build_batch_request
+        result = build_batch_request('scene-1', 'Write a scene.', 'claude-opus-4-6', 8192)
+        assert result['custom_id'] == 'scene-1'
+        assert result['params']['model'] == 'claude-opus-4-6'
+        assert result['params']['max_tokens'] == 8192
+        assert result['params']['messages'] == [{'role': 'user', 'content': 'Write a scene.'}]
+        assert 'system' not in result['params']
+
+    def test_with_system(self):
+        from storyforge.api import build_batch_request
+        system = [
+            {'type': 'text', 'text': 'Craft engine content here.'},
+            {'type': 'text', 'text': 'Voice guide here.',
+             'cache_control': {'type': 'ephemeral'}},
+        ]
+        result = build_batch_request('scene-1', 'Write a scene.', 'claude-opus-4-6', 8192,
+                                     system=system)
+        assert result['params']['system'] == system
+        assert result['params']['messages'] == [{'role': 'user', 'content': 'Write a scene.'}]
+
+    def test_serializes_to_valid_jsonl(self):
+        from storyforge.api import build_batch_request
+        system = [{'type': 'text', 'text': 'Context.',
+                   'cache_control': {'type': 'ephemeral'}}]
+        result = build_batch_request('s1', 'prompt', 'claude-sonnet-4-6', 4096, system=system)
+        line = json.dumps(result)
+        parsed = json.loads(line)
+        assert parsed['custom_id'] == 's1'
+        assert parsed['params']['system'][0]['cache_control']['type'] == 'ephemeral'
+
+    def test_default_max_tokens(self):
+        from storyforge.api import build_batch_request
+        result = build_batch_request('s1', 'prompt', 'claude-sonnet-4-6')
+        assert result['params']['max_tokens'] == 4096

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,6 +1,7 @@
 """Tests for prompt caching infrastructure."""
 
 import json
+import os
 
 
 class TestBuildBatchRequest:
@@ -39,3 +40,65 @@ class TestBuildBatchRequest:
         from storyforge.api import build_batch_request
         result = build_batch_request('s1', 'prompt', 'claude-sonnet-4-6')
         assert result['params']['max_tokens'] == 4096
+
+
+class TestBuildSharedContext:
+    def test_returns_list_of_dicts(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        assert isinstance(result, list)
+        assert len(result) > 0
+        for block in result:
+            assert block['type'] == 'text'
+            assert 'text' in block
+
+    def test_tier1_blocks_come_first(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        texts = [b['text'] for b in result]
+        # Craft engine is tier 1, character bible is tier 2
+        craft_idx = next((i for i, t in enumerate(texts) if 'Craft Engine' in t), None)
+        bible_idx = next((i for i, t in enumerate(texts) if 'Character Bible' in t), None)
+        assert craft_idx is not None
+        assert bible_idx is not None
+        assert craft_idx < bible_idx
+
+    def test_has_cache_control_breakpoints(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        blocks_with_cc = [b for b in result if 'cache_control' in b]
+        assert len(blocks_with_cc) >= 1
+
+    def test_skips_missing_files(self, tmp_path):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        project_dir = str(tmp_path / 'empty')
+        os.makedirs(os.path.join(project_dir, 'reference'), exist_ok=True)
+        result = build_shared_context(project_dir, model='claude-sonnet-4-6')
+        assert isinstance(result, list)
+
+    def test_in_process_cache(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result1 = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        result2 = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        assert result1 is result2
+
+    def test_includes_project_references(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        all_text = ' '.join(b['text'] for b in result)
+        assert 'Voice Guide' in all_text
+        assert 'Character Bible' in all_text
+
+    def test_includes_registries(self, fixture_dir, plugin_dir):
+        from storyforge.common import build_shared_context, _shared_context_cache
+        _shared_context_cache.clear()
+        result = build_shared_context(fixture_dir, model='claude-sonnet-4-6')
+        all_text = ' '.join(b['text'] for b in result)
+        assert 'Character Registry' in all_text
+        assert 'Location Registry' in all_text


### PR DESCRIPTION
## Summary

- **Prompt caching across all API calls** — shared project reference materials (craft engine, voice guide, character bible, registries) now go in the API `system` parameter with `cache_control` breakpoints, so Anthropic caches them across calls instead of re-processing from scratch each time
- **Two-tier cache architecture** — plugin-level references (craft engine, rubrics, AI-tell vocab) get 1h TTL; project-level references (bibles, voice guide, registries) get 5m TTL
- **Session-scoped cost summaries** — after each autonomous pass, shows both "This session" costs and "Project total" instead of cumulative-only
- **Human-readable durations** — `27888s` → `7h 44m 48s`

### Changes

**Infrastructure:**
- `build_shared_context(project_dir, model)` in `common.py` — assembles reference materials into cacheable system blocks with in-process caching
- `build_batch_request()` in `api.py` — standardizes batch JSONL construction (replaces copy-pasted dicts in 8+ modules)
- `system` parameter added to `invoke()`, `invoke_to_file()`, `invoke_api()`
- `format_duration()` and session-scoped `print_summary()` in `costs.py`

**Integration (all 9 command modules):**
cmd_write, cmd_score, cmd_evaluate, cmd_extract, cmd_revise, cmd_elaborate, cmd_enrich, cmd_timeline, cmd_scenes_setup

**Prompt builders updated:**
prompts.py, prompts_elaborate.py, revision.py — `system_context` parameter skips inlining shared material when system blocks are provided externally

## Test plan

- [x] 3367 tests passing, 0 failures
- [x] 74.85% coverage (above 73% threshold)
- [x] New tests: `test_prompt_caching.py` (11 tests), `test_costs.py` extensions (12 tests), `test_api.py` extensions (2 tests)
- [x] Existing test assertions updated for comma-formatted token counts
- [ ] Run a real `storyforge score` or `storyforge revise` on a project and verify cache_read > 0 in the cost summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)