### PR TITLE
Add migrate-medium for novel ↔ graphic-novel conversion (closes #216)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Key principles:
 
 ## Graphic Novel Mode
 
-Set `project.medium: graphic-novel` in storyforge.yaml at init time to switch a project into graphic-novel mode. Medium is durable; switching means a new project.
+Set `project.medium: graphic-novel` in storyforge.yaml at init time to switch a project into graphic-novel mode. To convert an existing project between mediums, use `storyforge migrate-medium --to {novel|graphic-novel}` (archives current state, resets scene drafts, transforms CSV schemas).
 
 **Supported (Plans 1 + 2):**
 - `elaborate` (spine, architecture, scene-map, voice, briefs)

--- a/scripts/lib/python/storyforge/__main__.py
+++ b/scripts/lib/python/storyforge/__main__.py
@@ -41,6 +41,7 @@ COMMANDS = {
     'cleanup': 'storyforge.cmd_cleanup',
     'cover': 'storyforge.cmd_cover',
     'migrate': 'storyforge.cmd_migrate',
+    'migrate-medium': 'storyforge.cmd_migrate_medium',
     'scenes-setup': 'storyforge.cmd_scenes_setup',
     'scenes-export': 'storyforge.cmd_scenes_export',
     'scenes-import': 'storyforge.cmd_scenes_import',

--- a/scripts/lib/python/storyforge/cmd_migrate_medium.py
+++ b/scripts/lib/python/storyforge/cmd_migrate_medium.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime
 
 from storyforge.common import detect_project_root, get_medium, log
+from storyforge.git import commit_and_push, ensure_on_branch
 
 
 # ============================================================================
@@ -97,7 +98,8 @@ def step2_create_archive(
 
     Returns the archive path.
     """
-    ts = datetime.now().strftime('%Y%m%d-%H%M%S')
+    # Include microseconds so two --force runs in the same second don't collide.
+    ts = datetime.now().strftime('%Y%m%d-%H%M%S-%f')
     archive_name = f'{ts}-{from_medium}-to-{to_medium}'
     archive_dir = os.path.join(project_dir, 'working', 'migration', archive_name)
     if not dry_run:
@@ -178,14 +180,13 @@ def step4_update_yaml(project_dir: str, target: str, dry_run: bool) -> None:
         with open(yaml_path, 'w', encoding='utf-8') as f:
             f.write(new_content)
         # Post-write verification: confirm medium was actually written correctly
-        from storyforge.common import get_medium
         actual = get_medium(project_dir)
         if actual != target:
             log(
                 f'ERROR: storyforge.yaml was written but get_medium() returned {actual!r} '
                 f'(expected {target!r}). '
-                'The YAML file may have a non-standard format. '
-                'Please set `project.medium: {target}` manually under the `project:` key.'
+                f'The YAML file may have a non-standard format. '
+                f'Please set `project.medium: {target}` manually under the `project:` key.'
             )
             sys.exit(1)
     log(f'  storyforge.yaml: medium set to {target!r}')
@@ -195,10 +196,36 @@ def step4_update_yaml(project_dir: str, target: str, dry_run: bool) -> None:
 # Step 5: Transform scenes.csv
 # ============================================================================
 
+
+# Full merged header that includes all columns from both mediums.
+# After migration the CSV always uses this header; irrelevant columns stay empty.
+# This lets the author immediately edit target_pages (N→GN) or target_words (GN→N)
+# without adding columns manually.
+_SCENES_FULL_HEADER = [
+    'id', 'seq', 'title', 'part', 'pov', 'location',
+    'timeline_day', 'time_of_day', 'duration', 'type', 'status',
+    'word_count', 'target_words',      # novel columns
+    'target_pages', 'panel_count', 'page_count',  # GN columns
+]
+
+_BRIEFS_FULL_HEADER = [
+    'id', 'goal', 'conflict', 'outcome', 'crisis', 'decision',
+    'knowledge_in', 'knowledge_out', 'key_actions', 'key_dialogue',
+    'emotions', 'motifs', 'subtext', 'continuity_deps', 'has_overflow',
+    'physical_state_in', 'physical_state_out',  # novel columns
+    'page_layout', 'panel_breakdown', 'visual_keywords',  # GN columns
+    'page_turn_beats', 'caption_strategy',                # GN columns
+]
+
+
 def step5_transform_scenes_csv(
     project_dir: str, from_medium: str, to_medium: str, dry_run: bool
 ) -> str:
-    """Clear medium-specific columns and reset status to 'mapped'."""
+    """Clear medium-specific columns, reset status to 'mapped', and widen header.
+
+    After migration the CSV uses _SCENES_FULL_HEADER so the author can
+    immediately populate target medium columns without adding them manually.
+    """
     scenes_path = os.path.join(project_dir, 'reference', 'scenes.csv')
     header, rows = _read_csv(scenes_path)
     if not rows:
@@ -212,11 +239,14 @@ def step5_transform_scenes_csv(
         log('  scenes.csv: cleared target_pages, panel_count, page_count')
 
     # Reset status to 'mapped' EXCEPT for terminal editorial states.
-    # (cut/merged are deliberate authorial decisions and must survive migration.)
+    # Normalize the value (strip whitespace, lowercase) before comparing so
+    # ' cut ' or 'CUT' don't slip through. (cut/merged are deliberate authorial
+    # decisions and must survive migration.)
     TERMINAL_STATUSES = {'cut', 'merged'}
     reset_count = 0
     for row in rows:
-        if row.get('status') not in TERMINAL_STATUSES:
+        status = (row.get('status') or '').strip().lower()
+        if status not in TERMINAL_STATUSES:
             row['status'] = 'mapped'
             reset_count += 1
     skipped = len(rows) - reset_count
@@ -224,7 +254,8 @@ def step5_transform_scenes_csv(
         + (f' (skipped {skipped} terminal: cut/merged)' if skipped else ''))
 
     if not dry_run:
-        _write_csv(scenes_path, header, rows)
+        # Always write the full header so target-medium columns are present.
+        _write_csv(scenes_path, _SCENES_FULL_HEADER, rows)
     return f'done:{len(rows)}'
 
 
@@ -235,10 +266,11 @@ def step5_transform_scenes_csv(
 def step6_transform_briefs_csv(
     project_dir: str, from_medium: str, to_medium: str, dry_run: bool
 ) -> str:
-    """Clear GN-specific brief columns when converting graphic-novel → novel."""
-    if not (from_medium == 'graphic-novel' and to_medium == 'novel'):
-        return 'skip: not applicable for this direction'
+    """Clear GN-specific brief columns and widen header to full schema.
 
+    On N→GN: adds the five GN columns (empty) so the author can populate them.
+    On GN→novel: clears the GN columns and keeps the full header for symmetry.
+    """
     briefs_path = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
     header, rows = _read_csv(briefs_path)
     if not rows:
@@ -246,11 +278,19 @@ def step6_transform_briefs_csv(
 
     gn_cols = ['page_layout', 'panel_breakdown', 'visual_keywords',
                'page_turn_beats', 'caption_strategy']
-    _clear_columns(rows, gn_cols)
-    log(f'  scene-briefs.csv: cleared GN columns ({", ".join(gn_cols)})')
+
+    if from_medium == 'graphic-novel' and to_medium == 'novel':
+        _clear_columns(rows, gn_cols)
+        log(f'  scene-briefs.csv: cleared GN columns ({", ".join(gn_cols)})')
+    elif from_medium == 'novel' and to_medium == 'graphic-novel':
+        # GN columns don't exist yet — nothing to clear, but we still widen the header.
+        log('  scene-briefs.csv: widening to full schema (added GN columns, empty)')
+    else:
+        return 'skip: not applicable for this direction'
 
     if not dry_run:
-        _write_csv(briefs_path, header, rows)
+        # Always write the full header so both novel and GN columns are present.
+        _write_csv(briefs_path, _BRIEFS_FULL_HEADER, rows)
     return f'done:{len(rows)}'
 
 
@@ -258,11 +298,25 @@ def step6_transform_briefs_csv(
 # Step 7: Archive and clear scenes directory
 # ============================================================================
 
+def _load_scene_ids(project_dir: str) -> set[str] | None:
+    """Return the set of scene IDs from reference/scenes.csv, or None if unavailable."""
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    _, rows = _read_csv(scenes_csv)
+    if not rows:
+        return None
+    ids = {r.get('id', '').strip() for r in rows if r.get('id', '').strip()}
+    return ids if ids else None
+
+
 def step7_archive_and_clear_scenes_dir(
     project_dir: str, archive_dir: str, from_medium: str, to_medium: str,
     dry_run: bool
 ) -> int:
     """Move scene files to archive and clear scenes/ for re-drafting.
+
+    Only moves files that match a known scene ID from reference/scenes.csv.
+    README.md, NOTES.md, and other author notes in scenes/ are left in place.
+    Falls back to moving all .md files (with a warning) if scenes.csv is absent.
 
     Returns count of files moved.
     """
@@ -271,13 +325,30 @@ def step7_archive_and_clear_scenes_dir(
         log('  scenes/: directory not found, skipping')
         return 0
 
-    scene_files = [
-        f for f in os.listdir(scenes_dir)
-        if f.endswith('.md') and f != '.gitkeep'
-    ]
+    all_md = [f for f in os.listdir(scenes_dir)
+              if f.endswith('.md') and f != '.gitkeep']
+
+    if not all_md:
+        log('  scenes/: no scene files to archive')
+        return 0
+
+    # Restrict to filenames that correspond to known scene IDs.
+    # This prevents README.md, NOTES.md, and other author notes from being archived.
+    known_ids = _load_scene_ids(project_dir)
+    if known_ids is not None:
+        scene_files = [f for f in all_md if f[:-3] in known_ids]  # strip ".md"
+        non_scene = set(all_md) - set(scene_files)
+        if non_scene:
+            log(f'  scenes/: leaving {len(non_scene)} non-scene file(s) in place: '
+                + ', '.join(sorted(non_scene)))
+    else:
+        # scenes.csv missing or empty — fall back to original behavior with warning.
+        log('  scenes/: WARNING: reference/scenes.csv not found or empty; '
+            'archiving ALL .md files (including any README/NOTES)')
+        scene_files = all_md
 
     if not scene_files:
-        log('  scenes/: no scene files to archive')
+        log('  scenes/: no scene files matched known IDs')
         return 0
 
     archive_scenes = os.path.join(archive_dir, 'scenes')
@@ -331,7 +402,8 @@ def step8_add_bible_visual_notes(
 ) -> list[str]:
     """Append visual-note stubs to character-bible.md and world-bible.md.
 
-    Only modifies files that exist and don't already contain '### Visual'.
+    Always appends to existing files (even when some ### Visual sections already
+    exist) so partial migrations don't leave characters without migration cues.
     Returns list of modified file paths.
     """
     ref_dir = os.path.join(project_dir, 'reference')
@@ -345,11 +417,11 @@ def step8_add_bible_visual_notes(
     for path, note in bibles:
         if not os.path.isfile(path):
             continue
-        with open(path, encoding='utf-8') as f:
-            content = f.read()
-        if '### Visual' in content:
-            log(f'  {os.path.basename(path)}: already has ### Visual sections, skipping')
-            continue
+        # Always append the migration note, even when SOME ### Visual sections
+        # already exist. A partial migration (e.g. one character already has a
+        # Visual section) would otherwise leave every other character without
+        # the prompt. The note is additive and harmless to delete; a skip would
+        # silently leave characters without migration cues.
         if not dry_run:
             with open(path, 'a', encoding='utf-8') as f:
                 f.write(note)
@@ -390,7 +462,7 @@ def step9_print_summary(
     if from_medium == 'novel' and to_medium == 'graphic-novel':
         print('  - scenes.csv: target_words and word_count cleared')
         print(f'  - scenes/: {scene_count} prose file(s) moved to archive/scenes')
-        print('  - character-bible.md, world-bible.md: visual notes appended (if no ### Visual sections existed)')
+        print('  - character-bible.md, world-bible.md: visual migration notes appended')
     elif from_medium == 'graphic-novel' and to_medium == 'novel':
         print('  - scenes.csv: target_pages, panel_count, page_count cleared')
         print('  - scene-briefs.csv: GN columns cleared (page_layout, panel_breakdown, visual_keywords, page_turn_beats, caption_strategy)')
@@ -471,6 +543,11 @@ def main(argv=None):
     log(f'  target={args.target}  dry-run={args.dry_run}  force={args.force}')
     log('')
 
+    # Per CLAUDE.md: if on main, create a feature branch first so the migration
+    # is never committed directly to main.
+    if not args.dry_run and not args.no_commit:
+        ensure_on_branch('migrate-medium', project_dir)
+
     # Step 1: Validate
     from_medium, to_medium = step1_validate_direction(
         project_dir, args.target, args.force
@@ -525,7 +602,6 @@ def main(argv=None):
 
     # Commit
     if not args.dry_run and not args.no_commit:
-        from storyforge.git import commit_and_push
         committed = commit_and_push(
             project_dir,
             f'Migrate medium: {from_medium} → {to_medium}',

--- a/scripts/lib/python/storyforge/cmd_migrate_medium.py
+++ b/scripts/lib/python/storyforge/cmd_migrate_medium.py
@@ -7,7 +7,7 @@ Usage:
     storyforge migrate-medium --to novel           # convert to novel
     storyforge migrate-medium --to graphic-novel   # convert to graphic-novel
     storyforge migrate-medium --to X --dry-run     # show what would happen
-    storyforge migrate-medium --to X --force       # skip confirmation
+    storyforge migrate-medium --to X --force       # bypass the "already in target medium" guard
 """
 
 import argparse
@@ -53,7 +53,7 @@ def _clear_columns(rows: list[dict], columns: list[str]) -> int:
             if col in row:
                 row[col] = ''
                 count += 1
-    return len(rows)
+    return count
 
 
 def _set_column(rows: list[dict], column: str, value: str) -> int:
@@ -137,13 +137,8 @@ def step3_snapshot_state(
                 os.makedirs(os.path.dirname(dest), exist_ok=True)
                 shutil.copy2(src, dest)
 
-    # Snapshot scenes/
-    scenes_dir = os.path.join(project_dir, 'scenes')
-    if os.path.isdir(scenes_dir):
-        snap.append('scenes/')
-        if not dry_run:
-            dest_scenes = os.path.join(archive_dir, 'scenes')
-            shutil.copytree(scenes_dir, dest_scenes, dirs_exist_ok=True)
+    # Note: scenes/ is NOT copied here — step 7 moves scene files to archive/scenes/,
+    # which IS the pre-migration snapshot of the scenes. Copying here would duplicate them.
 
     log(f'  Snapshot: {len(snap)} items archived')
     return snap
@@ -169,17 +164,30 @@ def step4_update_yaml(project_dir: str, target: str, dry_run: bool) -> None:
             flags=re.MULTILINE,
         )
     else:
-        # Insert medium: under the `project:` block
-        new_content = re.sub(
-            r'^(project:\n)',
+        # Insert medium: under the `project:` block.
+        # Match `project:` followed by anything up to and including the newline,
+        # so projects with `project: # main config` style yaml still get the field
+        # inserted under the project block.
+        pattern = re.compile(r'^(project:[^\n]*\n)', re.MULTILINE)
+        new_content = pattern.sub(
             rf'\g<1>  medium: {target}\n',
             content,
-            flags=re.MULTILINE,
         )
 
     if not dry_run:
         with open(yaml_path, 'w', encoding='utf-8') as f:
             f.write(new_content)
+        # Post-write verification: confirm medium was actually written correctly
+        from storyforge.common import get_medium
+        actual = get_medium(project_dir)
+        if actual != target:
+            log(
+                f'ERROR: storyforge.yaml was written but get_medium() returned {actual!r} '
+                f'(expected {target!r}). '
+                'The YAML file may have a non-standard format. '
+                'Please set `project.medium: {target}` manually under the `project:` key.'
+            )
+            sys.exit(1)
     log(f'  storyforge.yaml: medium set to {target!r}')
 
 
@@ -203,8 +211,17 @@ def step5_transform_scenes_csv(
         _clear_columns(rows, ['target_pages', 'panel_count', 'page_count'])
         log('  scenes.csv: cleared target_pages, panel_count, page_count')
 
-    _set_column(rows, 'status', 'mapped')
-    log(f'  scenes.csv: reset {len(rows)} scene(s) to status=mapped')
+    # Reset status to 'mapped' EXCEPT for terminal editorial states.
+    # (cut/merged are deliberate authorial decisions and must survive migration.)
+    TERMINAL_STATUSES = {'cut', 'merged'}
+    reset_count = 0
+    for row in rows:
+        if row.get('status') not in TERMINAL_STATUSES:
+            row['status'] = 'mapped'
+            reset_count += 1
+    skipped = len(rows) - reset_count
+    log(f'  scenes.csv: reset {reset_count} scene(s) to status=mapped'
+        + (f' (skipped {skipped} terminal: cut/merged)' if skipped else ''))
 
     if not dry_run:
         _write_csv(scenes_path, header, rows)
@@ -263,8 +280,7 @@ def step7_archive_and_clear_scenes_dir(
         log('  scenes/: no scene files to archive')
         return 0
 
-    subdir_name = 'scenes-novel' if from_medium == 'novel' else 'scenes-gn'
-    archive_scenes = os.path.join(archive_dir, subdir_name)
+    archive_scenes = os.path.join(archive_dir, 'scenes')
 
     if not dry_run:
         os.makedirs(archive_scenes, exist_ok=True)
@@ -276,7 +292,7 @@ def step7_archive_and_clear_scenes_dir(
         if not os.path.exists(gitkeep):
             open(gitkeep, 'w').close()
 
-    log(f'  scenes/: moved {len(scene_files)} file(s) to archive/{subdir_name}')
+    log(f'  scenes/: moved {len(scene_files)} file(s) to archive/scenes')
     return len(scene_files)
 
 
@@ -349,7 +365,7 @@ def step8_add_bible_visual_notes(
 
 def step9_print_summary(
     from_medium: str, to_medium: str, archive_dir: str,
-    scene_count: int, dry_run: bool
+    scene_count: int, dry_run: bool, no_commit: bool = False
 ) -> None:
     """Print a human-readable migration summary with next steps."""
     if dry_run:
@@ -369,16 +385,16 @@ def step9_print_summary(
     print()
     print('What changed:')
     print('  - storyforge.yaml: project.medium updated')
-    print('  - scenes.csv: status reset to "mapped" for all scenes')
+    print('  - scenes.csv: status reset to "mapped" for non-terminal scenes (cut/merged preserved)')
 
     if from_medium == 'novel' and to_medium == 'graphic-novel':
         print('  - scenes.csv: target_words and word_count cleared')
-        print(f'  - scenes/: {scene_count} prose file(s) moved to archive/scenes-novel')
+        print(f'  - scenes/: {scene_count} prose file(s) moved to archive/scenes')
         print('  - character-bible.md, world-bible.md: visual notes appended (if no ### Visual sections existed)')
     elif from_medium == 'graphic-novel' and to_medium == 'novel':
         print('  - scenes.csv: target_pages, panel_count, page_count cleared')
         print('  - scene-briefs.csv: GN columns cleared (page_layout, panel_breakdown, visual_keywords, page_turn_beats, caption_strategy)')
-        print(f'  - scenes/: {scene_count} script file(s) moved to archive/scenes-gn')
+        print(f'  - scenes/: {scene_count} script file(s) moved to archive/scenes')
 
     print()
     print('What was preserved:')
@@ -388,7 +404,11 @@ def step9_print_summary(
     print('  - All other reference files')
     print()
     print('Reversibility:')
-    print('  Every change is committed — use git to revert if needed.')
+    if no_commit:
+        print('  Changes are NOT committed (--no-commit). The archive in `working/migration/` is your')
+        print('  fallback if you need to recover. Run `git add -A && git commit` when ready.')
+    else:
+        print('  Every change is committed. Use `git revert` to undo the migration commit if needed.')
     print('  The full archive is preserved at:')
     print(f'    {archive_dir}')
     print()
@@ -430,7 +450,7 @@ def parse_args(argv):
     )
     parser.add_argument(
         '--force', action='store_true',
-        help='Skip confirmation; also bypass "already in target medium" guard',
+        help='Bypass the "already in target medium" guard. Useful if you previously aborted a migration and want to retry.',
     )
     parser.add_argument(
         '--no-commit', action='store_true',
@@ -498,7 +518,8 @@ def main(argv=None):
 
     # Step 9: Summary
     step9_print_summary(
-        from_medium, to_medium, archive_dir, scene_count, args.dry_run
+        from_medium, to_medium, archive_dir, scene_count, args.dry_run,
+        no_commit=args.no_commit,
     )
     log('  [9/9] Summary printed')
 

--- a/scripts/lib/python/storyforge/cmd_migrate_medium.py
+++ b/scripts/lib/python/storyforge/cmd_migrate_medium.py
@@ -1,0 +1,522 @@
+"""storyforge migrate-medium — Convert a project between novel and graphic-novel mode.
+
+Archives the current state, updates storyforge.yaml, transforms CSV files, and
+clears scene files for re-drafting in the target medium.
+
+Usage:
+    storyforge migrate-medium --to novel           # convert to novel
+    storyforge migrate-medium --to graphic-novel   # convert to graphic-novel
+    storyforge migrate-medium --to X --dry-run     # show what would happen
+    storyforge migrate-medium --to X --force       # skip confirmation
+"""
+
+import argparse
+import os
+import shutil
+import sys
+from datetime import datetime
+
+from storyforge.common import detect_project_root, get_medium, log
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _read_csv(path: str) -> tuple[list[str], list[dict]]:
+    """Read a pipe-delimited CSV. Returns (header_fields, rows_as_dicts)."""
+    if not os.path.isfile(path):
+        return [], []
+    with open(path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = [l for l in raw.splitlines() if l.strip()]
+    if not lines:
+        return [], []
+    header = lines[0].split('|')
+    rows = [dict(zip(header, l.split('|'))) for l in lines[1:]]
+    return header, rows
+
+
+def _write_csv(path: str, header: list[str], rows: list[dict]) -> None:
+    """Write a pipe-delimited CSV."""
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('|'.join(header) + '\n')
+        for row in rows:
+            f.write('|'.join(row.get(col, '') for col in header) + '\n')
+
+
+def _clear_columns(rows: list[dict], columns: list[str]) -> int:
+    """Clear specific columns on all rows. Returns count of rows touched."""
+    count = 0
+    for row in rows:
+        for col in columns:
+            if col in row:
+                row[col] = ''
+                count += 1
+    return len(rows)
+
+
+def _set_column(rows: list[dict], column: str, value: str) -> int:
+    """Set a column to a fixed value on all rows. Returns count of rows touched."""
+    count = 0
+    for row in rows:
+        if column in row:
+            row[column] = value
+            count += 1
+    return count
+
+
+# ============================================================================
+# Step 1: Validate direction
+# ============================================================================
+
+def step1_validate_direction(
+    project_dir: str, target: str, force: bool
+) -> tuple[str, str]:
+    """Detect current medium, refuse if already at target (unless --force).
+
+    Returns (from_medium, to_medium) on success.
+    Exits 1 on refusal.
+    """
+    current = get_medium(project_dir)
+    if current == target and not force:
+        log(f'Error: project is already in {target!r} mode.')
+        log('Nothing to do. Pass --force to create an archive anyway.')
+        sys.exit(1)
+    return current, target
+
+
+# ============================================================================
+# Step 2: Create archive directory
+# ============================================================================
+
+def step2_create_archive(
+    project_dir: str, from_medium: str, to_medium: str, dry_run: bool
+) -> str:
+    """Create timestamped archive directory.
+
+    Returns the archive path.
+    """
+    ts = datetime.now().strftime('%Y%m%d-%H%M%S')
+    archive_name = f'{ts}-{from_medium}-to-{to_medium}'
+    archive_dir = os.path.join(project_dir, 'working', 'migration', archive_name)
+    if not dry_run:
+        os.makedirs(archive_dir, exist_ok=True)
+    log(f'  Archive dir: {archive_dir}')
+    return archive_dir
+
+
+# ============================================================================
+# Step 3: Snapshot current state to archive
+# ============================================================================
+
+def step3_snapshot_state(
+    project_dir: str, archive_dir: str, dry_run: bool
+) -> list[str]:
+    """Copy storyforge.yaml, key CSVs, and scenes/ to the archive.
+
+    Returns list of copied paths.
+    """
+    ref_dir = os.path.join(project_dir, 'reference')
+    snap = []
+
+    files_to_copy = [
+        os.path.join(project_dir, 'storyforge.yaml'),
+        os.path.join(ref_dir, 'scenes.csv'),
+        os.path.join(ref_dir, 'scene-briefs.csv'),
+        os.path.join(ref_dir, 'voice-profile.csv'),
+        os.path.join(ref_dir, 'chapter-map.csv'),
+    ]
+
+    for src in files_to_copy:
+        if os.path.isfile(src):
+            rel = os.path.relpath(src, project_dir)
+            dest = os.path.join(archive_dir, rel)
+            snap.append(rel)
+            if not dry_run:
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                shutil.copy2(src, dest)
+
+    # Snapshot scenes/
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    if os.path.isdir(scenes_dir):
+        snap.append('scenes/')
+        if not dry_run:
+            dest_scenes = os.path.join(archive_dir, 'scenes')
+            shutil.copytree(scenes_dir, dest_scenes, dirs_exist_ok=True)
+
+    log(f'  Snapshot: {len(snap)} items archived')
+    return snap
+
+
+# ============================================================================
+# Step 4: Update storyforge.yaml
+# ============================================================================
+
+def step4_update_yaml(project_dir: str, target: str, dry_run: bool) -> None:
+    """Update project.medium in storyforge.yaml to the target value."""
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    with open(yaml_path, encoding='utf-8') as f:
+        content = f.read()
+
+    import re
+    # Replace existing medium field if present
+    if re.search(r'^\s+medium:\s*', content, re.MULTILINE):
+        new_content = re.sub(
+            r'^(\s+medium:\s*).*$',
+            rf'\g<1>{target}',
+            content,
+            flags=re.MULTILINE,
+        )
+    else:
+        # Insert medium: under the `project:` block
+        new_content = re.sub(
+            r'^(project:\n)',
+            rf'\g<1>  medium: {target}\n',
+            content,
+            flags=re.MULTILINE,
+        )
+
+    if not dry_run:
+        with open(yaml_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+    log(f'  storyforge.yaml: medium set to {target!r}')
+
+
+# ============================================================================
+# Step 5: Transform scenes.csv
+# ============================================================================
+
+def step5_transform_scenes_csv(
+    project_dir: str, from_medium: str, to_medium: str, dry_run: bool
+) -> str:
+    """Clear medium-specific columns and reset status to 'mapped'."""
+    scenes_path = os.path.join(project_dir, 'reference', 'scenes.csv')
+    header, rows = _read_csv(scenes_path)
+    if not rows:
+        return 'skip: no rows'
+
+    if from_medium == 'novel' and to_medium == 'graphic-novel':
+        _clear_columns(rows, ['target_words', 'word_count'])
+        log('  scenes.csv: cleared target_words, word_count')
+    elif from_medium == 'graphic-novel' and to_medium == 'novel':
+        _clear_columns(rows, ['target_pages', 'panel_count', 'page_count'])
+        log('  scenes.csv: cleared target_pages, panel_count, page_count')
+
+    _set_column(rows, 'status', 'mapped')
+    log(f'  scenes.csv: reset {len(rows)} scene(s) to status=mapped')
+
+    if not dry_run:
+        _write_csv(scenes_path, header, rows)
+    return f'done:{len(rows)}'
+
+
+# ============================================================================
+# Step 6: Transform scene-briefs.csv (GN→novel only)
+# ============================================================================
+
+def step6_transform_briefs_csv(
+    project_dir: str, from_medium: str, to_medium: str, dry_run: bool
+) -> str:
+    """Clear GN-specific brief columns when converting graphic-novel → novel."""
+    if not (from_medium == 'graphic-novel' and to_medium == 'novel'):
+        return 'skip: not applicable for this direction'
+
+    briefs_path = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+    header, rows = _read_csv(briefs_path)
+    if not rows:
+        return 'skip: no rows'
+
+    gn_cols = ['page_layout', 'panel_breakdown', 'visual_keywords',
+               'page_turn_beats', 'caption_strategy']
+    _clear_columns(rows, gn_cols)
+    log(f'  scene-briefs.csv: cleared GN columns ({", ".join(gn_cols)})')
+
+    if not dry_run:
+        _write_csv(briefs_path, header, rows)
+    return f'done:{len(rows)}'
+
+
+# ============================================================================
+# Step 7: Archive and clear scenes directory
+# ============================================================================
+
+def step7_archive_and_clear_scenes_dir(
+    project_dir: str, archive_dir: str, from_medium: str, to_medium: str,
+    dry_run: bool
+) -> int:
+    """Move scene files to archive and clear scenes/ for re-drafting.
+
+    Returns count of files moved.
+    """
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    if not os.path.isdir(scenes_dir):
+        log('  scenes/: directory not found, skipping')
+        return 0
+
+    scene_files = [
+        f for f in os.listdir(scenes_dir)
+        if f.endswith('.md') and f != '.gitkeep'
+    ]
+
+    if not scene_files:
+        log('  scenes/: no scene files to archive')
+        return 0
+
+    subdir_name = 'scenes-novel' if from_medium == 'novel' else 'scenes-gn'
+    archive_scenes = os.path.join(archive_dir, subdir_name)
+
+    if not dry_run:
+        os.makedirs(archive_scenes, exist_ok=True)
+        for fname in scene_files:
+            src = os.path.join(scenes_dir, fname)
+            shutil.move(src, os.path.join(archive_scenes, fname))
+        # Ensure scenes/ dir stays tracked by git
+        gitkeep = os.path.join(scenes_dir, '.gitkeep')
+        if not os.path.exists(gitkeep):
+            open(gitkeep, 'w').close()
+
+    log(f'  scenes/: moved {len(scene_files)} file(s) to archive/{subdir_name}')
+    return len(scene_files)
+
+
+# ============================================================================
+# Step 8: Add visual notes to bibles (novel → graphic-novel only)
+# ============================================================================
+
+_BIBLE_VISUAL_NOTE = """
+---
+
+> **Graphic Novel Migration Note**
+> Add a `### Visual` subsection for each character below. Include:
+> - Silhouette and body language cues
+> - Signature visual elements (costume, props, marks)
+> - Costume continuity notes (what stays the same across scenes)
+> - Any distinctive features the artist must maintain
+>
+> See `reference/character-bible.md` in the GN fixture for an example.
+"""
+
+_WORLD_VISUAL_NOTE = """
+---
+
+> **Graphic Novel Migration Note**
+> Add a `### Visual` subsection for each location below. Include:
+> - Visual keywords (textures, colours, lighting mood)
+> - Camera/perspective conventions for this space
+> - Continuity anchors (always-present elements)
+>
+> See `reference/world-bible.md` in the GN fixture for an example.
+"""
+
+
+def step8_add_bible_visual_notes(
+    project_dir: str, dry_run: bool
+) -> list[str]:
+    """Append visual-note stubs to character-bible.md and world-bible.md.
+
+    Only modifies files that exist and don't already contain '### Visual'.
+    Returns list of modified file paths.
+    """
+    ref_dir = os.path.join(project_dir, 'reference')
+    modified = []
+
+    bibles = [
+        (os.path.join(ref_dir, 'character-bible.md'), _BIBLE_VISUAL_NOTE),
+        (os.path.join(ref_dir, 'world-bible.md'), _WORLD_VISUAL_NOTE),
+    ]
+
+    for path, note in bibles:
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding='utf-8') as f:
+            content = f.read()
+        if '### Visual' in content:
+            log(f'  {os.path.basename(path)}: already has ### Visual sections, skipping')
+            continue
+        if not dry_run:
+            with open(path, 'a', encoding='utf-8') as f:
+                f.write(note)
+        modified.append(path)
+        log(f'  {os.path.basename(path)}: appended visual migration note')
+
+    return modified
+
+
+# ============================================================================
+# Step 9: Print summary
+# ============================================================================
+
+def step9_print_summary(
+    from_medium: str, to_medium: str, archive_dir: str,
+    scene_count: int, dry_run: bool
+) -> None:
+    """Print a human-readable migration summary with next steps."""
+    if dry_run:
+        print()
+        print('=== DRY RUN — no files were modified ===')
+        print()
+        print(f'Would migrate: {from_medium} → {to_medium}')
+        print(f'Would archive to: {archive_dir}')
+        print(f'Would clear {scene_count} scene file(s) from scenes/')
+        return
+
+    print()
+    print('=== Migration complete ===')
+    print()
+    print(f'Converted: {from_medium} → {to_medium}')
+    print(f'Archive:   {archive_dir}')
+    print()
+    print('What changed:')
+    print('  - storyforge.yaml: project.medium updated')
+    print('  - scenes.csv: status reset to "mapped" for all scenes')
+
+    if from_medium == 'novel' and to_medium == 'graphic-novel':
+        print('  - scenes.csv: target_words and word_count cleared')
+        print(f'  - scenes/: {scene_count} prose file(s) moved to archive/scenes-novel')
+        print('  - character-bible.md, world-bible.md: visual notes appended (if no ### Visual sections existed)')
+    elif from_medium == 'graphic-novel' and to_medium == 'novel':
+        print('  - scenes.csv: target_pages, panel_count, page_count cleared')
+        print('  - scene-briefs.csv: GN columns cleared (page_layout, panel_breakdown, visual_keywords, page_turn_beats, caption_strategy)')
+        print(f'  - scenes/: {scene_count} script file(s) moved to archive/scenes-gn')
+
+    print()
+    print('What was preserved:')
+    print('  - reference/scene-intent.csv (medium-agnostic)')
+    print('  - reference/voice-profile.csv (voice carries between mediums)')
+    print('  - reference/story-architecture.md (if present)')
+    print('  - All other reference files')
+    print()
+    print('Reversibility:')
+    print('  Every change is committed — use git to revert if needed.')
+    print('  The full archive is preserved at:')
+    print(f'    {archive_dir}')
+    print()
+
+    if from_medium == 'novel' and to_medium == 'graphic-novel':
+        print('Next steps:')
+        print('  1. Add ### Visual subsections to reference/character-bible.md per character')
+        print('  2. Add ### Visual subsections to reference/world-bible.md per location')
+        print('  3. Set target_pages for each scene in reference/scenes.csv')
+        print('  4. Run: ./storyforge elaborate --stage briefs')
+        print('     (fills page_layout, panel_breakdown, visual_keywords, page_turn_beats, caption_strategy)')
+        print('  5. Run: ./storyforge write  (to draft panel scripts scene by scene)')
+    elif from_medium == 'graphic-novel' and to_medium == 'novel':
+        print('Next steps:')
+        print('  1. Set target_words per scene in reference/scenes.csv')
+        print('     (or run ./storyforge elaborate --stage map to repopulate)')
+        print('  2. Run: ./storyforge write  (to draft prose scenes)')
+
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='storyforge migrate-medium',
+        description='Convert a project between novel and graphic-novel mode.',
+    )
+    parser.add_argument(
+        '--to', required=True,
+        choices=['novel', 'graphic-novel'],
+        metavar='{novel|graphic-novel}',
+        dest='target',
+        help='Target medium to convert to',
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true',
+        help='Show what would happen without modifying any files',
+    )
+    parser.add_argument(
+        '--force', action='store_true',
+        help='Skip confirmation; also bypass "already in target medium" guard',
+    )
+    parser.add_argument(
+        '--no-commit', action='store_true',
+        help='Apply changes but skip git commit',
+    )
+    return parser.parse_args(argv)
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main(argv=None):
+    args = parse_args(argv or [])
+    project_dir = detect_project_root()
+
+    log(f'migrate-medium: project={project_dir}')
+    log(f'  target={args.target}  dry-run={args.dry_run}  force={args.force}')
+    log('')
+
+    # Step 1: Validate
+    from_medium, to_medium = step1_validate_direction(
+        project_dir, args.target, args.force
+    )
+    log(f'  [1/9] Direction: {from_medium} → {to_medium}')
+
+    # Step 2: Create archive directory
+    archive_dir = step2_create_archive(
+        project_dir, from_medium, to_medium, args.dry_run
+    )
+    log(f'  [2/9] Archive directory created')
+
+    # Step 3: Snapshot state
+    snap = step3_snapshot_state(project_dir, archive_dir, args.dry_run)
+    log(f'  [3/9] State snapshot: {len(snap)} item(s)')
+
+    # Step 4: Update storyforge.yaml
+    step4_update_yaml(project_dir, to_medium, args.dry_run)
+    log(f'  [4/9] storyforge.yaml updated')
+
+    # Step 5: Transform scenes.csv
+    result = step5_transform_scenes_csv(
+        project_dir, from_medium, to_medium, args.dry_run
+    )
+    log(f'  [5/9] scenes.csv: {result}')
+
+    # Step 6: Transform scene-briefs.csv
+    result = step6_transform_briefs_csv(
+        project_dir, from_medium, to_medium, args.dry_run
+    )
+    log(f'  [6/9] scene-briefs.csv: {result}')
+
+    # Step 7: Archive and clear scenes dir
+    scene_count = step7_archive_and_clear_scenes_dir(
+        project_dir, archive_dir, from_medium, to_medium, args.dry_run
+    )
+    log(f'  [7/9] scenes/: {scene_count} file(s) archived')
+
+    # Step 8: Bible visual notes (novel → GN only)
+    if from_medium == 'novel' and to_medium == 'graphic-novel':
+        modified = step8_add_bible_visual_notes(project_dir, args.dry_run)
+        log(f'  [8/9] Bible visual notes: {len(modified)} file(s) updated')
+    else:
+        log('  [8/9] Bible visual notes: skipped (GN→novel direction)')
+
+    # Step 9: Summary
+    step9_print_summary(
+        from_medium, to_medium, archive_dir, scene_count, args.dry_run
+    )
+    log('  [9/9] Summary printed')
+
+    # Commit
+    if not args.dry_run and not args.no_commit:
+        from storyforge.git import commit_and_push
+        committed = commit_and_push(
+            project_dir,
+            f'Migrate medium: {from_medium} → {to_medium}',
+            [
+                'storyforge.yaml',
+                'reference/',
+                'scenes/',
+                'working/migration/',
+                'working/',
+            ],
+        )
+        if committed:
+            log('Changes committed and pushed.')
+        else:
+            log('No changes to commit (or git not available).')

--- a/skills/migrate-medium/SKILL.md
+++ b/skills/migrate-medium/SKILL.md
@@ -77,7 +77,7 @@ Before running anything, explain clearly what will happen:
 > **What changes:**
 > - `storyforge.yaml`: `project.medium` set to `graphic-novel`
 > - `reference/scenes.csv`: `target_words` and `word_count` cleared; all scenes reset to `status=mapped`
-> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-novel-to-graphic-novel/scenes-novel/`
+> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-novel-to-graphic-novel/scenes/`
 > - `reference/character-bible.md` and `reference/world-bible.md`: a visual migration note is appended if they lack `### Visual` sections
 >
 > **What stays the same:**
@@ -100,7 +100,7 @@ Before running anything, explain clearly what will happen:
 > - `storyforge.yaml`: `project.medium` set to `novel`
 > - `reference/scenes.csv`: `target_pages`, `panel_count`, `page_count` cleared; all scenes reset to `status=mapped`
 > - `reference/scene-briefs.csv`: GN columns cleared (`page_layout`, `panel_breakdown`, `visual_keywords`, `page_turn_beats`, `caption_strategy`)
-> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-graphic-novel-to-novel/scenes-gn/`
+> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-graphic-novel-to-novel/scenes/`
 >
 > **What stays the same:**
 > - `reference/scene-intent.csv`, `reference/voice-profile.csv`, `reference/story-architecture.md`
@@ -138,14 +138,13 @@ This command does not invoke Claude (no API calls), so there are no `CLAUDECODE`
 > ```bash
 > cd <project_dir> && <plugin_path>/storyforge migrate-medium --to {target} --force
 > ```
-> (The `--force` flag skips the interactive confirmation that the CLI would ask for in a terminal.)
+> (`--force` lets you re-run migration on a project that's already in the target medium.)
 >
 > **Option B: Run it yourself**
 > Copy this command and run it in a separate terminal:
 > ```bash
 > cd <project_dir> && <plugin_path>/storyforge migrate-medium --to {target}
 > ```
-> The command will ask for confirmation before changing anything.
 
 Wait for the author's choice. If Option B, provide the exact command (with the real paths filled in) and end the skill session.
 

--- a/skills/migrate-medium/SKILL.md
+++ b/skills/migrate-medium/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: migrate-medium
+description: Convert a project from novel to graphic-novel mode (or vice versa). Archives the old data, updates schema, and tells you what to populate next. Use when an author wants to change their project's delivery medium.
+---
+
+# Storyforge Medium Migration
+
+You are helping an author convert their Storyforge project between novel and graphic-novel mode. This is a structural, mechanical operation — not a creative one. All coaching levels are treated identically for this skill.
+
+**What this migration does:**
+- Archives the current `scenes/`, CSVs, and `storyforge.yaml` to `working/migration/`
+- Updates `project.medium` in `storyforge.yaml`
+- Resets all scene statuses to `mapped` (prose or panel scripts are archived, not deleted)
+- Clears the medium-specific numeric columns from `scenes.csv`
+- For GN→novel: clears GN-specific brief columns (`page_layout`, `panel_breakdown`, etc.)
+- For novel→GN: appends visual migration notes to `character-bible.md` and `world-bible.md`
+
+**What it preserves:**
+- `reference/scene-intent.csv` (medium-agnostic)
+- `reference/voice-profile.csv` (voice carries between mediums)
+- `reference/story-architecture.md`, `character-bible.md`, `world-bible.md` content
+- All registry CSVs (`characters.csv`, `locations.csv`, etc.)
+
+---
+
+## Locating the Storyforge Plugin
+
+The Storyforge plugin root is two levels up from this skill file's directory:
+`skills/migrate-medium/` → `skills/` → plugin root.
+
+Resolve the plugin path and store it for commands below.
+
+---
+
+## Step 1: Read Project State
+
+Read the project's current state before asking any questions:
+
+1. Read `storyforge.yaml` — find `project.medium` (defaults to `novel` if absent)
+2. Read `reference/scenes.csv` — count scenes, note their current statuses
+3. Note whether `scenes/` has any drafted `.md` files
+
+Summarize to the author:
+
+> This project is currently in **{current_medium}** mode.
+> It has **{N} scene(s)** — **{X}** drafted, **{Y}** at mapped/briefed.
+> {If scenes/ has files: "**{count} scene file(s)** in `scenes/` will be archived."}
+
+---
+
+## Step 2: Determine Target Medium
+
+Ask the author what they want to convert to:
+
+> What medium do you want to convert this project to?
+>
+> **A.** Graphic novel (panel scripts, page-based pacing)
+> **B.** Novel (prose, word-based pacing)
+
+Wait for their choice. If they chose the medium the project is already in, tell them:
+
+> This project is already in **{medium}** mode. Nothing to migrate.
+>
+> If you want to create an archive snapshot anyway, run:
+> ```bash
+> cd <project_dir> && <plugin_path>/storyforge migrate-medium --to {medium} --force --no-commit
+> ```
+
+---
+
+## Step 3: Explain the Migration
+
+Before running anything, explain clearly what will happen:
+
+**Novel → Graphic Novel:**
+
+> **What changes:**
+> - `storyforge.yaml`: `project.medium` set to `graphic-novel`
+> - `reference/scenes.csv`: `target_words` and `word_count` cleared; all scenes reset to `status=mapped`
+> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-novel-to-graphic-novel/scenes-novel/`
+> - `reference/character-bible.md` and `reference/world-bible.md`: a visual migration note is appended if they lack `### Visual` sections
+>
+> **What stays the same:**
+> - `reference/scene-intent.csv` (narrative intent is medium-agnostic)
+> - `reference/voice-profile.csv` (voice carries across mediums)
+> - `reference/story-architecture.md` (story structure is unchanged)
+> - All registry CSVs (characters, locations, values, etc.)
+> - Brief text columns in `scene-briefs.csv` (goal, conflict, outcome, etc.) — the GN-specific columns are already empty; they get filled via `./storyforge elaborate --stage briefs`
+>
+> **After migration, you'll need to:**
+> 1. Add `### Visual` subsections to `reference/character-bible.md` per character
+> 2. Add `### Visual` subsections to `reference/world-bible.md` per location
+> 3. Set `target_pages` for each scene in `reference/scenes.csv`
+> 4. Run `./storyforge elaborate --stage briefs` to fill GN-specific brief columns
+> 5. Run `./storyforge write` to draft panel scripts scene by scene
+
+**Graphic Novel → Novel:**
+
+> **What changes:**
+> - `storyforge.yaml`: `project.medium` set to `novel`
+> - `reference/scenes.csv`: `target_pages`, `panel_count`, `page_count` cleared; all scenes reset to `status=mapped`
+> - `reference/scene-briefs.csv`: GN columns cleared (`page_layout`, `panel_breakdown`, `visual_keywords`, `page_turn_beats`, `caption_strategy`)
+> - `scenes/`: all `.md` files moved to `working/migration/{timestamp}-graphic-novel-to-novel/scenes-gn/`
+>
+> **What stays the same:**
+> - `reference/scene-intent.csv`, `reference/voice-profile.csv`, `reference/story-architecture.md`
+> - `reference/character-bible.md` and `reference/world-bible.md` — `### Visual` subsections are kept (they may still be useful as art reference for cover design or press kit)
+> - All registry CSVs
+>
+> **After migration, you'll need to:**
+> 1. Set `target_words` per scene in `reference/scenes.csv`
+>    (or run `./storyforge elaborate --stage map` to repopulate word targets)
+> 2. Run `./storyforge write` to draft prose scenes
+
+---
+
+## Step 4: Confirm
+
+Ask once:
+
+> Are you ready to proceed?
+>
+> **Yes** — run the migration now
+> **No** — cancel
+
+If they say no, end the session. No changes will have been made.
+
+---
+
+## Step 5: Run the Migration Command
+
+This command does not invoke Claude (no API calls), so there are no `CLAUDECODE` concerns.
+
+> **Option A: Run it here**
+> I'll run the migration in this conversation.
+>
+> Run:
+> ```bash
+> cd <project_dir> && <plugin_path>/storyforge migrate-medium --to {target} --force
+> ```
+> (The `--force` flag skips the interactive confirmation that the CLI would ask for in a terminal.)
+>
+> **Option B: Run it yourself**
+> Copy this command and run it in a separate terminal:
+> ```bash
+> cd <project_dir> && <plugin_path>/storyforge migrate-medium --to {target}
+> ```
+> The command will ask for confirmation before changing anything.
+
+Wait for the author's choice. If Option B, provide the exact command (with the real paths filled in) and end the skill session.
+
+If Option A, run the command and capture the output. The command will print a summary of what happened and what to do next.
+
+---
+
+## Step 6: Post-Migration Next Steps
+
+After the command completes, present the author with their next actions depending on direction:
+
+**Novel → Graphic Novel:**
+
+> Migration complete. Here's what to do next:
+>
+> 1. **Add visual subsections to your bibles**
+>    Open `reference/character-bible.md` and add a `### Visual` block for each character.
+>    Open `reference/world-bible.md` and add a `### Visual` block for each key location.
+>    (The migration appended a note with the exact format to follow if your bibles didn't have them yet.)
+>
+> 2. **Set target pages per scene**
+>    Open `reference/scenes.csv` and fill in the `target_pages` column for each scene.
+>    Typical graphic-novel pacing: 4–8 pages per scene for a standard 100-page book.
+>
+> 3. **Fill GN brief columns**
+>    Run `/storyforge:elaborate` and choose the briefs stage.
+>    This will populate `page_layout`, `panel_breakdown`, `visual_keywords`, `page_turn_beats`, and `caption_strategy` for each scene.
+>
+> 4. **Draft panel scripts**
+>    Run `/storyforge:forge` or use `./storyforge write` to draft scenes as panel scripts.
+
+**Graphic Novel → Novel:**
+
+> Migration complete. Here's what to do next:
+>
+> 1. **Set target words per scene**
+>    Open `reference/scenes.csv` and fill in the `target_words` column.
+>    Alternatively, run `/storyforge:elaborate` and choose the map stage to have Claude suggest word targets.
+>
+> 2. **Draft prose scenes**
+>    Run `/storyforge:forge` or use `./storyforge write` to begin drafting prose scenes.
+
+---
+
+## Reversibility Note
+
+Remind the author:
+
+> All changes are committed to git. If you need to undo the migration:
+> ```bash
+> git log --oneline -5   # find the commit before migration
+> git revert HEAD        # revert the migration commit
+> ```
+>
+> The full archive of your original files is also preserved at:
+> `working/migration/{timestamp}-{from}-to-{to}/`

--- a/tests/test_cmd_migrate_medium.py
+++ b/tests/test_cmd_migrate_medium.py
@@ -1,0 +1,404 @@
+"""Tests for storyforge migrate-medium command."""
+
+import os
+import shutil
+
+import pytest
+
+from storyforge.cmd_migrate_medium import (
+    parse_args,
+    step1_validate_direction,
+    step2_create_archive,
+    step3_snapshot_state,
+    step4_update_yaml,
+    step5_transform_scenes_csv,
+    step6_transform_briefs_csv,
+    step7_archive_and_clear_scenes_dir,
+    step8_add_bible_visual_notes,
+    main,
+)
+from storyforge.common import get_medium
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_csv_rows(path):
+    """Return (header, rows_as_dicts) from a pipe-delimited CSV."""
+    with open(path, encoding='utf-8') as f:
+        lines = [l for l in f.read().splitlines() if l.strip()]
+    if not lines:
+        return [], []
+    header = lines[0].split('|')
+    rows = [dict(zip(header, l.split('|'))) for l in lines[1:]]
+    return header, rows
+
+
+def _get_archive_dir(project_dir):
+    """Return the first migration archive directory found, or None."""
+    migration_root = os.path.join(project_dir, 'working', 'migration')
+    if not os.path.isdir(migration_root):
+        return None
+    entries = sorted(os.listdir(migration_root))
+    if not entries:
+        return None
+    return os.path.join(migration_root, entries[0])
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Novel → GN basic
+# ---------------------------------------------------------------------------
+
+def test_migrate_novel_to_gn_basic(project_dir, monkeypatch):
+    """Start with novel fixture, run migrate-medium --to graphic-novel.
+
+    Asserts:
+    - medium changed to graphic-novel
+    - target_words cleared in scenes.csv
+    - scenes/ archived (no .md files remain)
+    - archive dir exists with expected content
+    - bibles have stub note appended
+    """
+    monkeypatch.chdir(project_dir)
+
+    # Verify starting state
+    assert get_medium(project_dir) == 'novel'
+
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    initial_scene_files = [f for f in os.listdir(scenes_dir) if f.endswith('.md')]
+    assert len(initial_scene_files) > 0, 'fixture must have scene files'
+
+    # Run migration
+    main(['--to', 'graphic-novel', '--no-commit', '--force'])
+
+    # Medium changed
+    assert get_medium(project_dir) == 'graphic-novel'
+
+    # target_words and word_count cleared
+    _, rows = _read_csv_rows(os.path.join(project_dir, 'reference', 'scenes.csv'))
+    for row in rows:
+        assert row.get('target_words', '') == '', \
+            f'target_words should be cleared, got {row.get("target_words")!r}'
+        assert row.get('word_count', '') == '', \
+            f'word_count should be cleared, got {row.get("word_count")!r}'
+
+    # All scenes reset to mapped
+    for row in rows:
+        assert row.get('status') == 'mapped', \
+            f'scene {row.get("id")} should be mapped, got {row.get("status")!r}'
+
+    # scenes/ is cleared of .md files
+    remaining = [f for f in os.listdir(scenes_dir) if f.endswith('.md')]
+    assert remaining == [], f'scenes/ should be empty of .md files, found: {remaining}'
+
+    # Archive exists and contains scenes
+    archive_dir = _get_archive_dir(project_dir)
+    assert archive_dir is not None, 'migration archive directory must exist'
+    assert 'novel' in archive_dir and 'graphic-novel' in archive_dir
+
+    archived_scenes = os.path.join(archive_dir, 'scenes-novel')
+    assert os.path.isdir(archived_scenes), 'archive must have scenes-novel subdir'
+    archived_files = [f for f in os.listdir(archived_scenes) if f.endswith('.md')]
+    assert len(archived_files) == len(initial_scene_files), \
+        f'all original scene files should be in archive'
+
+    # storyforge.yaml in archive
+    assert os.path.isfile(os.path.join(archive_dir, 'storyforge.yaml'))
+
+    # scenes.csv in archive
+    assert os.path.isfile(os.path.join(archive_dir, 'reference', 'scenes.csv'))
+
+    # Bible visual notes appended
+    char_bible = os.path.join(project_dir, 'reference', 'character-bible.md')
+    if os.path.isfile(char_bible):
+        with open(char_bible) as f:
+            content = f.read()
+        assert 'Graphic Novel Migration Note' in content, \
+            'character-bible.md should have visual migration note'
+
+
+# ---------------------------------------------------------------------------
+# Test 2: GN → novel basic
+# ---------------------------------------------------------------------------
+
+def test_migrate_gn_to_novel_basic(project_dir_gn, monkeypatch, tmp_path):
+    """Start with GN fixture (with a drafted scene), run migrate-medium --to novel.
+
+    Asserts:
+    - medium changed to novel
+    - target_pages, panel_count, page_count cleared
+    - GN brief columns cleared
+    - scenes/ archived
+    """
+    monkeypatch.chdir(project_dir_gn)
+
+    assert get_medium(project_dir_gn) == 'graphic-novel'
+
+    # Add a drafted scene file to the GN fixture
+    scenes_dir = os.path.join(project_dir_gn, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    test_scene = os.path.join(scenes_dir, 'the-blank-page.md')
+    with open(test_scene, 'w') as f:
+        f.write('## Page 1\n\n**Panel 1**\nFake panel script.\n')
+
+    main(['--to', 'novel', '--no-commit', '--force'])
+
+    # Medium changed
+    assert get_medium(project_dir_gn) == 'novel'
+
+    # GN scene columns cleared
+    _, rows = _read_csv_rows(os.path.join(project_dir_gn, 'reference', 'scenes.csv'))
+    for row in rows:
+        for col in ('target_pages', 'panel_count', 'page_count'):
+            assert row.get(col, '') == '', \
+                f'{col} should be cleared, got {row.get(col)!r}'
+        assert row.get('status') == 'mapped'
+
+    # GN brief columns cleared
+    _, brief_rows = _read_csv_rows(
+        os.path.join(project_dir_gn, 'reference', 'scene-briefs.csv')
+    )
+    gn_cols = ['page_layout', 'panel_breakdown', 'visual_keywords',
+               'page_turn_beats', 'caption_strategy']
+    for row in brief_rows:
+        for col in gn_cols:
+            if col in row:
+                assert row[col] == '', \
+                    f'GN column {col} should be cleared, got {row[col]!r}'
+
+    # scenes/ cleared
+    remaining = [f for f in os.listdir(scenes_dir)
+                 if f.endswith('.md') and f != '.gitkeep']
+    assert remaining == [], f'scenes/ should be empty after migration, found: {remaining}'
+
+    # Archive exists with scenes-gn
+    archive_dir = _get_archive_dir(project_dir_gn)
+    assert archive_dir is not None
+    archived = os.path.join(archive_dir, 'scenes-gn')
+    assert os.path.isdir(archived)
+    assert 'the-blank-page.md' in os.listdir(archived)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Refuses when already in target medium
+# ---------------------------------------------------------------------------
+
+def test_migrate_refuses_when_already_target(project_dir_gn, monkeypatch):
+    """Running migrate-medium --to graphic-novel on a GN project exits 1."""
+    monkeypatch.chdir(project_dir_gn)
+    assert get_medium(project_dir_gn) == 'graphic-novel'
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(['--to', 'graphic-novel', '--no-commit'])
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4: --force bypasses refusal
+# ---------------------------------------------------------------------------
+
+def test_migrate_force_bypasses_refusal(project_dir_gn, monkeypatch):
+    """Running with --force on an already-target project exits 0 and archives."""
+    monkeypatch.chdir(project_dir_gn)
+    assert get_medium(project_dir_gn) == 'graphic-novel'
+
+    # Should NOT raise SystemExit(1)
+    main(['--to', 'graphic-novel', '--no-commit', '--force'])
+
+    # Archive was still created
+    archive_dir = _get_archive_dir(project_dir_gn)
+    assert archive_dir is not None, 'archive should be created even with --force'
+
+
+# ---------------------------------------------------------------------------
+# Test 5: --dry-run makes no changes
+# ---------------------------------------------------------------------------
+
+def test_migrate_dry_run_makes_no_changes(project_dir, monkeypatch):
+    """--dry-run does not modify any files."""
+    monkeypatch.chdir(project_dir)
+
+    # Capture original file contents
+    yaml_path = os.path.join(project_dir, 'storyforge.yaml')
+    scenes_csv_path = os.path.join(project_dir, 'reference', 'scenes.csv')
+    scenes_dir = os.path.join(project_dir, 'scenes')
+
+    with open(yaml_path) as f:
+        original_yaml = f.read()
+    with open(scenes_csv_path) as f:
+        original_scenes_csv = f.read()
+    original_scene_files = sorted(os.listdir(scenes_dir))
+
+    main(['--to', 'graphic-novel', '--dry-run'])
+
+    # Nothing changed
+    with open(yaml_path) as f:
+        assert f.read() == original_yaml, 'storyforge.yaml should not be changed in dry-run'
+    with open(scenes_csv_path) as f:
+        assert f.read() == original_scenes_csv, 'scenes.csv should not be changed in dry-run'
+    assert sorted(os.listdir(scenes_dir)) == original_scene_files, \
+        'scenes/ should not be changed in dry-run'
+
+    # No migration archive created
+    migration_root = os.path.join(project_dir, 'working', 'migration')
+    assert not os.path.isdir(migration_root) or not os.listdir(migration_root), \
+        'migration archive should not be created in dry-run'
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Archive contains snapshot
+# ---------------------------------------------------------------------------
+
+def test_archive_contains_snapshot(project_dir, monkeypatch):
+    """Verify archive has copies of storyforge.yaml, scenes.csv, scene-briefs.csv, and scenes/."""
+    monkeypatch.chdir(project_dir)
+
+    main(['--to', 'graphic-novel', '--no-commit', '--force'])
+
+    archive_dir = _get_archive_dir(project_dir)
+    assert archive_dir is not None
+
+    # storyforge.yaml
+    assert os.path.isfile(os.path.join(archive_dir, 'storyforge.yaml'))
+
+    # scenes.csv
+    assert os.path.isfile(os.path.join(archive_dir, 'reference', 'scenes.csv'))
+
+    # scene-briefs.csv
+    assert os.path.isfile(os.path.join(archive_dir, 'reference', 'scene-briefs.csv'))
+
+    # scenes/ files
+    archived_scenes = os.path.join(archive_dir, 'scenes-novel')
+    assert os.path.isdir(archived_scenes), 'archive must contain scenes-novel/'
+    archived_files = [f for f in os.listdir(archived_scenes) if f.endswith('.md')]
+    assert len(archived_files) > 0, 'archive must contain at least one scene file'
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual steps
+# ---------------------------------------------------------------------------
+
+def test_step1_validate_direction_exits_when_already_target(project_dir):
+    """step1 exits 1 if project is already at target and force=False."""
+    # novel fixture → asking for novel should exit 1
+    with pytest.raises(SystemExit) as exc_info:
+        step1_validate_direction(project_dir, 'novel', force=False)
+    assert exc_info.value.code == 1
+
+
+def test_step1_validate_direction_allows_force(project_dir):
+    """step1 returns (from, to) without exiting when force=True."""
+    from_m, to_m = step1_validate_direction(project_dir, 'novel', force=True)
+    assert from_m == 'novel'
+    assert to_m == 'novel'
+
+
+def test_step5_clears_novel_columns_for_novel_to_gn(project_dir):
+    """N→GN clears target_words and word_count."""
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    _, before_rows = _read_csv_rows(scenes_csv)
+    # Ensure there's something to clear
+    assert any(r.get('target_words') for r in before_rows)
+
+    step5_transform_scenes_csv(project_dir, 'novel', 'graphic-novel', dry_run=False)
+
+    _, after_rows = _read_csv_rows(scenes_csv)
+    for row in after_rows:
+        assert row.get('target_words', '') == ''
+        assert row.get('word_count', '') == ''
+        assert row.get('status') == 'mapped'
+
+
+def test_step5_clears_gn_columns_for_gn_to_novel(project_dir_gn):
+    """GN→novel clears target_pages, panel_count, page_count."""
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    _, before_rows = _read_csv_rows(scenes_csv)
+    assert any(r.get('target_pages') for r in before_rows)
+
+    step5_transform_scenes_csv(project_dir_gn, 'graphic-novel', 'novel', dry_run=False)
+
+    _, after_rows = _read_csv_rows(scenes_csv)
+    for row in after_rows:
+        assert row.get('target_pages', '') == ''
+        assert row.get('status') == 'mapped'
+
+
+def test_step6_clears_gn_brief_columns(project_dir_gn):
+    """GN→novel clears all five GN brief columns."""
+    briefs_csv = os.path.join(project_dir_gn, 'reference', 'scene-briefs.csv')
+    _, before = _read_csv_rows(briefs_csv)
+    assert any(r.get('panel_breakdown') for r in before), \
+        'fixture should have panel_breakdown populated'
+
+    step6_transform_briefs_csv(project_dir_gn, 'graphic-novel', 'novel', dry_run=False)
+
+    _, after = _read_csv_rows(briefs_csv)
+    gn_cols = ['page_layout', 'panel_breakdown', 'visual_keywords',
+               'page_turn_beats', 'caption_strategy']
+    for row in after:
+        for col in gn_cols:
+            if col in row:
+                assert row[col] == '', f'{col} should be cleared'
+
+
+def test_step6_skips_for_novel_to_gn(project_dir):
+    """step6 is a no-op for novel→GN direction."""
+    briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+    with open(briefs_csv) as f:
+        original = f.read()
+
+    result = step6_transform_briefs_csv(project_dir, 'novel', 'graphic-novel', dry_run=False)
+    assert result.startswith('skip')
+
+    with open(briefs_csv) as f:
+        assert f.read() == original, 'scene-briefs.csv should not be modified for N→GN'
+
+
+def test_step8_appends_visual_note_when_no_visual_sections(project_dir):
+    """step8 appends visual note to bibles that lack ### Visual sections."""
+    char_bible = os.path.join(project_dir, 'reference', 'character-bible.md')
+    assert os.path.isfile(char_bible)
+    with open(char_bible) as f:
+        content = f.read()
+    assert '### Visual' not in content, 'fixture bible should not have ### Visual'
+
+    modified = step8_add_bible_visual_notes(project_dir, dry_run=False)
+    assert char_bible in modified or any(char_bible == m for m in modified)
+
+    with open(char_bible) as f:
+        updated = f.read()
+    assert 'Graphic Novel Migration Note' in updated
+
+
+def test_step8_skips_when_visual_already_present(project_dir_gn):
+    """step8 does not modify bibles that already have ### Visual sections."""
+    char_bible = os.path.join(project_dir_gn, 'reference', 'character-bible.md')
+    with open(char_bible) as f:
+        content_before = f.read()
+    assert '### Visual' in content_before
+
+    modified = step8_add_bible_visual_notes(project_dir_gn, dry_run=False)
+    assert char_bible not in modified
+
+    with open(char_bible) as f:
+        assert f.read() == content_before, 'file should be unchanged'
+
+
+def test_parse_args_requires_to():
+    """parse_args exits with error if --to is missing."""
+    with pytest.raises(SystemExit):
+        parse_args([])
+
+
+def test_parse_args_accepts_both_mediums():
+    args = parse_args(['--to', 'novel'])
+    assert args.target == 'novel'
+    args = parse_args(['--to', 'graphic-novel'])
+    assert args.target == 'graphic-novel'
+
+
+def test_parse_args_dry_run_and_force():
+    args = parse_args(['--to', 'novel', '--dry-run', '--force'])
+    assert args.dry_run is True
+    assert args.force is True

--- a/tests/test_cmd_migrate_medium.py
+++ b/tests/test_cmd_migrate_medium.py
@@ -97,8 +97,8 @@ def test_migrate_novel_to_gn_basic(project_dir, monkeypatch):
     assert archive_dir is not None, 'migration archive directory must exist'
     assert 'novel' in archive_dir and 'graphic-novel' in archive_dir
 
-    archived_scenes = os.path.join(archive_dir, 'scenes-novel')
-    assert os.path.isdir(archived_scenes), 'archive must have scenes-novel subdir'
+    archived_scenes = os.path.join(archive_dir, 'scenes')
+    assert os.path.isdir(archived_scenes), 'archive must have scenes/ subdir'
     archived_files = [f for f in os.listdir(archived_scenes) if f.endswith('.md')]
     assert len(archived_files) == len(initial_scene_files), \
         f'all original scene files should be in archive'
@@ -172,10 +172,10 @@ def test_migrate_gn_to_novel_basic(project_dir_gn, monkeypatch, tmp_path):
                  if f.endswith('.md') and f != '.gitkeep']
     assert remaining == [], f'scenes/ should be empty after migration, found: {remaining}'
 
-    # Archive exists with scenes-gn
+    # Archive exists with scenes/
     archive_dir = _get_archive_dir(project_dir_gn)
     assert archive_dir is not None
-    archived = os.path.join(archive_dir, 'scenes-gn')
+    archived = os.path.join(archive_dir, 'scenes')
     assert os.path.isdir(archived)
     assert 'the-blank-page.md' in os.listdir(archived)
 
@@ -269,8 +269,8 @@ def test_archive_contains_snapshot(project_dir, monkeypatch):
     assert os.path.isfile(os.path.join(archive_dir, 'reference', 'scene-briefs.csv'))
 
     # scenes/ files
-    archived_scenes = os.path.join(archive_dir, 'scenes-novel')
-    assert os.path.isdir(archived_scenes), 'archive must contain scenes-novel/'
+    archived_scenes = os.path.join(archive_dir, 'scenes')
+    assert os.path.isdir(archived_scenes), 'archive must contain scenes/'
     archived_files = [f for f in os.listdir(archived_scenes) if f.endswith('.md')]
     assert len(archived_files) > 0, 'archive must contain at least one scene file'
 
@@ -383,6 +383,28 @@ def test_step8_skips_when_visual_already_present(project_dir_gn):
 
     with open(char_bible) as f:
         assert f.read() == content_before, 'file should be unchanged'
+
+
+def test_migrate_preserves_cut_and_merged_statuses(project_dir, monkeypatch):
+    """Scenes with status=cut or status=merged are terminal editorial states
+    and MUST be preserved across migration. Resetting them to 'mapped'
+    would reactivate scenes the author deliberately removed."""
+    monkeypatch.chdir(project_dir)
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    # Append rows with terminal statuses (13 columns to match the header:
+    # id|seq|title|part|pov|location|timeline_day|time_of_day|duration|type|status|word_count|target_words)
+    with open(scenes_csv, 'a') as f:
+        f.write('cut-scene|99|Cut Scene|1|||||||cut||\n')
+        f.write('merged-scene|100|Merged Scene|1|||||||merged||\n')
+    from storyforge import cmd_migrate_medium
+    cmd_migrate_medium.main(['--to', 'graphic-novel', '--no-commit'])
+
+    # Verify cut and merged scenes still have their terminal statuses
+    from storyforge.csv_cli import get_field
+    assert get_field(scenes_csv, 'cut-scene', 'status') == 'cut', \
+        'cut scene status must survive migration'
+    assert get_field(scenes_csv, 'merged-scene', 'status') == 'merged', \
+        'merged scene status must survive migration'
 
 
 def test_parse_args_requires_to():

--- a/tests/test_cmd_migrate_medium.py
+++ b/tests/test_cmd_migrate_medium.py
@@ -342,17 +342,27 @@ def test_step6_clears_gn_brief_columns(project_dir_gn):
                 assert row[col] == '', f'{col} should be cleared'
 
 
-def test_step6_skips_for_novel_to_gn(project_dir):
-    """step6 is a no-op for novel→GN direction."""
+def test_step6_widens_header_for_novel_to_gn(project_dir):
+    """step6 widens scene-briefs.csv to the full schema on novel→GN.
+
+    The five GN columns are added (empty) so the author can populate them
+    after migration without manually editing the header.
+    """
     briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
     with open(briefs_csv) as f:
-        original = f.read()
+        original_header = f.readline().strip().split('|')
+    # Novel fixture should NOT have GN columns yet
+    assert 'page_layout' not in original_header
 
     result = step6_transform_briefs_csv(project_dir, 'novel', 'graphic-novel', dry_run=False)
-    assert result.startswith('skip')
+    assert result.startswith('done')
 
     with open(briefs_csv) as f:
-        assert f.read() == original, 'scene-briefs.csv should not be modified for N→GN'
+        new_header = f.readline().strip().split('|')
+    # After widening, GN columns must be present
+    for col in ('page_layout', 'panel_breakdown', 'visual_keywords',
+                'page_turn_beats', 'caption_strategy'):
+        assert col in new_header, f'{col} must be in widened header'
 
 
 def test_step8_appends_visual_note_when_no_visual_sections(project_dir):
@@ -371,18 +381,28 @@ def test_step8_appends_visual_note_when_no_visual_sections(project_dir):
     assert 'Graphic Novel Migration Note' in updated
 
 
-def test_step8_skips_when_visual_already_present(project_dir_gn):
-    """step8 does not modify bibles that already have ### Visual sections."""
+def test_step8_appends_even_when_visual_already_present(project_dir_gn):
+    """step8 always appends the migration note, even when ### Visual sections exist.
+
+    A partial migration (some characters already have a Visual section) would
+    otherwise leave the remaining characters without a migration cue. The note
+    is additive and harmless to delete; skipping silently leaves gaps.
+    """
     char_bible = os.path.join(project_dir_gn, 'reference', 'character-bible.md')
     with open(char_bible) as f:
         content_before = f.read()
-    assert '### Visual' in content_before
+    assert '### Visual' in content_before, 'GN fixture should already have ### Visual'
 
     modified = step8_add_bible_visual_notes(project_dir_gn, dry_run=False)
-    assert char_bible not in modified
+    # The note SHOULD be appended (changed behavior)
+    assert char_bible in modified, 'char_bible should be in modified list'
 
     with open(char_bible) as f:
-        assert f.read() == content_before, 'file should be unchanged'
+        content_after = f.read()
+    assert 'Graphic Novel Migration Note' in content_after, \
+        'migration note should be appended even when ### Visual exists'
+    # The original content is preserved at the front
+    assert content_after.startswith(content_before)
 
 
 def test_migrate_preserves_cut_and_merged_statuses(project_dir, monkeypatch):
@@ -424,3 +444,89 @@ def test_parse_args_dry_run_and_force():
     args = parse_args(['--to', 'novel', '--dry-run', '--force'])
     assert args.dry_run is True
     assert args.force is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: Fix #1 — branch creation
+# ---------------------------------------------------------------------------
+
+def test_migrate_creates_branch_when_on_main(project_dir, monkeypatch, tmp_path):
+    """Per CLAUDE.md, migrate-medium MUST create a feature branch if on main.
+
+    Skipping this would commit a medium conversion directly to main.
+    """
+    import subprocess
+    monkeypatch.chdir(project_dir)
+    # Initialize a git repo on main
+    subprocess.run(['git', 'init', '-b', 'main'], cwd=project_dir, check=True,
+                   capture_output=True)
+    subprocess.run(['git', 'add', '-A'], cwd=project_dir, check=True,
+                   capture_output=True)
+    subprocess.run(['git', '-c', 'user.email=test@test', '-c', 'user.name=test',
+                    'commit', '-m', 'initial'], cwd=project_dir, check=True,
+                   capture_output=True)
+    from storyforge import cmd_migrate_medium
+    cmd_migrate_medium.main(['--to', 'graphic-novel'])
+    # After migration, HEAD should be on a storyforge/migrate-medium-* branch
+    result = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                            cwd=project_dir, capture_output=True, text=True)
+    branch = result.stdout.strip()
+    assert branch.startswith('storyforge/migrate-medium-'), (
+        f'expected feature branch, but on {branch}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Fix #2 — partial-Visual detection is binary
+# ---------------------------------------------------------------------------
+
+def test_migrate_appends_visual_note_even_when_one_visual_section_exists(
+        project_dir, monkeypatch):
+    """If a bible has SOME ### Visual sections already (partial migration),
+    the migration still appends the prompt so the author has a complete cue
+    for the un-migrated characters."""
+    monkeypatch.chdir(project_dir)
+    char_bible = os.path.join(project_dir, 'reference', 'character-bible.md')
+    # Seed a partial state: one Visual section
+    with open(char_bible, 'a') as f:
+        f.write('\n## Alice\n\n### Visual\n\nAlice has red hair.\n\n## Bob\n\n(needs visual)\n')
+    from storyforge import cmd_migrate_medium
+    cmd_migrate_medium.main(['--to', 'graphic-novel', '--no-commit'])
+    # The migration note should still appear at end of file
+    with open(char_bible) as f:
+        content = f.read()
+    assert 'Graphic Novel Migration Note' in content, \
+        'migration note must be appended even when partial ### Visual sections exist'
+    # Alice's section was NOT removed — original content is intact
+    assert '## Alice' in content
+    assert '## Bob' in content
+
+
+# ---------------------------------------------------------------------------
+# Regression: Fix #3 — non-scene .md files must not be archived
+# ---------------------------------------------------------------------------
+
+def test_migrate_preserves_readme_and_notes_in_scenes_dir(project_dir, monkeypatch):
+    """README.md, NOTES.md, and other non-scene .md files in scenes/ must
+    NOT be archived as scenes — they are author notes."""
+    monkeypatch.chdir(project_dir)
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    # Create a scene-shaped file and a README
+    for sid in ['the-opening', 'README', 'NOTES']:
+        with open(os.path.join(scenes_dir, f'{sid}.md'), 'w') as f:
+            f.write(f'# {sid}\n')
+    # Make 'the-opening' an actual scene in scenes.csv
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    with open(scenes_csv, 'a') as f:
+        f.write('the-opening|99|Opening|1|||||||drafted||||\n')
+    from storyforge import cmd_migrate_medium
+    cmd_migrate_medium.main(['--to', 'graphic-novel', '--no-commit'])
+    # README.md and NOTES.md should still be in scenes/
+    assert os.path.isfile(os.path.join(scenes_dir, 'README.md')), \
+        'README.md must not be archived'
+    assert os.path.isfile(os.path.join(scenes_dir, 'NOTES.md')), \
+        'NOTES.md must not be archived'
+    # the-opening.md should NOT be in scenes/ (archived)
+    assert not os.path.isfile(os.path.join(scenes_dir, 'the-opening.md')), \
+        'the-opening.md should have been archived'

--- a/tests/wiring/test_cli_dispatch.py
+++ b/tests/wiring/test_cli_dispatch.py
@@ -32,6 +32,7 @@ class TestMainDispatch:
         'write', 'evaluate', 'revise', 'score', 'elaborate', 'extract',
         'validate', 'hone', 'reconcile', 'enrich', 'assemble', 'visualize',
         'timeline', 'cleanup', 'cover', 'scenes-setup', 'review', 'migrate',
+        'migrate-medium',
     }
 
     def test_all_documented_commands_present(self):


### PR DESCRIPTION
## Summary

New `./storyforge migrate-medium --to {novel|graphic-novel}` command that converts an existing project's medium. Archives the prior state to `working/migration/{timestamp}-{from}-to-{to}/` for recovery, updates the medium field, and applies direction-specific transformations to scenes.csv and scene-briefs.csv.

Closes #216.

## What's new

- `cmd_migrate_medium.py` — nine-step migration: detect direction → archive snapshot → update yaml → clear medium-specific columns → reset non-terminal scene statuses → archive scenes/ directory → append visual-section stubs to bibles (N→GN only) → print summary with next steps
- `skills/migrate-medium/SKILL.md` — interactive guide that explains what changes, what's preserved, and what the author needs to do next
- Dispatcher wired; version bumped to 1.21.0

## Safety design

- **Snapshot before mutate.** Every file is copied to `working/migration/{...}/` before any destructive step runs. If the snapshot fails, the migration aborts before touching project files.
- **`shutil.move`** is used to relocate `scenes/`, not delete-and-rewrite.
- **Cut/merged scenes are preserved.** Caught in code review — these terminal editorial statuses MUST survive migration so deliberately-cut scenes aren't reactivated. Regression test added.
- **YAML insertion handles legacy projects.** Projects predating Plan 1 (no `medium:` field) get the field inserted under the `project:` block. Regex broadened to tolerate trailing comments. Post-write verification confirms the field landed.
- **Reversibility via git** (every commit auto-revertible) plus the timestamped archive in `working/migration/` as a fallback.

## Tests

- 17 unit tests in `tests/test_cmd_migrate_medium.py` covering both directions, --dry-run, --force, archive contents, brief column clearing
- Regression test for cut/merged status preservation
- Wiring test updated to expect `migrate-medium` in `COMMANDS`

## Test plan

- [x] `python3 -m pytest tests/` — 3522 passing, 0 failures
- [x] Code review caught cut/merged data loss bug — fixed before merge
- [x] Code review caught YAML regex too narrow for legacy formats — fixed with post-write verification
- [x] Dry-run + manual smoke test on a fixture copy: archive created, scenes.csv columns cleared, status reset to 'mapped' on non-terminal rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)