### PR TITLE
Fix evaluate prompt caching: manuscript in cached system blocks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_evaluate.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate.py
@@ -301,6 +301,22 @@ def _build_file_list(project_dir, filter_mode, filter_value, range_start,
 # Prompt building
 # ============================================================================
 
+
+def _build_manuscript_text(scene_files: list[str], project_dir: str) -> str:
+    """Build inline manuscript content from scene/chapter files.
+
+    Returns the concatenated manuscript text for inclusion in system blocks.
+    """
+    parts = []
+    for sf in scene_files:
+        sf_path = os.path.join(project_dir, sf)
+        if os.path.isfile(sf_path):
+            parts.append(f'===== {sf} =====\n\n')
+            parts.append(open(sf_path).read())
+            parts.append(f'\n\n===== END {sf} =====\n')
+    return ''.join(parts)
+
+
 def _build_eval_prompt(evaluator, is_custom, api_mode, project_dir, plugin_dir,
                        scene_files, scope_description, input_type,
                        project_title, genre_display, logline,
@@ -347,15 +363,8 @@ def _build_eval_prompt(evaluator, is_custom, api_mode, project_dir, plugin_dir,
     else:
         persona = persona.replace('{AI_TELL_WORDS}', '')
 
-    # Inline manuscript content for API mode
-    manuscript_inline = ''
-    if api_mode:
-        for sf in scene_files:
-            sf_path = os.path.join(project_dir, sf)
-            if os.path.isfile(sf_path):
-                manuscript_inline += f'\n===== {sf} =====\n\n'
-                manuscript_inline += open(sf_path).read()
-                manuscript_inline += f'\n\n===== END {sf} =====\n'
+    # Manuscript content is now passed via system blocks for caching.
+    # See _build_manuscript_text() and the batch/direct launch code.
 
     # Final evaluation context
     final_block = ''
@@ -399,10 +408,8 @@ def _build_eval_prompt(evaluator, is_custom, api_mode, project_dir, plugin_dir,
 
     if api_mode:
         parts.extend([
-            '===== MANUSCRIPT =====\n',
-            manuscript_inline,
-            '\n===== INSTRUCTIONS =====\n',
-            'The manuscript is provided above. Evaluate it following the structure defined in your role description.\n',
+            '===== INSTRUCTIONS =====\n',
+            'The manuscript is provided in the system context. Evaluate it following the structure defined in your role description.\n',
         ])
     else:
         if input_type == 'chapters':
@@ -1048,6 +1055,16 @@ def main(argv=None):
 
     # Build shared context for prompt caching (batch + direct modes)
     system = build_shared_context(project_dir, model=eval_models[0] if eval_models else '')
+
+    # Append manuscript as a cached system block (shared across all evaluators)
+    if use_api_prompts:
+        manuscript_text = _build_manuscript_text(scene_files, project_dir)
+        if manuscript_text:
+            system = system + [
+                {'type': 'text',
+                 'text': f'===== MANUSCRIPT =====\n\n{manuscript_text}',
+                 'cache_control': {'type': 'ephemeral'}},
+            ]
 
     if eval_mode == 'batch':
 

--- a/tests/commands/test_cmd_evaluate.py
+++ b/tests/commands/test_cmd_evaluate.py
@@ -571,6 +571,55 @@ class TestBuildEvalPrompt:
         assert 'The cartographer studied her instruments.' in text
         assert '===== scenes/act1-sc01.md =====' in text
 
+    def test_build_manuscript_text_multiple_scenes(self, project_dir):
+        """_build_manuscript_text should concatenate multiple scene files."""
+        scenes_dir = os.path.join(project_dir, 'scenes')
+        for name, content in [('act1-sc01.md', 'Scene one content.'),
+                              ('act1-sc02.md', 'Scene two content.'),
+                              ('act2-sc01.md', 'Scene three content.')]:
+            with open(os.path.join(scenes_dir, name), 'w') as f:
+                f.write(content)
+
+        text = _build_manuscript_text(
+            ['scenes/act1-sc01.md', 'scenes/act1-sc02.md', 'scenes/act2-sc01.md'],
+            project_dir,
+        )
+        assert 'Scene one content.' in text
+        assert 'Scene two content.' in text
+        assert 'Scene three content.' in text
+        assert '===== scenes/act1-sc01.md =====' in text
+        assert '===== scenes/act2-sc01.md =====' in text
+
+    def test_build_manuscript_text_skips_missing_files(self, project_dir):
+        """_build_manuscript_text should skip files that don't exist."""
+        scene_path = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        with open(scene_path, 'w') as f:
+            f.write('Exists.')
+
+        text = _build_manuscript_text(
+            ['scenes/act1-sc01.md', 'scenes/nonexistent.md'],
+            project_dir,
+        )
+        assert 'Exists.' in text
+        assert 'nonexistent' not in text
+
+    def test_build_manuscript_text_empty_list(self, project_dir):
+        """_build_manuscript_text with no files returns empty string."""
+        assert _build_manuscript_text([], project_dir) == ''
+
+    def test_build_manuscript_text_chapter_files(self, project_dir):
+        """_build_manuscript_text should work with assembled chapter paths."""
+        ch_dir = os.path.join(project_dir, 'manuscript', 'chapters')
+        os.makedirs(ch_dir, exist_ok=True)
+        with open(os.path.join(ch_dir, 'chapter-01.md'), 'w') as f:
+            f.write('Chapter one assembled content.')
+
+        text = _build_manuscript_text(
+            ['manuscript/chapters/chapter-01.md'], project_dir,
+        )
+        assert 'Chapter one assembled content.' in text
+        assert '===== manuscript/chapters/chapter-01.md =====' in text
+
     def test_prompt_non_api_mode_no_inline(self, project_dir):
         """Non-API mode should reference files but not inline content."""
         plugin_dir = PLUGIN_DIR

--- a/tests/commands/test_cmd_evaluate.py
+++ b/tests/commands/test_cmd_evaluate.py
@@ -18,6 +18,7 @@ from storyforge.cmd_evaluate import (
     _load_custom_evaluators,
     _resolve_voice_guide,
     _build_eval_prompt,
+    _build_manuscript_text,
     _build_synthesis_prompt,
 )
 
@@ -548,14 +549,9 @@ class TestBuildEvalPrompt:
         assert prompt is not None
         assert 'fantasy' in prompt
 
-    def test_prompt_api_mode_includes_manuscript_inline(self, project_dir):
-        """API mode should inline scene content in prompt."""
+    def test_prompt_api_mode_references_system_manuscript(self, project_dir):
+        """API mode prompt should reference manuscript in system context."""
         plugin_dir = PLUGIN_DIR
-
-        # Write scene content
-        scene_path = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
-        with open(scene_path, 'w') as f:
-            f.write('The cartographer studied her instruments.')
 
         prompt = _build_eval_prompt(
             'first-reader', False, True, project_dir, plugin_dir,
@@ -563,7 +559,17 @@ class TestBuildEvalPrompt:
             'Test', 'fantasy', '', '', False, '20260101-000000', [],
         )
 
-        assert 'The cartographer studied her instruments.' in prompt
+        assert 'manuscript is provided in the system context' in prompt
+
+    def test_build_manuscript_text_inlines_content(self, project_dir):
+        """_build_manuscript_text should inline scene file content."""
+        scene_path = os.path.join(project_dir, 'scenes', 'act1-sc01.md')
+        with open(scene_path, 'w') as f:
+            f.write('The cartographer studied her instruments.')
+
+        text = _build_manuscript_text(['scenes/act1-sc01.md'], project_dir)
+        assert 'The cartographer studied her instruments.' in text
+        assert '===== scenes/act1-sc01.md =====' in text
 
     def test_prompt_non_api_mode_no_inline(self, project_dir):
         """Non-API mode should reference files but not inline content."""


### PR DESCRIPTION
## Summary
- Manuscript content (~115k tokens) was duplicated across all 6 evaluators as a plain string with no `cache_control`
- Now built once via `_build_manuscript_text()` and appended to system blocks with `cache_control: ephemeral`
- After the first evaluator, the API caches the manuscript and reuses it for the remaining 5
- Works for both `--manuscript` (assembled chapters) and default (scene files) modes
- Works for both batch and direct API modes

## Cost impact
For a 6-evaluator batch with a full manuscript (~115k tokens):
- **Before**: 6 × 115k = ~690k uncached input tokens
- **After**: 115k cached write + 5 × 115k cached reads (90% discount) = ~172k effective tokens
- **Savings**: ~75% reduction in input token cost for evaluate

## Test plan
- [x] All 54 evaluate tests pass
- [ ] Run `storyforge evaluate --dry-run` and verify prompts reference system context
- [ ] Run `storyforge evaluate --manuscript --final` on slipform and verify batch completes with cache hits

🤖 Generated with [Claude Code](https://claude.ai/code)