### PR TITLE
Fix cache_control TTL format

### DIFF
--- a/scripts/lib/python/storyforge/common.py
+++ b/scripts/lib/python/storyforge/common.py
@@ -348,7 +348,7 @@ def build_shared_context(project_dir: str, model: str = '') -> list[dict]:
     if tier1_blocks:
         if tier1_chars >= min_chars:
             # Tier 1 meets threshold — add breakpoint with extended TTL
-            tier1_blocks[-1]['cache_control'] = {'type': 'ephemeral', 'ttl': 3600}
+            tier1_blocks[-1]['cache_control'] = {'type': 'ephemeral', 'ttl': '1h'}
         blocks.extend(tier1_blocks)
 
     if tier2_blocks:


### PR DESCRIPTION
## Summary

- Anthropic API expects TTL as string `'1h'`, not integer `3600`
- Was causing HTTP 400: `system.2.cache_control.ephemeral.ttl: Input should be '5m' or '1h'`

One-line fix in `build_shared_context()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)