### PR TITLE
Fix cover image priority: prefer jpg over png/svg

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/assembly.py
+++ b/scripts/lib/python/storyforge/assembly.py
@@ -1257,15 +1257,26 @@ def generate_publish_manifest(project_dir: str, cover_path: str | None = None,
 
 
 def _resolve_cover_path(project_dir: str, cover_path: str | None) -> str | None:
-    """Resolve a cover image path, auto-detecting if not provided."""
+    """Resolve a cover image path, auto-detecting if not provided.
+
+    Priority: explicit cover_path > production.cover_image YAML field >
+    auto-detect from production/ then manuscript/assets/ (jpg first).
+    """
     if cover_path:
         if os.path.isabs(cover_path):
             return cover_path
         return os.path.join(project_dir, cover_path)
 
-    # Auto-detect from standard locations
+    # Check production.cover_image YAML field
+    cover_image = read_production_field(project_dir, 'cover_image')
+    if cover_image:
+        full = os.path.join(project_dir, cover_image)
+        if os.path.isfile(full):
+            return full
+
+    # Auto-detect from standard locations (jpg preferred for publishing)
     for directory in ('production', 'manuscript/assets'):
-        for ext in ('png', 'jpg', 'jpeg', 'svg'):
+        for ext in ('jpg', 'jpeg', 'png', 'webp', 'svg'):
             candidate = os.path.join(project_dir, directory, f'cover.{ext}')
             if os.path.isfile(candidate):
                 return candidate

--- a/scripts/lib/python/storyforge/assembly.py
+++ b/scripts/lib/python/storyforge/assembly.py
@@ -1268,11 +1268,16 @@ def _resolve_cover_path(project_dir: str, cover_path: str | None) -> str | None:
         return os.path.join(project_dir, cover_path)
 
     # Check production.cover_image YAML field
-    cover_image = read_production_field(project_dir, 'cover_image')
+    try:
+        cover_image = read_production_field(project_dir, 'cover_image')
+    except Exception:
+        cover_image = ''
     if cover_image:
         full = os.path.join(project_dir, cover_image)
         if os.path.isfile(full):
             return full
+        from storyforge.common import log
+        log(f'WARNING: production.cover_image set to {cover_image!r} but file not found, falling back to auto-detect')
 
     # Auto-detect from standard locations (jpg preferred for publishing)
     for directory in ('production', 'manuscript/assets'):

--- a/tests/integration/test_assembly.py
+++ b/tests/integration/test_assembly.py
@@ -746,7 +746,7 @@ class TestResolveCoverPath:
         result = _resolve_cover_path(str(tmp_path), 'assets/cover.png')
         assert result == os.path.join(str(tmp_path), 'assets/cover.png')
 
-    def test_auto_detects_production_cover(self, tmp_path):
+    def test_auto_detects_production_png(self, tmp_path):
         prod = tmp_path / 'production'
         prod.mkdir()
         (prod / 'cover.png').write_text('img')
@@ -776,6 +776,13 @@ class TestResolveCoverPath:
         result = _resolve_cover_path(str(tmp_path), None)
         assert result == str(prod / 'cover.jpg')
 
+    def test_auto_detects_webp(self, tmp_path):
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.webp').write_text('webp')
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(prod / 'cover.webp')
+
     def test_cover_image_yaml_field(self, tmp_path, monkeypatch):
         """production.cover_image YAML field should be checked before auto-detect."""
         prod = tmp_path / 'production'
@@ -791,6 +798,32 @@ class TestResolveCoverPath:
         )
         result = _resolve_cover_path(str(tmp_path), None)
         assert result == str(custom)
+
+    def test_cover_image_yaml_missing_file_falls_back(self, tmp_path, monkeypatch, capsys):
+        """When cover_image YAML points to a missing file, warn and fall back."""
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.jpg').write_text('fallback')
+
+        monkeypatch.setattr(
+            'storyforge.assembly.read_production_field',
+            lambda pd, field: 'nonexistent/cover.png' if field == 'cover_image' else None,
+        )
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(prod / 'cover.jpg')
+        assert 'WARNING' in capsys.readouterr().out
+
+    def test_cover_image_yaml_read_error_falls_back(self, tmp_path, monkeypatch):
+        """When read_production_field raises, fall back to auto-detect."""
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.jpg').write_text('fallback')
+
+        def _raise(*a, **kw):
+            raise OSError('permission denied')
+        monkeypatch.setattr('storyforge.assembly.read_production_field', _raise)
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(prod / 'cover.jpg')
 
     def test_no_cover_returns_none(self, tmp_path):
         assert _resolve_cover_path(str(tmp_path), None) is None

--- a/tests/integration/test_assembly.py
+++ b/tests/integration/test_assembly.py
@@ -760,6 +760,38 @@ class TestResolveCoverPath:
         result = _resolve_cover_path(str(tmp_path), None)
         assert result == str(assets / 'cover.jpg')
 
+    def test_jpg_preferred_over_png(self, tmp_path):
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.png').write_text('png')
+        (prod / 'cover.jpg').write_text('jpg')
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(prod / 'cover.jpg')
+
+    def test_jpg_preferred_over_svg(self, tmp_path):
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.svg').write_text('svg')
+        (prod / 'cover.jpg').write_text('jpg')
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(prod / 'cover.jpg')
+
+    def test_cover_image_yaml_field(self, tmp_path, monkeypatch):
+        """production.cover_image YAML field should be checked before auto-detect."""
+        prod = tmp_path / 'production'
+        prod.mkdir()
+        (prod / 'cover.svg').write_text('svg')
+        custom = tmp_path / 'assets' / 'final-cover.jpg'
+        custom.parent.mkdir(parents=True)
+        custom.write_text('custom')
+
+        monkeypatch.setattr(
+            'storyforge.assembly.read_production_field',
+            lambda pd, field: 'assets/final-cover.jpg' if field == 'cover_image' else None,
+        )
+        result = _resolve_cover_path(str(tmp_path), None)
+        assert result == str(custom)
+
     def test_no_cover_returns_none(self, tmp_path):
         assert _resolve_cover_path(str(tmp_path), None) is None
 


### PR DESCRIPTION
## Summary
- `_resolve_cover_path` now prefers jpg over png/svg when auto-detecting cover images
- Also checks the `production.cover_image` YAML field before falling back to auto-detect
- Priority chain: explicit `cover_path` arg > `cover_image` YAML field > auto-detect (jpg > jpeg > png > webp > svg)

## Problem
When a jpg cover existed alongside the original png/svg, publish picked up the wrong one because auto-detect searched png before jpg.

## Test plan
- [x] 3 new tests: jpg-over-png, jpg-over-svg, cover_image YAML field
- [x] All 8 cover path tests pass
- [x] All 20 publish API tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)