### PR TITLE
Fix review findings from prompt caching PR

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/api.py
+++ b/scripts/lib/python/storyforge/api.py
@@ -161,19 +161,34 @@ def invoke_to_file(prompt: str, model: str, log_file: str, max_tokens: int = 409
     return response
 
 
+_invoke_api_consecutive_failures = 0
+_INVOKE_API_FAILURE_THRESHOLD = 5
+
+
 def invoke_api(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
                timeout: int = API_TIMEOUT, system: list[dict] | None = None) -> str:
     """High-level convenience: invoke API and return text response.
 
     Returns empty string on failure (logs warning but doesn't raise).
+    Raises RuntimeError if failures exceed threshold (likely systemic issue).
     Used by git.py review phase, runner.py healing zones, and command modules.
     """
+    global _invoke_api_consecutive_failures
     try:
         response = invoke(prompt, model, max_tokens, label=label, timeout=timeout, system=system)
+        _invoke_api_consecutive_failures = 0
         return extract_text(response)
     except Exception as e:
         from storyforge.common import log
+        _invoke_api_consecutive_failures += 1
         log(f'WARNING: API call failed: {e}')
+        if _invoke_api_consecutive_failures >= _INVOKE_API_FAILURE_THRESHOLD:
+            _invoke_api_consecutive_failures = 0
+            raise RuntimeError(
+                f'API calls failed {_INVOKE_API_FAILURE_THRESHOLD} times consecutively — '
+                f'likely a systemic issue (bad API key, malformed request, etc.). '
+                f'Last error: {e}'
+            ) from e
         return ''
 
 

--- a/scripts/lib/python/storyforge/cmd_evaluate.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate.py
@@ -1203,6 +1203,8 @@ def main(argv=None):
         log('Running synthesis session...')
         synth_start = time.time()
         synth_model = select_model('synthesis')
+        # Rebuild shared context for synthesis model tier (may differ from evaluator tier)
+        system = build_shared_context(project_dir, model=synth_model)
         synth_log = os.path.join(log_dir, 'eval-synthesis.log')
 
         api_mode = eval_mode != 'interactive'

--- a/scripts/lib/python/storyforge/costs.py
+++ b/scripts/lib/python/storyforge/costs.py
@@ -131,31 +131,38 @@ def _accumulate(rows: list, col_map: dict) -> dict:
     total_cost = 0.0
     total_dur = 0
 
+    def _safe_int(val: str) -> int:
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return 0
+
+    def _safe_float(val: str) -> float:
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            return 0.0
+
     for parts in rows:
-        for col_name, target in [
-            ('input_tokens', 'input'),
-            ('output_tokens', 'output'),
-            ('cache_read', 'cache_r'),
-            ('cache_create', 'cache_c'),
-            ('duration_s', 'dur'),
-        ]:
+        for col_name in ('input_tokens', 'output_tokens', 'cache_read',
+                         'cache_create', 'duration_s'):
             if col_name in col_map and col_map[col_name] < len(parts):
                 val = parts[col_map[col_name]]
                 if val:
                     if col_name == 'input_tokens':
-                        total_input += int(val)
+                        total_input += _safe_int(val)
                     elif col_name == 'output_tokens':
-                        total_output += int(val)
+                        total_output += _safe_int(val)
                     elif col_name == 'cache_read':
-                        total_cache_r += int(val)
+                        total_cache_r += _safe_int(val)
                     elif col_name == 'cache_create':
-                        total_cache_c += int(val)
+                        total_cache_c += _safe_int(val)
                     elif col_name == 'duration_s':
-                        total_dur += int(val)
+                        total_dur += _safe_int(val)
         if 'cost_usd' in col_map and col_map['cost_usd'] < len(parts):
             val = parts[col_map['cost_usd']]
             if val:
-                total_cost += float(val)
+                total_cost += _safe_float(val)
 
     return {
         'input': total_input,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,6 +96,55 @@ class TestInvokeSystemParam:
         assert body['messages'] == [{'role': 'user', 'content': 'hello'}]
 
 
+class TestInvokeApiConsecutiveFailures:
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_single_failure_returns_empty(self, mock_key, mock_req):
+        import storyforge.api as api_mod
+        api_mod._invoke_api_consecutive_failures = 0
+        mock_req.side_effect = RuntimeError('API error')
+        result = api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+        assert result == ''
+
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_consecutive_failures_raise(self, mock_key, mock_req):
+        import storyforge.api as api_mod
+        api_mod._invoke_api_consecutive_failures = 0
+        mock_req.side_effect = RuntimeError('API error')
+        for _ in range(4):
+            result = api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+            assert result == ''
+        # 5th consecutive failure should raise
+        import pytest
+        with pytest.raises(RuntimeError, match='consecutively'):
+            api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+
+    @patch('storyforge.api._api_request')
+    @patch('storyforge.api.get_api_key', return_value='test-key')
+    def test_success_resets_counter(self, mock_key, mock_req):
+        import storyforge.api as api_mod
+        api_mod._invoke_api_consecutive_failures = 0
+        # Fail 3 times, succeed, fail 3 more — should NOT raise
+        call_count = [0]
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 4:  # 4th call succeeds
+                return {'content': [{'type': 'text', 'text': 'ok'}],
+                        'usage': {'input_tokens': 10, 'output_tokens': 5}}
+            raise RuntimeError('API error')
+        mock_req.side_effect = side_effect
+        for _ in range(3):
+            api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+        result = api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+        assert result == 'ok'
+        assert api_mod._invoke_api_consecutive_failures == 0
+        # 3 more failures should not raise (counter was reset)
+        mock_req.side_effect = RuntimeError('API error')
+        for _ in range(3):
+            api_mod.invoke_api('hello', 'claude-sonnet-4-6')
+
+
 class TestLogApiUsage:
     def test_creates_ledger(self, tmp_path):
         from storyforge.api import log_operation, calculate_cost_from_usage

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -132,6 +132,18 @@ class TestSessionScopedSummary:
         assert 'Project total' in out
         assert 'This session' not in out
 
+    def test_corrupt_ledger_row_skipped(self, tmp_path, capsys):
+        project_dir = str(tmp_path / 'proj')
+        self._make_ledger(project_dir, [
+            '2026-04-15T10:00:00|revise|scene-1|claude-opus-4-6|100000|10000|0|0|5.250000|300',
+            '2026-04-15T11:00:00|revise|scene-2|claude-opus-4-6|CORRUPT|bad|x|y|nope|zzz',
+        ])
+        print_summary(project_dir, 'revise')
+        out = capsys.readouterr().out
+        # Should not crash — corrupt row's values treated as 0
+        assert 'Invocations:   2' in out
+        assert '100,000' in out
+
     def test_duration_uses_format_duration(self, tmp_path, capsys):
         project_dir = str(tmp_path / 'proj')
         self._make_ledger(project_dir, [


### PR DESCRIPTION
## Summary

Fixes three pre-existing issues surfaced during the prompt caching PR review:

- **invoke_api consecutive failure detection** — after 5 consecutive API failures, raises `RuntimeError` instead of silently returning empty strings. A single failure still returns empty (existing behavior). A success resets the counter. This catches systemic issues (bad API key, malformed system blocks) that would otherwise silently skip all work.
- **Corrupt ledger data handling** — `_accumulate` in `print_summary` now uses safe int/float conversions that return 0 on corrupt values instead of crashing with `ValueError`. Prevents the cost summary from crashing after a successful long-running command.
- **Evaluate model tier mismatch** — rebuilds shared context with the synthesis model before synthesis/assessment calls, so cache breakpoints meet Opus's 4096-token minimum instead of using Sonnet's 2048-token threshold.

## Test plan

- [x] 3371 tests passing, 0 failures
- [x] New: `TestInvokeApiConsecutiveFailures` (3 tests) — single failure, threshold raise, success reset
- [x] New: `test_corrupt_ledger_row_skipped` — corrupt values don't crash summary
- [x] Full regression suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)