### PR TITLE
Fix hone crashes and revise plan writing (#199)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -222,7 +222,7 @@ def _resolve_targets_to_scene_ids(targets, valid_scene_ids, ref_dir):
             need_character_lookup.append(t)
 
     if not need_character_lookup:
-        return resolved
+        return sorted(set(resolved))
 
     # Try to resolve character names via scene-intent.csv characters column
     intent_path = os.path.join(ref_dir, 'scene-intent.csv')
@@ -2147,7 +2147,11 @@ def main(argv=None):
                 from storyforge.elaborate import _read_csv_as_map
                 valid_ids = set(_read_csv_as_map(target_csv).keys())
                 raw_targets = [t.strip() for t in targets.split(';') if t.strip()]
-                target_scenes = _resolve_targets_to_scene_ids(raw_targets, valid_ids, ref_dir) or None
+                target_scenes = _resolve_targets_to_scene_ids(raw_targets, valid_ids, ref_dir)
+                if not target_scenes:
+                    log(f'  WARNING: No valid scene IDs resolved from targets "{targets}" — skipping pass')
+                    _update_pass_field(plan_rows, pass_num, 'status', 'failed', csv_plan_file)
+                    continue
             else:
                 target_scenes = None
 

--- a/scripts/lib/python/storyforge/cmd_revise.py
+++ b/scripts/lib/python/storyforge/cmd_revise.py
@@ -170,20 +170,85 @@ def _file_hash(path):
         return hashlib.sha256(f.read()).hexdigest()
 
 
-def _write_hone_findings(path, fix_location, targets, guidance):
-    """Write a findings file for hone from revision plan pass data."""
+def _write_hone_findings(path, fix_location, targets, guidance, ref_dir=''):
+    """Write a findings file for hone from revision plan pass data.
+
+    When *targets* is empty (full scope), reads the target CSV and expands to
+    all scene IDs so that ``load_external_findings`` can match them.
+
+    When targets contain values that are not valid scene IDs (e.g. character
+    names), they are resolved to the scenes where each character appears via the
+    ``characters`` column in scene-intent.csv.
+    """
     os.makedirs(os.path.dirname(path), exist_ok=True)
     target_file = 'scene-briefs.csv' if fix_location == 'brief' else 'scene-intent.csv'
-    scene_ids = [t.strip() for t in targets.split(';') if t.strip()] if targets else []
+    raw_targets = [t.strip() for t in targets.split(';') if t.strip()] if targets else []
     safe_guidance = _sanitize_csv_field(guidance)
+
+    # Determine the set of valid scene IDs from the target CSV
+    valid_scene_ids: set[str] = set()
+    if ref_dir:
+        csv_path = os.path.join(ref_dir, target_file)
+        if os.path.isfile(csv_path):
+            from storyforge.elaborate import _read_csv_as_map
+            valid_scene_ids = set(_read_csv_as_map(csv_path).keys())
+
+    if not raw_targets:
+        # Full scope — expand to all scene IDs from the target CSV
+        scene_ids = sorted(valid_scene_ids) if valid_scene_ids else []
+    elif valid_scene_ids:
+        # Resolve any non-scene-ID targets (e.g. character names) to scenes
+        scene_ids = _resolve_targets_to_scene_ids(raw_targets, valid_scene_ids, ref_dir)
+    else:
+        scene_ids = raw_targets
+
     with open(path, 'w') as f:
         f.write('scene_id|target_file|fields|guidance\n')
         if not scene_ids:
-            # Global scope — write a single row with empty scene_id
-            f.write(f'|{target_file}||{safe_guidance}\n')
+            log('  WARNING: No scene IDs to write in findings file')
+        for sid in scene_ids:
+            f.write(f'{sid}|{target_file}||{safe_guidance}\n')
+
+
+def _resolve_targets_to_scene_ids(targets, valid_scene_ids, ref_dir):
+    """Resolve targets to scene IDs, expanding character names via scene-intent.csv."""
+    resolved = []
+    need_character_lookup = []
+
+    for t in targets:
+        if t in valid_scene_ids:
+            resolved.append(t)
         else:
-            for sid in scene_ids:
-                f.write(f'{sid}|{target_file}||{safe_guidance}\n')
+            need_character_lookup.append(t)
+
+    if not need_character_lookup:
+        return resolved
+
+    # Try to resolve character names via scene-intent.csv characters column
+    intent_path = os.path.join(ref_dir, 'scene-intent.csv')
+    if not os.path.isfile(intent_path):
+        for name in need_character_lookup:
+            log(f'  WARNING: Target "{name}" is not a valid scene ID and '
+                f'scene-intent.csv not found for character lookup — skipping')
+        return resolved
+
+    from storyforge.elaborate import _read_csv_as_map
+    intent_map = _read_csv_as_map(intent_path)
+
+    for name in need_character_lookup:
+        name_lower = name.lower()
+        matching_scenes = []
+        for sid, row in intent_map.items():
+            chars = [c.strip().lower() for c in row.get('characters', '').split(';') if c.strip()]
+            if name_lower in chars:
+                matching_scenes.append(sid)
+        if matching_scenes:
+            log(f'  Resolved character "{name}" to {len(matching_scenes)} scenes')
+            resolved.extend(matching_scenes)
+        else:
+            log(f'  WARNING: Target "{name}" is not a valid scene ID or character name — skipping')
+
+    return sorted(set(resolved))
 
 
 def _redraft_from_briefs(project_dir, scene_ids, model, log_dir, system=None):
@@ -2065,18 +2130,26 @@ def main(argv=None):
             start_time = time.time()
             pass_model = select_revision_model(pass_name, pass_purpose)
 
+            ref_dir = os.path.join(project_dir, 'reference')
+
             findings_path = os.path.join(
                 project_dir, 'working', 'plans',
                 f'hone-findings-{pass_name}.csv')
-            _write_hone_findings(findings_path, fix_location, targets, guidance)
+            _write_hone_findings(findings_path, fix_location, targets, guidance, ref_dir=ref_dir)
 
             target_csv = os.path.join(
                 project_dir, 'reference',
                 'scene-briefs.csv' if fix_location == 'brief' else 'scene-intent.csv')
             old_hash = _file_hash(target_csv)
 
-            ref_dir = os.path.join(project_dir, 'reference')
-            target_scenes = [t.strip() for t in targets.split(';') if t.strip()] if targets else None
+            # Resolve targets to valid scene IDs (handles character names, full scope)
+            if targets:
+                from storyforge.elaborate import _read_csv_as_map
+                valid_ids = set(_read_csv_as_map(target_csv).keys())
+                raw_targets = [t.strip() for t in targets.split(';') if t.strip()]
+                target_scenes = _resolve_targets_to_scene_ids(raw_targets, valid_ids, ref_dir) or None
+            else:
+                target_scenes = None
 
             log(f'  Delegating to hone ({fix_location}) for {len(target_scenes) if target_scenes else "all"} scenes...')
 

--- a/scripts/lib/python/storyforge/hone.py
+++ b/scripts/lib/python/storyforge/hone.py
@@ -1505,6 +1505,9 @@ def hone_briefs(
     total_scenes = len(by_scene)
 
     for idx, (sid, issues) in enumerate(by_scene.items(), 1):
+        if sid not in briefs_map:
+            log(f'  [{idx}/{total_scenes}] WARNING: "{sid}" is not a valid scene ID in scene-briefs.csv — skipping')
+            continue
         abstract_issues = [i for i in issues if i['issue'] == 'abstract']
         trim_issues = [i for i in issues if i['issue'] in ('overspecified', 'verbose')]
         issue_types = sorted(set(i['issue'] for i in issues))

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -140,7 +140,7 @@ Each upstream pass automatically re-drafts affected scenes from updated briefs.
 
 ### Plan Format
 
-Write the plan to `working/plans/revision-plan.csv`:
+The plan is a pipe-delimited CSV at `working/plans/revision-plan.csv`:
 
 ```
 pass|name|purpose|scope|targets|guidance|protection|findings|status|model_tier|fix_location
@@ -149,15 +149,43 @@ pass|name|purpose|scope|targets|guidance|protection|findings|status|model_tier|f
 3|prose-tightening|Voice consistency and AI pattern cleanup|full||Follow voice guide strictly|scene-30b|F012;F015|pending|opus|craft
 ```
 
+### Writing the Plan — MANDATORY
+
+**You MUST write the plan CSV to disk immediately.** Do not just present it in conversation — `./storyforge revise` reads the file from disk.
+
+Use the versioned plan writer to write the file AND create the symlink:
+
+```bash
+python3 -c "
+from storyforge.cmd_revise import _create_versioned_plan, CSV_PLAN_FIELDS
+import os
+plan_file = os.path.join('PROJECT_DIR', 'working', 'plans', 'revision-plan.csv')
+rows = [
+    {'pass': '1', 'name': 'NAME', 'purpose': 'PURPOSE', 'scope': 'SCOPE', 'targets': '', 'guidance': 'GUIDANCE', 'protection': '', 'findings': '', 'status': 'pending', 'model_tier': 'sonnet', 'fix_location': 'brief'},
+]
+_create_versioned_plan(plan_file, rows)
+print(f'Plan written: {plan_file}')
+"
+```
+
+Replace `PROJECT_DIR` and the rows with actual values. After writing, verify:
+```bash
+ls -la PROJECT_DIR/working/plans/revision-plan.csv
+```
+
+If you cannot run `_create_versioned_plan` (e.g. import issues), write the CSV directly:
+1. Write the plan to `working/plans/revision-plan.csv` as a pipe-delimited CSV
+2. Verify the file exists and has the correct header
+
 ### Presenting the Plan
 
-Present each pass with:
+After writing the plan to disk, present each pass with:
 - Name and purpose
 - Which scenes are affected
 - What will change (upstream CSV updates or prose edits)
 - Key guidance decisions (with rationale the author can review)
 
-Ask the author to approve before executing. They can edit any guidance entry.
+Ask the author to approve before executing. They can edit any guidance entry — if they do, update the file on disk immediately. The plan is always on disk and ready to run.
 
 ## Step 4: Execute the Revision
 

--- a/tests/test_hone_findings.py
+++ b/tests/test_hone_findings.py
@@ -83,3 +83,78 @@ class TestHoneBriefsWithFindings:
         from storyforge.hone import hone_briefs
         sig = inspect.signature(hone_briefs)
         assert 'findings_file' in sig.parameters
+
+    def test_invalid_scene_id_skipped_not_crash(self, project_dir):
+        """Regression #199: non-scene-ID targets must not crash hone_briefs."""
+        from storyforge.hone import hone_briefs
+        ref_dir = os.path.join(project_dir, 'reference')
+
+        # Write a findings file with an invalid scene ID (character name)
+        findings = os.path.join(project_dir, 'working', 'findings.csv')
+        os.makedirs(os.path.dirname(findings), exist_ok=True)
+        with open(findings, 'w') as f:
+            f.write('scene_id|target_file|fields|guidance\n')
+            f.write('not-a-real-scene|scene-briefs.csv|goal|Fix this\n')
+
+        # Should not raise KeyError
+        result = hone_briefs(
+            ref_dir=ref_dir,
+            project_dir=project_dir,
+            scene_ids=['not-a-real-scene'],
+            coaching_level='full',
+            dry_run=True,
+            findings_file=findings,
+        )
+        assert isinstance(result, dict)
+
+
+class TestHoneIntentWithFindings:
+    def test_invalid_scene_id_skipped_not_crash(self, project_dir):
+        """Regression #199: non-scene-ID targets must not crash hone_intent."""
+        from storyforge.hone import hone_intent
+        ref_dir = os.path.join(project_dir, 'reference')
+
+        findings = os.path.join(project_dir, 'working', 'findings.csv')
+        os.makedirs(os.path.dirname(findings), exist_ok=True)
+        with open(findings, 'w') as f:
+            f.write('scene_id|target_file|fields|guidance\n')
+            f.write('not-a-real-scene|scene-intent.csv|function|Fix this\n')
+
+        result = hone_intent(
+            ref_dir=ref_dir,
+            project_dir=project_dir,
+            scene_ids=['not-a-real-scene'],
+            coaching_level='full',
+            dry_run=True,
+            findings_file=findings,
+        )
+        assert isinstance(result, dict)
+
+
+class TestResolveTargetsToSceneIds:
+    def test_valid_scene_ids_pass_through(self):
+        """Valid scene IDs should pass through unchanged."""
+        from storyforge.cmd_revise import _resolve_targets_to_scene_ids
+        valid = {'scene-a', 'scene-b', 'scene-c'}
+        result = _resolve_targets_to_scene_ids(['scene-a', 'scene-b'], valid, '/tmp')
+        assert result == ['scene-a', 'scene-b']
+
+    def test_character_names_resolve_to_scenes(self, fixture_dir):
+        """Character names should resolve to scenes via scene-intent.csv."""
+        from storyforge.cmd_revise import _resolve_targets_to_scene_ids
+        from storyforge.elaborate import _read_csv_as_map
+        ref_dir = os.path.join(fixture_dir, 'reference')
+        briefs_map = _read_csv_as_map(os.path.join(ref_dir, 'scene-briefs.csv'))
+        valid = set(briefs_map.keys())
+        # "Pell" is a character in the fixture
+        result = _resolve_targets_to_scene_ids(['Pell'], valid, ref_dir)
+        assert len(result) > 0
+        assert 'Pell' not in result  # resolved to scene IDs
+
+    def test_unknown_targets_skipped(self, fixture_dir):
+        """Targets that are neither scene IDs nor character names are skipped."""
+        from storyforge.cmd_revise import _resolve_targets_to_scene_ids
+        ref_dir = os.path.join(fixture_dir, 'reference')
+        valid = {'scene-a'}
+        result = _resolve_targets_to_scene_ids(['nonexistent-thing'], valid, ref_dir)
+        assert result == []

--- a/tests/test_revise_upstream.py
+++ b/tests/test_revise_upstream.py
@@ -49,27 +49,79 @@ class TestWriteHoneFindings:
             content = f.read()
         assert 'scene-intent.csv' in content
 
-    def test_empty_targets_writes_global_scope_row(self, tmp_path):
-        """Regression: empty targets must produce a global-scope row, not an empty file."""
+    def test_empty_targets_no_ref_dir_writes_header_only(self, tmp_path):
+        """Without ref_dir, empty targets produces header-only file with warning."""
         from storyforge.cmd_revise import _write_hone_findings
         path = str(tmp_path / 'findings.csv')
         _write_hone_findings(path, 'brief', '', 'General fix')
 
         with open(path) as f:
             lines = f.read().strip().split('\n')
-        assert len(lines) == 2  # Header + one global-scope row
-        assert lines[1].startswith('|scene-briefs.csv||General fix')
+        assert len(lines) == 1  # Header only — no data rows
 
-    def test_empty_targets_intent_target_file(self, tmp_path):
-        """Global scope for intent fix_location uses scene-intent.csv."""
+    def test_empty_targets_with_ref_dir_expands_to_all_scenes(self, tmp_path, fixture_dir):
+        """Regression #199: full-scope pass must expand to all scene IDs from the CSV."""
         from storyforge.cmd_revise import _write_hone_findings
+        ref_dir = os.path.join(fixture_dir, 'reference')
         path = str(tmp_path / 'findings.csv')
-        _write_hone_findings(path, 'intent', '', 'Fix intent globally')
+        _write_hone_findings(path, 'brief', '', 'General fix', ref_dir=ref_dir)
 
         with open(path) as f:
             lines = f.read().strip().split('\n')
-        assert len(lines) == 2
-        assert 'scene-intent.csv' in lines[1]
+        # Header + one row per scene in scene-briefs.csv
+        assert len(lines) > 1
+        # Every data row should have a non-empty scene_id
+        for line in lines[1:]:
+            sid = line.split('|')[0]
+            assert sid, f'Empty scene_id in findings row: {line}'
+            assert 'scene-briefs.csv' in line
+
+    def test_empty_targets_intent_expands_to_all_scenes(self, tmp_path, fixture_dir):
+        """Full scope for intent fix_location expands to all scene IDs."""
+        from storyforge.cmd_revise import _write_hone_findings
+        ref_dir = os.path.join(fixture_dir, 'reference')
+        path = str(tmp_path / 'findings.csv')
+        _write_hone_findings(path, 'intent', '', 'Fix intent globally', ref_dir=ref_dir)
+
+        with open(path) as f:
+            lines = f.read().strip().split('\n')
+        assert len(lines) > 1
+        for line in lines[1:]:
+            sid = line.split('|')[0]
+            assert sid, f'Empty scene_id in findings row: {line}'
+            assert 'scene-intent.csv' in line
+
+    def test_character_name_targets_resolve_to_scenes(self, tmp_path, fixture_dir):
+        """Regression #199: character name targets must resolve to scene IDs."""
+        from storyforge.cmd_revise import _write_hone_findings
+        ref_dir = os.path.join(fixture_dir, 'reference')
+        path = str(tmp_path / 'findings.csv')
+        # "Pell" is a character in the fixture's scene-intent.csv
+        _write_hone_findings(path, 'brief', 'Pell', 'Fix Pell scenes', ref_dir=ref_dir)
+
+        with open(path) as f:
+            lines = f.read().strip().split('\n')
+        assert len(lines) > 1
+        # All data rows should have valid scene IDs, not "Pell"
+        for line in lines[1:]:
+            sid = line.split('|')[0]
+            assert sid != 'Pell', 'Character name should be resolved to scene IDs'
+            assert sid, f'Empty scene_id in findings row: {line}'
+
+    def test_mixed_scene_ids_and_character_names(self, tmp_path, fixture_dir):
+        """Mix of valid scene IDs and character names resolves correctly."""
+        from storyforge.cmd_revise import _write_hone_findings
+        ref_dir = os.path.join(fixture_dir, 'reference')
+        path = str(tmp_path / 'findings.csv')
+        # act1-sc01 is a valid scene ID, "Pell" is a character name
+        _write_hone_findings(path, 'intent', 'act1-sc01;Pell', 'Fix things', ref_dir=ref_dir)
+
+        with open(path) as f:
+            lines = f.read().strip().split('\n')
+        scene_ids = [line.split('|')[0] for line in lines[1:]]
+        assert 'act1-sc01' in scene_ids
+        # Pell should be resolved, not kept as raw target
+        assert 'Pell' not in scene_ids
 
 
 class TestGenerateStructuralPlan:


### PR DESCRIPTION
## Summary

- **Full-scope intent passes** wrote empty `scene_id` in findings files, which `load_external_findings` silently skipped → hone reported "no changes." Now `_write_hone_findings` expands empty targets to all scene IDs from the target CSV.
- **Character-name targets** (e.g. `croy`) flowed through as `scene_id` values → `KeyError` in `hone_briefs`. New `_resolve_targets_to_scene_ids` resolves character names to scenes via `scene-intent.csv`, and `hone_briefs` guards against invalid IDs.
- **Unresolved targets** no longer silently fall back to full scope — the pass is skipped with a warning.
- **Revise skill** now mandates writing the plan CSV to disk immediately (with `_create_versioned_plan`) before presenting, fixing "nothing to do" when running `./storyforge revise`.

Closes #199

## Test plan

- [x] 3397 tests pass, 10 skipped
- [x] New regression tests for empty scene_id expansion, character name resolution, mixed targets, invalid scene ID guards in hone_briefs and hone_intent
- [x] Code review addressed: unresolved targets fail the pass instead of running on all scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)