### PR TITLE
Fix scoring diagnosis hang and PR comment crash (#203)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -275,7 +275,11 @@ def main(argv=None):
             sys.exit(1)
 
         log(f'Running diagnosis only from {diag_cycle_dir}')
-        diag_cycle = int(os.path.basename(diag_cycle_dir).replace('cycle-', ''))
+        try:
+            diag_cycle = int(os.path.basename(diag_cycle_dir).replace('cycle-', ''))
+        except ValueError:
+            log(f'ERROR: Could not determine cycle number from {diag_cycle_dir}')
+            sys.exit(1)
         _run_improvement_cycle(
             diag_cycle, diag_cycle_dir, project_dir, weights_file, plugin_dir,
             intent_csv, title,

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -70,6 +70,9 @@ def parse_args(argv):
     parser.add_argument('--parallel', type=int,
                         default=int(os.environ.get('STORYFORGE_SCORE_PARALLEL', '6')),
                         help='Parallel workers for direct mode (default: 6)')
+    parser.add_argument('--diagnosis-only', action='store_true',
+                        help='Generate diagnosis and proposals from existing scores '
+                             '(skip scoring, run improvement cycle only)')
     return parser.parse_args(argv)
 
 
@@ -249,6 +252,39 @@ def main(argv=None):
             targeted_principles, scene_ids, project_dir, cycle, cycle_dir,
             plugin_dir, weights_file, title,
         )
+        return
+
+    # =========================================================================
+    # Diagnosis-only fast path
+    # =========================================================================
+    # When --diagnosis-only is set, skip all scoring and run just the
+    # improvement cycle (diagnosis + proposals) from existing scores.
+
+    if args.diagnosis_only:
+        # Use latest cycle dir if it has scores, otherwise use current
+        latest_link = os.path.join(project_dir, 'working', 'scores', 'latest')
+        if os.path.islink(latest_link):
+            diag_cycle_dir = os.path.realpath(latest_link)
+        else:
+            diag_cycle_dir = cycle_dir
+
+        scores_file = os.path.join(diag_cycle_dir, 'scene-scores.csv')
+        if not os.path.isfile(scores_file):
+            log(f'ERROR: No scene-scores.csv found in {diag_cycle_dir}')
+            log('Run a full scoring cycle first, then use --diagnosis-only.')
+            sys.exit(1)
+
+        log(f'Running diagnosis only from {diag_cycle_dir}')
+        diag_cycle = int(os.path.basename(diag_cycle_dir).replace('cycle-', ''))
+        _run_improvement_cycle(
+            diag_cycle, diag_cycle_dir, project_dir, weights_file, plugin_dir,
+            intent_csv, title,
+        )
+        _generate_report_and_comment(
+            diag_cycle, diag_cycle_dir, project_dir, score_mode, scene_count,
+        )
+        commit_and_push(project_dir, f'Score: diagnosis-only cycle {diag_cycle}',
+                        ['working/'])
         return
 
     # Cost forecast
@@ -1593,8 +1629,8 @@ def _generate_report_and_comment(cycle, cycle_dir, project_dir, score_mode,
             pr_num = r.stdout.strip() if r.returncode == 0 else ''
             if pr_num:
                 subprocess.run(
-                    ['gh', 'pr', 'comment', pr_num, '--body', comment],
-                    capture_output=True, cwd=project_dir,
+                    ['gh', 'pr', 'comment', pr_num, '--body-file', '-'],
+                    input=comment.encode(), capture_output=True, cwd=project_dir,
                 )
                 log(f'Posted scoring summary to PR #{pr_num}')
 

--- a/scripts/lib/python/storyforge/history.py
+++ b/scripts/lib/python/storyforge/history.py
@@ -121,12 +121,17 @@ def get_scene_history(
     project_dir: str,
     scene_id: str,
     principle: str,
+    _rows: list[dict[str, str]] | None = None,
 ) -> list[tuple[int, float]]:
     """Return (cycle, score) tuples for one scene+principle, sorted by cycle.
 
     Returns [] if no history file exists or no matching rows.
+
+    Args:
+        _rows: Optional pre-loaded history rows (from ``_read_history``).
+            When provided, skips reading the file from disk.
     """
-    rows = _read_history(project_dir)
+    rows = _rows if _rows is not None else _read_history(project_dir)
     matches = [
         r for r in rows
         if r.get('scene_id') == scene_id and r.get('principle') == principle
@@ -145,6 +150,7 @@ def detect_stalls(
     principle: str,
     min_cycles: int = 2,
     max_score: float = 3.0,
+    _rows: list[dict[str, str]] | None = None,
 ) -> list[dict]:
     """Find scenes stuck at low scores for consecutive recent cycles.
 
@@ -152,10 +158,16 @@ def detect_stalls(
     with no improvement (the last score is not higher than the first of the
     trailing window).
 
+    Args:
+        _rows: Optional pre-loaded history rows (from ``_read_history``).
+            When provided, skips reading the file from disk.  Passing this
+            avoids O(N) redundant file reads when calling detect_stalls in
+            a loop.
+
     Returns list of:
       {scene_id, scores: [(cycle, score), ...], cycles_stalled: int}
     """
-    rows = _read_history(project_dir)
+    rows = _rows if _rows is not None else _read_history(project_dir)
     if not rows:
         return []
 
@@ -166,7 +178,7 @@ def detect_stalls(
 
     stalls = []
     for scene_id in scene_ids:
-        history = get_scene_history(project_dir, scene_id, principle)
+        history = get_scene_history(project_dir, scene_id, principle, _rows=rows)
         if len(history) < min_cycles:
             continue
 

--- a/scripts/lib/python/storyforge/history.py
+++ b/scripts/lib/python/storyforge/history.py
@@ -39,7 +39,7 @@ def _is_principle_column(col: str) -> bool:
     return True
 
 
-def _read_history(project_dir: str) -> list[dict[str, str]]:
+def read_history(project_dir: str) -> list[dict[str, str]]:
     """Read score-history.csv, return list of row dicts.
 
     Returns [] if the file does not exist.
@@ -131,7 +131,7 @@ def get_scene_history(
         _rows: Optional pre-loaded history rows (from ``_read_history``).
             When provided, skips reading the file from disk.
     """
-    rows = _rows if _rows is not None else _read_history(project_dir)
+    rows = _rows if _rows is not None else read_history(project_dir)
     matches = [
         r for r in rows
         if r.get('scene_id') == scene_id and r.get('principle') == principle
@@ -167,7 +167,7 @@ def detect_stalls(
     Returns list of:
       {scene_id, scores: [(cycle, score), ...], cycles_stalled: int}
     """
-    rows = _rows if _rows is not None else _read_history(project_dir)
+    rows = _rows if _rows is not None else read_history(project_dir)
     if not rows:
         return []
 
@@ -203,13 +203,18 @@ def detect_regressions(
     project_dir: str,
     principle: str,
     threshold: float = -0.5,
+    _rows: list[dict[str, str]] | None = None,
 ) -> list[dict]:
     """Find scenes where score dropped by >= |threshold| between consecutive cycles.
+
+    Args:
+        _rows: Optional pre-loaded history rows (from ``read_history``).
+            When provided, skips reading the file from disk.
 
     Returns list of:
       {scene_id, from_cycle, to_cycle, from_score, to_score, delta}
     """
-    rows = _read_history(project_dir)
+    rows = _rows if _rows is not None else read_history(project_dir)
     if not rows:
         return []
 
@@ -220,7 +225,7 @@ def detect_regressions(
 
     regressions = []
     for scene_id in scene_ids:
-        history = get_scene_history(project_dir, scene_id, principle)
+        history = get_scene_history(project_dir, scene_id, principle, _rows=rows)
         if len(history) < 2:
             continue
 

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -317,8 +317,8 @@ def _attribute_root_causes(diag_rows, diag_header, project_dir):
     # Pre-load history once — avoids O(N) redundant file reads
     history_rows = None
     try:
-        from storyforge.history import _read_history
-        history_rows = _read_history(project_dir)
+        from storyforge.history import read_history
+        history_rows = read_history(project_dir)
     except Exception:
         history_rows = []
 

--- a/scripts/lib/python/storyforge/scoring.py
+++ b/scripts/lib/python/storyforge/scoring.py
@@ -314,6 +314,14 @@ def _attribute_root_causes(diag_rows, diag_header, project_dir):
     ref_dir = os.path.join(project_dir, 'reference')
     brief_issue_scenes = None
 
+    # Pre-load history once — avoids O(N) redundant file reads
+    history_rows = None
+    try:
+        from storyforge.history import _read_history
+        history_rows = _read_history(project_dir)
+    except Exception:
+        history_rows = []
+
     for row in diag_rows:
         priority = row[priority_idx]
         if priority not in ('high', 'medium'):
@@ -339,11 +347,11 @@ def _attribute_root_causes(diag_rows, diag_header, project_dir):
             except Exception:
                 brief_issue_scenes = set()
 
-        # Check stall history (lazy load per principle)
+        # Check stall history (using pre-loaded rows)
         stalled_scenes = set()
         try:
             from storyforge.history import detect_stalls
-            stalls = detect_stalls(project_dir, principle)
+            stalls = detect_stalls(project_dir, principle, _rows=history_rows)
             stalled_scenes = {s['scene_id'] for s in stalls}
         except Exception:
             pass

--- a/tests/test_crlf.py
+++ b/tests/test_crlf.py
@@ -187,10 +187,10 @@ class TestPromptsCrlf:
 
 
 class TestHistoryCrlf:
-    """history._read_history handles CRLF files."""
+    """history.read_history handles CRLF files."""
 
     def test_read_history_crlf(self, tmp_path):
-        from storyforge.history import _read_history
+        from storyforge.history import read_history
         history_dir = tmp_path / 'working' / 'scores'
         history_dir.mkdir(parents=True)
         history_csv = str(history_dir / 'score-history.csv')
@@ -198,7 +198,7 @@ class TestHistoryCrlf:
             f.write(b'cycle|scene_id|principle|score\r\n')
             f.write(b'1|sc-01|pacing|7\r\n')
             f.write(b'1|sc-02|pacing|5\r\n')
-        rows = _read_history(str(tmp_path))
+        rows = read_history(str(tmp_path))
         assert len(rows) == 2
         assert rows[0]['score'] == '7'
         assert rows[1]['scene_id'] == 'sc-02'

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -50,31 +50,31 @@ class TestHistoryPath:
 
 class TestReadHistory:
     def test_returns_empty_when_no_file(self, tmp_path):
-        from storyforge.history import _read_history
-        result = _read_history(str(tmp_path))
+        from storyforge.history import read_history
+        result = read_history(str(tmp_path))
         assert result == []
 
     def test_reads_existing_file(self, tmp_path):
-        from storyforge.history import _history_path, _read_history
+        from storyforge.history import _history_path, read_history
         path = _history_path(str(tmp_path))
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'w', newline='', encoding='utf-8') as f:
             f.write('cycle|scene_id|principle|score\n')
             f.write('1|scene-a|prose_naturalness|4\n')
-        result = _read_history(str(tmp_path))
+        result = read_history(str(tmp_path))
         assert len(result) == 1
         assert result[0]['scene_id'] == 'scene-a'
         assert result[0]['score'] == '4'
 
     def test_coerces_none_to_empty_string(self, tmp_path):
-        from storyforge.history import _history_path, _read_history
+        from storyforge.history import _history_path, read_history
         path = _history_path(str(tmp_path))
         os.makedirs(os.path.dirname(path), exist_ok=True)
         # Write a row with fewer fields than header (causes None in DictReader)
         with open(path, 'w', newline='', encoding='utf-8') as f:
             f.write('cycle|scene_id|principle|score\n')
             f.write('1|scene-a|prose_naturalness\n')  # missing score
-        result = _read_history(str(tmp_path))
+        result = read_history(str(tmp_path))
         assert result[0]['score'] == ''
 
 
@@ -467,30 +467,30 @@ class TestCachedHistoryReads:
         _write_scores_csv(path, rows, ['cycle', 'scene_id', 'principle', 'score'])
 
     def test_detect_stalls_with_preloaded_rows(self, tmp_path):
-        from storyforge.history import detect_stalls, _read_history
+        from storyforge.history import detect_stalls, read_history
         self._setup_history(str(tmp_path), [
             {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
             {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
         ])
-        rows = _read_history(str(tmp_path))
+        rows = read_history(str(tmp_path))
         result = detect_stalls(str(tmp_path), 'p1', _rows=rows)
         assert len(result) == 1
         assert result[0]['scene_id'] == 'scene-a'
 
     def test_get_scene_history_with_preloaded_rows(self, tmp_path):
-        from storyforge.history import get_scene_history, _read_history
+        from storyforge.history import get_scene_history, read_history
         self._setup_history(str(tmp_path), [
             {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '3'},
             {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '4'},
         ])
-        rows = _read_history(str(tmp_path))
+        rows = read_history(str(tmp_path))
         result = get_scene_history(str(tmp_path), 'scene-a', 'p1', _rows=rows)
         assert len(result) == 2
         assert result[0] == (1, 3.0)
         assert result[1] == (2, 4.0)
 
     def test_cached_and_uncached_produce_same_results(self, tmp_path):
-        from storyforge.history import detect_stalls, _read_history
+        from storyforge.history import detect_stalls, read_history
         self._setup_history(str(tmp_path), [
             {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
             {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
@@ -498,7 +498,7 @@ class TestCachedHistoryReads:
             {'cycle': '2', 'scene_id': 'scene-b', 'principle': 'p1', 'score': '5'},
         ])
         uncached = detect_stalls(str(tmp_path), 'p1')
-        rows = _read_history(str(tmp_path))
+        rows = read_history(str(tmp_path))
         cached = detect_stalls(str(tmp_path), 'p1', _rows=rows)
         assert len(uncached) == len(cached)
         assert uncached[0]['scene_id'] == cached[0]['scene_id']

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -457,3 +457,48 @@ class TestDetectRegressions:
         ])
         result = detect_regressions(str(tmp_path), 'prose_naturalness')
         assert result == []
+
+
+class TestCachedHistoryReads:
+    """Regression #203: detect_stalls and get_scene_history must accept pre-loaded rows."""
+
+    def _setup_history(self, project_dir, rows):
+        path = os.path.join(project_dir, 'working', 'scores', 'score-history.csv')
+        _write_scores_csv(path, rows, ['cycle', 'scene_id', 'principle', 'score'])
+
+    def test_detect_stalls_with_preloaded_rows(self, tmp_path):
+        from storyforge.history import detect_stalls, _read_history
+        self._setup_history(str(tmp_path), [
+            {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
+            {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
+        ])
+        rows = _read_history(str(tmp_path))
+        result = detect_stalls(str(tmp_path), 'p1', _rows=rows)
+        assert len(result) == 1
+        assert result[0]['scene_id'] == 'scene-a'
+
+    def test_get_scene_history_with_preloaded_rows(self, tmp_path):
+        from storyforge.history import get_scene_history, _read_history
+        self._setup_history(str(tmp_path), [
+            {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '3'},
+            {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '4'},
+        ])
+        rows = _read_history(str(tmp_path))
+        result = get_scene_history(str(tmp_path), 'scene-a', 'p1', _rows=rows)
+        assert len(result) == 2
+        assert result[0] == (1, 3.0)
+        assert result[1] == (2, 4.0)
+
+    def test_cached_and_uncached_produce_same_results(self, tmp_path):
+        from storyforge.history import detect_stalls, _read_history
+        self._setup_history(str(tmp_path), [
+            {'cycle': '1', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
+            {'cycle': '2', 'scene_id': 'scene-a', 'principle': 'p1', 'score': '2'},
+            {'cycle': '1', 'scene_id': 'scene-b', 'principle': 'p1', 'score': '4'},
+            {'cycle': '2', 'scene_id': 'scene-b', 'principle': 'p1', 'score': '5'},
+        ])
+        uncached = detect_stalls(str(tmp_path), 'p1')
+        rows = _read_history(str(tmp_path))
+        cached = detect_stalls(str(tmp_path), 'p1', _rows=rows)
+        assert len(uncached) == len(cached)
+        assert uncached[0]['scene_id'] == cached[0]['scene_id']

--- a/tests/test_targeted_scoring.py
+++ b/tests/test_targeted_scoring.py
@@ -273,3 +273,19 @@ def test_deterministic_flag_dry_run(project_dir, plugin_dir, monkeypatch):
     assert 'Deterministic' in combined
     assert '$0.00' in combined
     assert 'prose_repetition' in combined
+
+
+# ---------------------------------------------------------------------------
+# --diagnosis-only flag
+# ---------------------------------------------------------------------------
+
+def test_parse_diagnosis_only_flag():
+    from storyforge.cmd_score import parse_args
+    args = parse_args(['--diagnosis-only'])
+    assert args.diagnosis_only is True
+
+
+def test_diagnosis_only_default_false():
+    from storyforge.cmd_score import parse_args
+    args = parse_args([])
+    assert args.diagnosis_only is False


### PR DESCRIPTION
## Summary

- **Cache history reads**: `_attribute_root_causes` was calling `detect_stalls()` per principle, each re-reading `score-history.csv` from disk. With 12,985 high-priority principles and ~50K history rows, this took 8,950 seconds. Now reads the file once and passes pre-loaded rows via `_rows` parameter. Should complete in seconds.
- **PR comment via stdin**: Use `--body-file -` instead of `--body` to pass the scoring comment to `gh pr comment`. The 13,813-proposal comment exceeded the OS argument length limit (~262KB on macOS).
- **`--diagnosis-only` flag**: Run just the diagnosis + proposals from existing scores without re-running the full scoring pipeline.

Closes #203

## Test plan

- [x] 3406 tests pass, 10 skipped
- [x] Cached and uncached `detect_stalls` produce identical results
- [x] `get_scene_history` works with pre-loaded rows
- [x] `--diagnosis-only` flag parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)