### PR TITLE
Improve logging during scoring improvement cycle

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -454,7 +454,6 @@ def main(argv=None):
     # Improvement cycle
     # =========================================================================
 
-    log('Running improvement cycle...')
     _run_improvement_cycle(
         cycle, cycle_dir, project_dir, weights_file, plugin_dir,
         intent_csv, title,
@@ -1361,11 +1360,34 @@ def _run_narrative_scoring(title, metadata_csv, project_dir, cycle_dir,
         log(f'  WARNING: Narrative scoring API call failed: {e}')
 
 
+def _count_high_priority(diagnosis_file: str) -> int:
+    """Count high-priority principles in a diagnosis CSV."""
+    if not os.path.isfile(diagnosis_file):
+        return 0
+    with open(diagnosis_file) as f:
+        lines = [l.strip() for l in f if l.strip()]
+    if len(lines) < 2:
+        return 0
+    header = lines[0].split('|')
+    pri_idx = header.index('priority') if 'priority' in header else -1
+    if pri_idx < 0:
+        return 0
+    count = 0
+    for line in lines[1:]:
+        parts = line.split('|')
+        if pri_idx < len(parts) and parts[pri_idx] == 'high':
+            count += 1
+    return count
+
+
 def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
                            plugin_dir, intent_csv, title):
     """Run diagnosis, proposals, and apply approved changes."""
     from storyforge.scoring import generate_diagnosis, generate_proposals
     from storyforge.csv_cli import update_field as csv_update
+
+    log('Improvement cycle: generating diagnosis...')
+    t0 = time.monotonic()
 
     # Previous cycle
     prev_dir = ''
@@ -1375,20 +1397,28 @@ def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
             prev_dir = ''
 
     generate_diagnosis(cycle_dir, prev_dir or '-', weights_file)
+    log(f'Improvement cycle: diagnosis complete ({time.monotonic() - t0:.1f}s)')
+
+    log('Improvement cycle: generating proposals...')
+    t0 = time.monotonic()
     generate_proposals(cycle_dir, weights_file)
 
     proposals_file = os.path.join(cycle_dir, 'proposals.csv')
     diagnosis_file = os.path.join(cycle_dir, 'diagnosis.csv')
 
     if not os.path.isfile(proposals_file):
-        log('No proposals generated')
+        log(f'Improvement cycle: no proposals generated ({time.monotonic() - t0:.1f}s)')
         return
 
     # Count proposals
     with open(proposals_file) as f:
         lines = [l.strip() for l in f if l.strip()]
     proposal_count = len(lines) - 1  # subtract header
-    log(f'Generated {proposal_count} improvement proposals')
+
+    # Count high-priority principles from diagnosis
+    high_count = _count_high_priority(diagnosis_file)
+    priority_note = f' ({high_count} high-priority principles)' if high_count else ''
+    log(f'Improvement cycle: {proposal_count} proposals generated{priority_note} ({time.monotonic() - t0:.1f}s)')
 
     if proposal_count <= 0:
         return
@@ -1408,13 +1438,18 @@ def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
 
     # Apply approved proposals
     if coaching != 'strict':
+        log('Improvement cycle: applying proposals...')
+        t0 = time.monotonic()
         applied = _apply_proposals(proposals_file, weights_file, intent_csv,
                                    project_dir)
-        log(f'{applied} proposals applied. Run storyforge write to rewrite with updated guidance.')
+        log(f'Improvement cycle: {applied} proposals applied ({time.monotonic() - t0:.1f}s)')
 
     # Collect exemplars
+    log('Improvement cycle: collecting exemplars...')
+    t0 = time.monotonic()
     from storyforge.scoring import collect_exemplars
     collect_exemplars(cycle_dir, project_dir, str(cycle))
+    log(f'Improvement cycle: exemplars collected ({time.monotonic() - t0:.1f}s)')
 
     # Check for validated patterns
     from storyforge.scoring import check_validated_patterns
@@ -1427,6 +1462,8 @@ def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
             parts = line.split('|')
             if len(parts) >= 3:
                 log(f'  {parts[0]} ({parts[1]}): avg improvement {parts[2]}')
+
+    log('Improvement cycle: complete')
 
 
 def _approve_all_proposals(proposals_file: str) -> None:

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -1362,22 +1362,8 @@ def _run_narrative_scoring(title, metadata_csv, project_dir, cycle_dir,
 
 def _count_high_priority(diagnosis_file: str) -> int:
     """Count high-priority principles in a diagnosis CSV."""
-    if not os.path.isfile(diagnosis_file):
-        return 0
-    with open(diagnosis_file) as f:
-        lines = [l.strip() for l in f if l.strip()]
-    if len(lines) < 2:
-        return 0
-    header = lines[0].split('|')
-    pri_idx = header.index('priority') if 'priority' in header else -1
-    if pri_idx < 0:
-        return 0
-    count = 0
-    for line in lines[1:]:
-        parts = line.split('|')
-        if pri_idx < len(parts) and parts[pri_idx] == 'high':
-            count += 1
-    return count
+    from storyforge.csv_cli import get_column
+    return sum(1 for v in get_column(diagnosis_file, 'priority') if v == 'high')
 
 
 def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
@@ -1430,19 +1416,21 @@ def _run_improvement_cycle(cycle, cycle_dir, project_dir, weights_file,
         _approve_all_proposals(proposals_file)
     elif coaching == 'coach':
         log('Coaching level: coach — proposals require interactive approval')
-        # In non-interactive script, just report
+        # No approved proposals in non-interactive script; skip apply
     elif coaching == 'strict':
         log('Coaching level: strict — diagnosis and proposals generated as report only')
         _print_strict_report(diagnosis_file, proposals_file)
         return
 
-    # Apply approved proposals
-    if coaching != 'strict':
+    # Apply approved proposals (only 'full' will have approved proposals here)
+    if coaching == 'full':
         log('Improvement cycle: applying proposals...')
         t0 = time.monotonic()
         applied = _apply_proposals(proposals_file, weights_file, intent_csv,
                                    project_dir)
         log(f'Improvement cycle: {applied} proposals applied ({time.monotonic() - t0:.1f}s)')
+        if applied:
+            log('Run storyforge write to rewrite with updated guidance.')
 
     # Collect exemplars
     log('Improvement cycle: collecting exemplars...')

--- a/tests/test_score_logging.py
+++ b/tests/test_score_logging.py
@@ -1,0 +1,141 @@
+"""Tests for improvement cycle logging in cmd_score."""
+
+import os
+from unittest.mock import patch, MagicMock
+
+from storyforge.cmd_score import _count_high_priority, _run_improvement_cycle
+
+
+def test_count_high_priority_with_mixed_priorities(tmp_path):
+    diag = tmp_path / 'diagnosis.csv'
+    diag.write_text(
+        'principle|scale|avg_score|worst_items|delta_from_last|priority|root_cause\n'
+        'prose_repetition|scene|1.8|s1;s2||high|craft\n'
+        'avoid_passive|scene|2.5|s3||medium|craft\n'
+        'economy_clarity|scene|1.5|s1||high|craft\n'
+    )
+    assert _count_high_priority(str(diag)) == 2
+
+
+def test_count_high_priority_no_high(tmp_path):
+    diag = tmp_path / 'diagnosis.csv'
+    diag.write_text(
+        'principle|scale|avg_score|worst_items|delta_from_last|priority|root_cause\n'
+        'avoid_passive|scene|3.5|s3||low|craft\n'
+    )
+    assert _count_high_priority(str(diag)) == 0
+
+
+def test_count_high_priority_missing_file():
+    assert _count_high_priority('/nonexistent/diagnosis.csv') == 0
+
+
+def test_count_high_priority_empty_file(tmp_path):
+    diag = tmp_path / 'diagnosis.csv'
+    diag.write_text('')
+    assert _count_high_priority(str(diag)) == 0
+
+
+@patch('storyforge.scoring.check_validated_patterns', return_value='')
+@patch('storyforge.scoring.collect_exemplars')
+@patch('storyforge.scoring.generate_proposals')
+@patch('storyforge.scoring.generate_diagnosis')
+@patch('storyforge.cmd_score.get_coaching_level', return_value='full')
+def test_improvement_cycle_logs_all_phases(
+    mock_coaching, mock_diag, mock_proposals, mock_exemplars,
+    mock_patterns, tmp_path, capsys
+):
+    """Verify that every phase of the improvement cycle produces log output."""
+    cycle_dir = str(tmp_path / 'cycle-1')
+    os.makedirs(cycle_dir)
+    project_dir = str(tmp_path / 'project')
+    os.makedirs(os.path.join(project_dir, 'working'), exist_ok=True)
+
+    weights_file = str(tmp_path / 'craft-weights.csv')
+    with open(weights_file, 'w') as f:
+        f.write('principle|weight\nprose_repetition|5\n')
+
+    intent_csv = str(tmp_path / 'scene-intent.csv')
+    with open(intent_csv, 'w') as f:
+        f.write('id|function\n')
+
+    # generate_diagnosis writes diagnosis.csv
+    def fake_diagnosis(cd, pd, wf):
+        with open(os.path.join(cd, 'diagnosis.csv'), 'w') as f:
+            f.write(
+                'principle|scale|avg_score|worst_items|delta_from_last|priority|root_cause\n'
+                'prose_repetition|scene|1.8|s1||high|craft\n'
+            )
+    mock_diag.side_effect = fake_diagnosis
+
+    # generate_proposals writes proposals.csv
+    def fake_proposals(cd, wf):
+        with open(os.path.join(cd, 'proposals.csv'), 'w') as f:
+            f.write(
+                'id|principle|lever|target|change|rationale|status\n'
+                'p001|prose_repetition|craft_weight|global|weight 5 → 7|avg_score 1.8, priority high|pending\n'
+            )
+    mock_proposals.side_effect = fake_proposals
+
+    # Storyforge YAML for coaching level detection
+    yaml_file = os.path.join(project_dir, 'storyforge.yaml')
+    with open(yaml_file, 'w') as f:
+        f.write('project:\n  title: Test\n  coaching_level: full\n')
+
+    _run_improvement_cycle(
+        cycle=1, cycle_dir=cycle_dir, project_dir=project_dir,
+        weights_file=weights_file, plugin_dir='/fake',
+        intent_csv=intent_csv, title='Test',
+    )
+
+    captured = capsys.readouterr().out
+    assert 'Improvement cycle: generating diagnosis...' in captured
+    assert 'Improvement cycle: diagnosis complete' in captured
+    assert 'Improvement cycle: generating proposals...' in captured
+    assert '1 proposals generated (1 high-priority principles)' in captured
+    assert 'Improvement cycle: applying proposals...' in captured
+    assert 'proposals applied' in captured
+    assert 'Improvement cycle: collecting exemplars...' in captured
+    assert 'Improvement cycle: exemplars collected' in captured
+    assert 'Improvement cycle: complete' in captured
+
+
+@patch('storyforge.scoring.generate_proposals')
+@patch('storyforge.scoring.generate_diagnosis')
+def test_improvement_cycle_no_proposals_logs_cleanly(
+    mock_diag, mock_proposals, tmp_path, capsys
+):
+    """When no proposals are generated, the cycle logs and exits cleanly."""
+    cycle_dir = str(tmp_path / 'cycle-1')
+    os.makedirs(cycle_dir)
+    project_dir = str(tmp_path / 'project')
+    os.makedirs(os.path.join(project_dir, 'working'), exist_ok=True)
+
+    weights_file = str(tmp_path / 'craft-weights.csv')
+    with open(weights_file, 'w') as f:
+        f.write('principle|weight\n')
+
+    intent_csv = str(tmp_path / 'scene-intent.csv')
+    with open(intent_csv, 'w') as f:
+        f.write('id|function\n')
+
+    def fake_diagnosis(cd, pd, wf):
+        with open(os.path.join(cd, 'diagnosis.csv'), 'w') as f:
+            f.write('principle|scale|avg_score|worst_items|delta_from_last|priority|root_cause\n')
+    mock_diag.side_effect = fake_diagnosis
+
+    # generate_proposals does NOT write a proposals file
+    mock_proposals.side_effect = lambda cd, wf: None
+
+    _run_improvement_cycle(
+        cycle=1, cycle_dir=cycle_dir, project_dir=project_dir,
+        weights_file=weights_file, plugin_dir='/fake',
+        intent_csv=intent_csv, title='Test',
+    )
+
+    captured = capsys.readouterr().out
+    assert 'Improvement cycle: generating diagnosis...' in captured
+    assert 'Improvement cycle: no proposals generated' in captured
+    # Should NOT reach later phases
+    assert 'applying proposals' not in captured
+    assert 'collecting exemplars' not in captured

--- a/tests/test_score_logging.py
+++ b/tests/test_score_logging.py
@@ -1,7 +1,7 @@
 """Tests for improvement cycle logging in cmd_score."""
 
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from storyforge.cmd_score import _count_high_priority, _run_improvement_cycle
 
@@ -95,6 +95,7 @@ def test_improvement_cycle_logs_all_phases(
     assert '1 proposals generated (1 high-priority principles)' in captured
     assert 'Improvement cycle: applying proposals...' in captured
     assert 'proposals applied' in captured
+    assert 'Run storyforge write to rewrite with updated guidance.' in captured
     assert 'Improvement cycle: collecting exemplars...' in captured
     assert 'Improvement cycle: exemplars collected' in captured
     assert 'Improvement cycle: complete' in captured
@@ -139,3 +140,58 @@ def test_improvement_cycle_no_proposals_logs_cleanly(
     # Should NOT reach later phases
     assert 'applying proposals' not in captured
     assert 'collecting exemplars' not in captured
+
+
+@patch('storyforge.scoring.check_validated_patterns', return_value='')
+@patch('storyforge.scoring.collect_exemplars')
+@patch('storyforge.scoring.generate_proposals')
+@patch('storyforge.scoring.generate_diagnosis')
+@patch('storyforge.cmd_score.get_coaching_level', return_value='coach')
+def test_improvement_cycle_coach_skips_apply(
+    mock_coaching, mock_diag, mock_proposals, mock_exemplars,
+    mock_patterns, tmp_path, capsys
+):
+    """Coach mode should not attempt to apply proposals."""
+    cycle_dir = str(tmp_path / 'cycle-1')
+    os.makedirs(cycle_dir)
+    project_dir = str(tmp_path / 'project')
+    os.makedirs(os.path.join(project_dir, 'working'), exist_ok=True)
+
+    weights_file = str(tmp_path / 'craft-weights.csv')
+    with open(weights_file, 'w') as f:
+        f.write('principle|weight\nprose_repetition|5\n')
+
+    intent_csv = str(tmp_path / 'scene-intent.csv')
+    with open(intent_csv, 'w') as f:
+        f.write('id|function\n')
+
+    def fake_diagnosis(cd, pd, wf):
+        with open(os.path.join(cd, 'diagnosis.csv'), 'w') as f:
+            f.write(
+                'principle|scale|avg_score|worst_items|delta_from_last|priority|root_cause\n'
+                'prose_repetition|scene|1.8|s1||high|craft\n'
+            )
+    mock_diag.side_effect = fake_diagnosis
+
+    def fake_proposals(cd, wf):
+        with open(os.path.join(cd, 'proposals.csv'), 'w') as f:
+            f.write(
+                'id|principle|lever|target|change|rationale|status\n'
+                'p001|prose_repetition|craft_weight|global|weight 5 → 7|avg_score 1.8, priority high|pending\n'
+            )
+    mock_proposals.side_effect = fake_proposals
+
+    _run_improvement_cycle(
+        cycle=1, cycle_dir=cycle_dir, project_dir=project_dir,
+        weights_file=weights_file, plugin_dir='/fake',
+        intent_csv=intent_csv, title='Test',
+    )
+
+    captured = capsys.readouterr().out
+    assert 'proposals require interactive approval' in captured
+    # Coach mode must NOT apply proposals or show the apply phase
+    assert 'applying proposals' not in captured
+    assert 'Run storyforge write' not in captured
+    # Should still collect exemplars
+    assert 'Improvement cycle: collecting exemplars...' in captured
+    assert 'Improvement cycle: complete' in captured


### PR DESCRIPTION
## Summary
- Adds phase-level progress logging with elapsed times to the scoring improvement cycle
- Each phase (diagnosis, proposals, apply, exemplars) now logs start/completion with timing
- High-priority principle count included in proposal summary line
- Closes #195

## Test plan
- [x] 6 new tests in `test_score_logging.py` covering `_count_high_priority` and full cycle logging
- [ ] Run `storyforge score` on a project and verify logging appears at each phase boundary

🤖 Generated with [Claude Code](https://claude.ai/code)