### PR TITLE
Gzip publish, cover optimization, structured dashboard data

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.17.6",
+  "version": "1.18.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/assembly.py
+++ b/scripts/lib/python/storyforge/assembly.py
@@ -1241,8 +1241,13 @@ def generate_publish_manifest(project_dir: str, cover_path: str | None = None,
                 manifest['dashboard_html'] = f.read()
 
     # Always include structured dashboard data for server-side rendering
-    from storyforge.visualize import load_dashboard_data
-    manifest['dashboard_data'] = load_dashboard_data(project_dir)
+    try:
+        from storyforge.visualize import load_dashboard_data
+        manifest['dashboard_data'] = load_dashboard_data(project_dir)
+    except Exception as exc:
+        from storyforge.common import log as _log
+        _log(f'WARNING: Could not load dashboard data: {exc}')
+        manifest['dashboard_data'] = {}
 
     # Embed cover as base64 if requested
     if include_cover:
@@ -1339,7 +1344,7 @@ def _optimize_cover_image(cover_path: str, project_dir: str) -> str:
             log(f'Cover: resized from {width}x{height} to max {_COVER_MAX_DIMENSION}px '
                 f'({new_size:,} bytes)')
     except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
-        pass  # resize failed — use whatever we have
+        log('WARNING: cover resize failed, using converted image as-is')
 
     return optimized
 

--- a/scripts/lib/python/storyforge/assembly.py
+++ b/scripts/lib/python/storyforge/assembly.py
@@ -1240,13 +1240,18 @@ def generate_publish_manifest(project_dir: str, cover_path: str | None = None,
             with open(dashboard_path) as f:
                 manifest['dashboard_html'] = f.read()
 
+    # Always include structured dashboard data for server-side rendering
+    from storyforge.visualize import load_dashboard_data
+    manifest['dashboard_data'] = load_dashboard_data(project_dir)
+
     # Embed cover as base64 if requested
     if include_cover:
         resolved = _resolve_cover_path(project_dir, cover_path)
         if resolved and os.path.isfile(resolved):
-            with open(resolved, 'rb') as f:
+            optimized = _optimize_cover_image(resolved, project_dir)
+            with open(optimized, 'rb') as f:
                 manifest['cover_base64'] = base64.b64encode(f.read()).decode('ascii')
-            manifest['cover_extension'] = os.path.splitext(resolved)[1]
+            manifest['cover_extension'] = os.path.splitext(optimized)[1]
 
     output_path = os.path.join(project_dir, 'working', 'publish-manifest.json')
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
@@ -1254,6 +1259,89 @@ def generate_publish_manifest(project_dir: str, cover_path: str | None = None,
         json.dump(manifest, f, indent=2, ensure_ascii=False)
 
     return output_path
+
+
+_COVER_MAX_DIMENSION = 1600
+_COVER_MAX_BYTES = 500_000  # 500 KB — skip optimization if already small
+
+
+def _optimize_cover_image(cover_path: str, project_dir: str) -> str:
+    """Optimize a cover image for publishing.
+
+    Converts PNG to JPEG and resizes if either dimension exceeds
+    _COVER_MAX_DIMENSION.  Uses macOS ``sips`` (available on Darwin).
+    Returns path to the optimized file in working/, or the original
+    path if optimization is unnecessary or unavailable.
+    """
+    import platform
+    import shutil
+    import subprocess
+
+    file_size = os.path.getsize(cover_path)
+    ext = os.path.splitext(cover_path)[1].lower()
+
+    # Skip if already small enough
+    if file_size <= _COVER_MAX_BYTES and ext in ('.jpg', '.jpeg'):
+        return cover_path
+
+    # sips is macOS-only
+    if platform.system() != 'Darwin':
+        from storyforge.common import log
+        if file_size > _COVER_MAX_BYTES:
+            log(f'WARNING: Cover image is {file_size:,} bytes — '
+                f'optimization requires macOS sips')
+        return cover_path
+
+    from storyforge.common import log
+    working_dir = os.path.join(project_dir, 'working')
+    os.makedirs(working_dir, exist_ok=True)
+
+    # Convert PNG/WebP to JPEG for smaller size
+    if ext in ('.png', '.webp'):
+        optimized = os.path.join(working_dir, 'cover-optimized.jpg')
+        shutil.copy2(cover_path, optimized)
+        try:
+            subprocess.run(
+                ['sips', '-s', 'format', 'jpeg',
+                 '-s', 'formatOptions', '85',
+                 optimized, '--out', optimized],
+                capture_output=True, check=True,
+            )
+            log(f'Cover: converted {ext} to JPEG '
+                f'({file_size:,} → {os.path.getsize(optimized):,} bytes)')
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            log(f'WARNING: sips conversion failed, using original')
+            return cover_path
+    else:
+        optimized = os.path.join(working_dir, f'cover-optimized{ext}')
+        shutil.copy2(cover_path, optimized)
+
+    # Resize if dimensions are too large
+    try:
+        result = subprocess.run(
+            ['sips', '-g', 'pixelWidth', '-g', 'pixelHeight', optimized],
+            capture_output=True, text=True, check=True,
+        )
+        width = height = 0
+        for line in result.stdout.splitlines():
+            if 'pixelWidth' in line:
+                width = int(line.split(':')[-1].strip())
+            elif 'pixelHeight' in line:
+                height = int(line.split(':')[-1].strip())
+
+        if max(width, height) > _COVER_MAX_DIMENSION:
+            subprocess.run(
+                ['sips', '--resampleHeightWidthMax', str(_COVER_MAX_DIMENSION),
+                 optimized],
+                capture_output=True, check=True,
+            )
+            new_size = os.path.getsize(optimized)
+            log(f'Cover: resized from {width}x{height} to max {_COVER_MAX_DIMENSION}px '
+                f'({new_size:,} bytes)')
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        pass  # resize failed — use whatever we have
+
+    return optimized
 
 
 def _resolve_cover_path(project_dir: str, cover_path: str | None) -> str | None:

--- a/scripts/lib/python/storyforge/bookshelf.py
+++ b/scripts/lib/python/storyforge/bookshelf.py
@@ -114,7 +114,8 @@ def authenticate(supabase_url: str, supabase_anon_key: str,
 def publish(bookshelf_url: str, token: str, manifest: dict) -> dict:
     """Publish a book via the Bookshelf API.
 
-    Sends the manifest as a PUT request to /api/books/<slug>.
+    Sends the manifest as a gzip-compressed PUT request to /api/books/<slug>.
+    Falls back to uncompressed if the server returns 415 Unsupported Media Type.
 
     Args:
         bookshelf_url: Deployed bookshelf URL.
@@ -127,22 +128,45 @@ def publish(bookshelf_url: str, token: str, manifest: dict) -> dict:
     Raises:
         RuntimeError: If the API returns an error.
     """
+    import gzip
+
     slug = manifest.get('slug', '')
     if not slug:
         raise RuntimeError('Manifest missing slug field')
 
     url = f'{bookshelf_url.rstrip("/")}/api/books/{urllib.parse.quote(slug)}'
-    body = json.dumps(manifest, ensure_ascii=False).encode()
+    raw_body = json.dumps(manifest, ensure_ascii=False).encode()
+
+    # Log manifest size breakdown
+    _log_manifest_size(manifest, raw_body)
+
+    # Gzip compress the body
+    compressed_body = gzip.compress(raw_body)
+    log(f'Manifest compressed: {len(raw_body):,} → {len(compressed_body):,} bytes '
+        f'({100 - len(compressed_body) * 100 // len(raw_body)}% reduction)')
+
     headers = {
         'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
         'Authorization': f'Bearer {token}',
     }
 
-    req = urllib.request.Request(url, data=body, headers=headers, method='PUT')
+    req = urllib.request.Request(url, data=compressed_body, headers=headers, method='PUT')
     try:
         with urllib.request.urlopen(req, timeout=120) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
+        if e.code == 415:
+            # Server doesn't support gzip — fall back to uncompressed
+            log('Server does not support gzip, retrying uncompressed...')
+            headers.pop('Content-Encoding')
+            req = urllib.request.Request(url, data=raw_body, headers=headers, method='PUT')
+            try:
+                with urllib.request.urlopen(req, timeout=120) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as e2:
+                e = e2  # fall through to error handling below
+
         detail = e.read().decode(errors='replace') if e.fp else ''
         try:
             error_data = json.loads(detail)
@@ -157,6 +181,21 @@ def publish(bookshelf_url: str, token: str, manifest: dict) -> dict:
         ) from e
     except urllib.error.URLError as e:
         raise RuntimeError(f'Cannot reach Bookshelf: {e.reason}') from e
+
+
+def _log_manifest_size(manifest: dict, raw_body: bytes) -> None:
+    """Log a breakdown of manifest component sizes."""
+    parts = []
+    for key in ('dashboard_html', 'dashboard_data', 'cover_base64'):
+        val = manifest.get(key)
+        if val:
+            size = len(json.dumps(val, ensure_ascii=False).encode())
+            if size > 10_000:
+                parts.append(f'{key}: {size:,} bytes')
+    chapters_size = len(json.dumps(manifest.get('chapters', []), ensure_ascii=False).encode())
+    parts.append(f'chapters: {chapters_size:,} bytes')
+    parts.append(f'total: {len(raw_body):,} bytes')
+    log(f'Manifest size: {"; ".join(parts)}')
 
 
 # ============================================================================

--- a/tests/test_bookshelf.py
+++ b/tests/test_bookshelf.py
@@ -1,4 +1,5 @@
 """Tests for bookshelf API client module."""
+import gzip
 import json
 import os
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -36,12 +37,18 @@ class _MockHandler(BaseHTTPRequestHandler):
 
     def do_PUT(self):
         length = int(self.headers.get('Content-Length', 0))
-        body = self.rfile.read(length) if length else b''
+        raw = self.rfile.read(length) if length else b''
+        encoding = self.headers.get('Content-Encoding', '')
+        if encoding == 'gzip':
+            body = json.loads(gzip.decompress(raw))
+        else:
+            body = json.loads(raw) if raw else None
         _MockHandler.last_request = {
             'method': 'PUT',
             'path': self.path,
             'headers': dict(self.headers),
-            'body': json.loads(body) if body else None,
+            'body': body,
+            'was_gzipped': encoding == 'gzip',
         }
         self.send_response(_MockHandler.response_code)
         self.send_header('Content-Type', 'application/json')
@@ -206,6 +213,23 @@ class TestPublish:
 
         with pytest.raises(RuntimeError, match='upsert_scenes'):
             publish(mock_server, 'token', {'slug': 'test'})
+
+    def test_publish_sends_gzip(self, mock_server):
+        """Publish must gzip-compress the request body."""
+        from storyforge.bookshelf import publish
+        _MockHandler.response_body = json.dumps({
+            'ok': True, 'book_id': 'id', 'slug': 'test',
+            'published': {'chapters': 0, 'scenes': 0, 'words': 0},
+            'highlights': {'unchanged': 0, 'reanchored': 0, 'orphaned': 0},
+            'cover_uploaded': False,
+        }).encode()
+
+        manifest = {'title': 'T', 'author': 'A', 'slug': 'test', 'chapters': []}
+        publish(mock_server, 'token', manifest)
+
+        req = _MockHandler.last_request
+        assert req['was_gzipped'] is True
+        assert req['body']['slug'] == 'test'
 
 
 # ============================================================================

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -2,6 +2,8 @@
 import json
 import os
 
+import pytest
+
 
 def _make_project(tmp_path, scenes, chapters):
     """Helper to create a minimal project for manifest tests."""
@@ -127,3 +129,56 @@ class TestGeneratePublishManifest:
         html = manifest['chapters'][0]['scenes'][0]['content_html']
         assert 'title: Some Title' not in html
         assert 'Actual prose' in html
+
+    def test_includes_dashboard_data(self, tmp_path):
+        """Manifest should always include structured dashboard_data."""
+        from storyforge.assembly import generate_publish_manifest
+        proj = _make_project(tmp_path, ['s1'], [('Ch', ['s1'])])
+        # Need scene-intent.csv for load_dashboard_data
+        ref = os.path.join(proj, 'reference')
+        with open(os.path.join(ref, 'scene-intent.csv'), 'w') as f:
+            f.write('id|function|action_sequel|emotional_arc|value_at_stake|value_shift|turning_point|characters|on_stage|mice_threads\n')
+            f.write('s1|test fn|action|calm to tense|truth|+/-|revelation|A|A|\n')
+        path = generate_publish_manifest(proj)
+        with open(path) as f:
+            manifest = json.load(f)
+        assert 'dashboard_data' in manifest
+        assert 'scenes' in manifest['dashboard_data']
+        assert 'project' in manifest['dashboard_data']
+
+
+class TestOptimizeCoverImage:
+    def test_small_jpeg_returns_original(self, tmp_path):
+        """Small JPEG files should pass through without optimization."""
+        from storyforge.assembly import _optimize_cover_image
+        # Create a small fake JPEG (under threshold)
+        cover = tmp_path / 'cover.jpg'
+        cover.write_bytes(b'\xff\xd8\xff' + b'\x00' * 100)
+        result = _optimize_cover_image(str(cover), str(tmp_path))
+        assert result == str(cover)
+
+    def test_large_png_triggers_optimization(self, tmp_path):
+        """Large PNG files should be converted to optimized JPEG."""
+        import platform
+        import subprocess
+        from storyforge.assembly import _optimize_cover_image, _COVER_MAX_BYTES
+        if platform.system() != 'Darwin':
+            pytest.skip('sips only available on macOS')
+        # Create a real PNG using sips (convert a blank JPEG)
+        cover = tmp_path / 'cover.png'
+        # Create a large-ish test image
+        try:
+            subprocess.run(
+                ['sips', '-s', 'format', 'png', '-z', '2000', '2000',
+                 '/System/Library/Desktop Pictures/Solid Colors/Black.png',
+                 '--out', str(cover)],
+                capture_output=True, check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pytest.skip('Could not create test PNG with sips')
+        if cover.stat().st_size <= _COVER_MAX_BYTES:
+            pytest.skip('Test PNG not large enough to trigger optimization')
+        result = _optimize_cover_image(str(cover), str(tmp_path))
+        assert result != str(cover)
+        assert result.endswith('.jpg')
+        assert os.path.getsize(result) < cover.stat().st_size

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -157,16 +157,15 @@ class TestOptimizeCoverImage:
         result = _optimize_cover_image(str(cover), str(tmp_path))
         assert result == str(cover)
 
-    def test_large_png_triggers_optimization(self, tmp_path):
+    def test_large_png_triggers_optimization(self, tmp_path, monkeypatch):
         """Large PNG files should be converted to optimized JPEG."""
         import platform
         import subprocess
-        from storyforge.assembly import _optimize_cover_image, _COVER_MAX_BYTES
+        import storyforge.assembly as asm
         if platform.system() != 'Darwin':
             pytest.skip('sips only available on macOS')
-        # Create a real PNG using sips (convert a blank JPEG)
+        # Create a real PNG using sips
         cover = tmp_path / 'cover.png'
-        # Create a large-ish test image
         try:
             subprocess.run(
                 ['sips', '-s', 'format', 'png', '-z', '2000', '2000',
@@ -176,9 +175,9 @@ class TestOptimizeCoverImage:
             )
         except (subprocess.CalledProcessError, FileNotFoundError):
             pytest.skip('Could not create test PNG with sips')
-        if cover.stat().st_size <= _COVER_MAX_BYTES:
-            pytest.skip('Test PNG not large enough to trigger optimization')
-        result = _optimize_cover_image(str(cover), str(tmp_path))
+        # Lower the threshold so the test image triggers optimization
+        monkeypatch.setattr(asm, '_COVER_MAX_BYTES', 1000)
+        result = asm._optimize_cover_image(str(cover), str(tmp_path))
         assert result != str(cover)
         assert result.endswith('.jpg')
         assert os.path.getsize(result) < cover.stat().st_size


### PR DESCRIPTION
## Summary

- **Gzip compression**: Publish manifest is gzip-compressed before sending to Bookshelf API (Content-Encoding: gzip), with automatic fallback to uncompressed on 415. Logs manifest size breakdown before upload.
- **Cover optimization**: Large cover images are resized (max 1600px) and PNG/WebP converted to JPEG quality 85 via macOS `sips` before base64 encoding.
- **Structured dashboard data**: `dashboard_data` (scores, rationales, briefs, etc.) is now included as structured JSON in the manifest alongside `dashboard_html`, enabling future server-side dashboard rendering.

Companion PR in bookshelf: benjaminsnorris/bookshelf (feature/gzip-dashboard-data branch) adds gzip decompression and `dashboard_data` JSONB column.

Follow-up issues:
- benjaminsnorris/bookshelf#7 — Render dashboard from `dashboard_data`
- #201 — Stop generating/sending `dashboard_html` (depends on bookshelf#7)

## Test plan

- [x] 3400 tests pass, 11 skipped
- [x] Gzip compression verified via mock server test
- [x] Dashboard data included in manifest verified
- [x] Cover optimization skips small JPEGs, converts large PNGs
- [x] Bookshelf TypeScript type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)