### PR TITLE
GN scoring and lightweight evaluation (closes #209 partial; revise deferred)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,20 +349,23 @@ Key principles:
 | `scoring_weather.py` | Deterministic scorer: no_weather_dreams (scene opening patterns) |
 | `scoring_rhythm.py` | Deterministic scorer: sentence_as_thought (sentence length variance) |
 | `scoring_economy.py` | Deterministic scorer: economy_clarity (composite filler/AI-tell/passive/adverb) |
+| `scoring_gn.py` | Deterministic GN scorers: brief_fidelity, panel_density, dialogue_compression, layout_rhythm, caption_economy, panel_composition_depth |
 
 ## Graphic Novel Mode
 
 Set `project.medium: graphic-novel` in storyforge.yaml at init time to switch a project into graphic-novel mode. To convert an existing project between mediums, use `storyforge migrate-medium --to {novel|graphic-novel}` (archives current state, resets scene drafts, transforms CSV schemas).
 
-**Supported (Plans 1 + 2):**
+**Supported (Plans 1 + 2 + 3):**
 - `elaborate` (spine, architecture, scene-map, voice, briefs)
 - `hone`, `validate`, `cleanup`
 - `write` — drafts panel scripts per scene (mirrors novel-mode write; routes to `cmd_write_gn`)
 - `assemble` — produces the artist handoff bundle: `manuscript/{script.md, visual-references.md, chapter-map.md, handoff-readme.md}` (routes to `cmd_script_package`)
 - Schema validation enforces graphic-novel column rules (target_pages required, panel_breakdown required at briefed status)
+- `score` — 6 deterministic GN principles in `scoring_gn.py` (brief_fidelity, panel_density, dialogue_compression, layout_rhythm, caption_economy, panel_composition_depth); no API calls, instant and cost-free (routes to `cmd_score_gn`)
+- `evaluate` — 3-persona evaluation panel (panel-composition, pacing, dialogue critics) that adds subjective findings the deterministic scorers can't catch (routes to `cmd_evaluate_gn`)
 
 **Not yet supported (followups tracked as issues):**
-- `evaluate`, `score`, `revise` — GN-specific rubric is its own design problem (#209)
+- `revise` — GN-specific revision passes deferred pending real scoring/evaluation data (#209 followup)
 - `publish`, `annotations` — Bookshelf integration for GN (#215)
 - `extract` — extract structure from existing scripts/prose (#213)
 

--- a/docs/superpowers/plans/2026-05-21-gn-scoring-evaluation.md
+++ b/docs/superpowers/plans/2026-05-21-gn-scoring-evaluation.md
@@ -1,0 +1,502 @@
+# GN Scoring and Lightweight Evaluation (Issue #209)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Give graphic-novel authors actionable feedback on drafted scenes via deterministic craft scoring + a lightweight multi-evaluator panel. `cmd_revise_gn` is explicitly deferred to a followup once we have real-world scoring data to inform what revisions matter.
+
+**Architecture:** Two new commands (`cmd_score_gn`, `cmd_evaluate_gn`) routed by the dispatcher. Six deterministic scorers in a single `scoring_gn.py` module (mirrors the novel-mode scoring modules but produces structured score dicts directly rather than the LLM pipeline). Three evaluator personas as markdown files. Existing `score` skill becomes medium-aware.
+
+**Issue:** [#209](https://github.com/benjaminsnorris/storyforge/issues/209)
+
+**v1 scope:** Score + lightweight evaluate. Revise deferred to followup (will be opened as a new issue at end).
+
+---
+
+## v1 Craft Principles (Deterministic)
+
+Each principle runs without API calls, scoring panel scripts on objective signals:
+
+| Principle | What it measures | Score formula |
+|---|---|---|
+| `brief_fidelity` | Does the script honor the brief contract? Wraps `script_format.check_brief_fidelity`. | 1.0 - (failures / total_checks), clamped to [0, 1] |
+| `panel_density` | Average panels per page. Sweet spot 4-7. | 1.0 - (distance from 5.5) / 5.5, clamped |
+| `dialogue_compression` | Word balloons ≤ 25 words. | Fraction of balloons under threshold |
+| `layout_rhythm` | Variation in per-page panel counts. Too uniform = mechanical; too varied = chaotic. | Penalizes both extremes around stdev ≈ 1.5 |
+| `caption_economy` | Captions per page. Strategy-aware: `minimal` expects ≤1, `journal-voiceover` expects ≤3, `none` expects 0, `omniscient` expects ≤4. | Fraction of pages within strategy's target |
+| `panel_composition_depth` | Composition prose word count per panel. Sweet spot 15-50 words. | Fraction of panels in the sweet spot |
+
+Each scorer returns `{principle, score, scene_id, findings: [...]}` where findings are actionable specifics (e.g., "Page 3 panel 4 has only 6 words of composition; artist needs more visual detail").
+
+## v1 Evaluator Personas
+
+Three markdown files, each containing the system prompt that turns Claude into that evaluator:
+
+1. **panel-composition-critic.md** — Reads the script. Asks: does each panel give the artist enough? Are character/setting visuals consistent with the bibles? Where is composition too sparse to draw?
+
+2. **pacing-critic.md** — Reads the script. Asks: does the page-to-page rhythm match the emotional arc? Are page-turn beats earned? Where does pacing falter (too many quiet pages in a row, no breathing room after action)?
+
+3. **dialogue-critic.md** — Reads the script. Asks: are balloons compressed? Are character voices distinct? Does caption strategy actually appear consistent with what the brief specified?
+
+Each evaluator outputs findings in the existing evaluation findings format (fix_location, severity, message, scene_id, page/panel anchor).
+
+---
+
+## File Structure
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `scripts/lib/python/storyforge/scoring_gn.py` | All 6 deterministic scorers in one module |
+| `scripts/lib/python/storyforge/cmd_score_gn.py` | Orchestration: loads scenes, runs scorers, writes output |
+| `scripts/lib/python/storyforge/cmd_evaluate_gn.py` | Orchestration: builds prompts per evaluator, invokes API, parses findings |
+| `scripts/prompts/evaluators-gn/panel-composition-critic.md` | Persona prompt |
+| `scripts/prompts/evaluators-gn/pacing-critic.md` | Persona prompt |
+| `scripts/prompts/evaluators-gn/dialogue-critic.md` | Persona prompt |
+| `references/default-craft-weights-gn.csv` | GN-specific weights (6 principles for v1) |
+| `tests/test_scoring_gn.py` | Unit tests for the 6 deterministic scorers |
+| `tests/test_cmd_score_gn.py` | End-to-end tests with the GN fixture |
+| `tests/test_cmd_evaluate_gn.py` | End-to-end tests with API mocked |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `scripts/lib/python/storyforge/__main__.py` | Remove `score`, `evaluate` from `GN_UNSUPPORTED_COMMANDS`; add to `GN_ROUTED_COMMANDS` |
+| `skills/score/SKILL.md` | Add medium-aware section for graphic-novel projects |
+| `tests/wiring/test_cli_dispatch.py` | Update EXPECTED_COMMANDS if needed |
+| `.claude-plugin/plugin.json` | Bump to 1.22.0 |
+| `CLAUDE.md` | Move `score`, `evaluate` from "Not yet supported" to "Supported"; mention scoring_gn principles |
+
+---
+
+## Tasks
+
+### Task 1: `scoring_gn.py` — six deterministic scorers
+
+**Files:**
+- Create: `scripts/lib/python/storyforge/scoring_gn.py`
+- Create: `tests/test_scoring_gn.py`
+
+Module structure (mirror the existing `scoring_passive.py`, `scoring_adverbs.py`, etc. pattern):
+
+```python
+"""Deterministic craft scorers for graphic-novel mode.
+
+Each scorer takes a parsed script (via storyforge.script_format.parse_script)
+and a brief row, then returns a structured score dict with findings.
+
+Scorers expose `score_scene(parsed_script, brief_row, scene_id) -> dict` and
+the module exposes a top-level `score_project(project_dir) -> dict` for the
+dispatcher contract (returns {'skipped': True, 'reason': '...'} on errors,
+otherwise a structured score dict).
+"""
+
+import statistics
+from storyforge.script_format import parse_script, check_brief_fidelity
+from storyforge.common import get_medium
+
+PRINCIPLES = (
+    'brief_fidelity', 'panel_density', 'dialogue_compression',
+    'layout_rhythm', 'caption_economy', 'panel_composition_depth',
+)
+
+
+def score_brief_fidelity(parsed, brief_row, script_text):
+    """1.0 - (failures / total_brief_checks). 4 checks: dialogue, visuals, panels, page-turns."""
+    failures = check_brief_fidelity(brief_row, script_text)
+    total_checks = 4  # 4 kinds of fidelity failures possible
+    failure_count = len(failures)
+    score = max(0.0, 1.0 - (failure_count / total_checks))
+    findings = [
+        {'kind': f['kind'], 'detail': f['detail'], 'severity': f.get('severity', 'medium')}
+        for f in failures
+    ]
+    return {'principle': 'brief_fidelity', 'score': score, 'findings': findings}
+
+
+def score_panel_density(parsed, brief_row=None, script_text=None):
+    """Sweet spot: 4-7 panels per page. Score = 1.0 - (|avg - 5.5| / 5.5)."""
+    pages = parsed['pages']
+    if not pages:
+        return {'principle': 'panel_density', 'score': 1.0, 'findings': []}
+    densities = [len(p['panels']) for p in pages]
+    avg = sum(densities) / len(densities)
+    score = max(0.0, 1.0 - abs(avg - 5.5) / 5.5)
+    findings = []
+    for p in pages:
+        n = len(p['panels'])
+        if n > 9:
+            findings.append({
+                'kind': 'panel_density_high',
+                'detail': f'Page {p["number"]}: {n} panels (cramped)',
+                'severity': 'medium',
+            })
+        elif n == 0:
+            findings.append({
+                'kind': 'panel_density_zero',
+                'detail': f'Page {p["number"]}: no panels parsed',
+                'severity': 'high',
+            })
+    return {'principle': 'panel_density', 'score': score, 'findings': findings}
+
+
+def score_dialogue_compression(parsed, brief_row=None, script_text=None):
+    """Word balloons ≤ 25 words. Score = fraction under threshold."""
+    MAX_WORDS = 25
+    all_balloons = []
+    for page in parsed['pages']:
+        for panel in page['panels']:
+            for d in panel['dialogue']:
+                # Only count actual dialogue and captions — skip SFX
+                if d['prefix'] in ('SFX',):
+                    continue
+                word_count = len(d['text'].split())
+                all_balloons.append((page['number'], panel['number'],
+                                     d['prefix'], word_count))
+    if not all_balloons:
+        return {'principle': 'dialogue_compression', 'score': 1.0, 'findings': []}
+    under = sum(1 for _, _, _, w in all_balloons if w <= MAX_WORDS)
+    score = under / len(all_balloons)
+    findings = [
+        {
+            'kind': 'balloon_too_long',
+            'detail': f'Page {pg} panel {pn} {pre}: {w} words (max {MAX_WORDS})',
+            'severity': 'medium' if w <= 40 else 'high',
+        }
+        for pg, pn, pre, w in all_balloons if w > MAX_WORDS
+    ]
+    return {'principle': 'dialogue_compression', 'score': score, 'findings': findings}
+
+
+def score_layout_rhythm(parsed, brief_row=None, script_text=None):
+    """Stdev of panels-per-page. Penalize both extremes (≤ 0.3 = mechanical,
+    ≥ 3.0 = chaotic). Sweet spot stdev ≈ 1.0-2.0."""
+    pages = parsed['pages']
+    if len(pages) < 2:
+        return {'principle': 'layout_rhythm', 'score': 1.0, 'findings': []}
+    densities = [len(p['panels']) for p in pages]
+    stdev = statistics.stdev(densities)
+    # Triangle scoring: peak at stdev=1.5, falls off either side
+    if stdev <= 1.5:
+        score = max(0.0, stdev / 1.5)
+    else:
+        score = max(0.0, 1.0 - (stdev - 1.5) / 2.0)
+    findings = []
+    if stdev <= 0.3:
+        findings.append({
+            'kind': 'layout_too_uniform',
+            'detail': f'Panel-count stdev {stdev:.2f}: pages feel mechanically identical',
+            'severity': 'medium',
+        })
+    if stdev >= 3.0:
+        findings.append({
+            'kind': 'layout_too_chaotic',
+            'detail': f'Panel-count stdev {stdev:.2f}: wild variation may disorient',
+            'severity': 'low',
+        })
+    return {'principle': 'layout_rhythm', 'score': score, 'findings': findings}
+
+
+CAPTION_STRATEGY_TARGETS = {
+    'minimal': 1,
+    'journal-voiceover': 3,
+    'journal voiceover': 3,
+    'omniscient': 4,
+    'omniscient narration': 4,
+    'none': 0,
+}
+
+
+def score_caption_economy(parsed, brief_row, script_text=None):
+    """Captions per page. Strategy-aware target."""
+    strategy = (brief_row.get('caption_strategy') or 'minimal').strip().lower()
+    target = CAPTION_STRATEGY_TARGETS.get(strategy, 2)
+    pages = parsed['pages']
+    if not pages:
+        return {'principle': 'caption_economy', 'score': 1.0, 'findings': []}
+    findings = []
+    within = 0
+    for page in pages:
+        captions = [
+            d for panel in page['panels'] for d in panel['dialogue']
+            if d['prefix'] == 'CAPTION'
+        ]
+        cap_count = len(captions)
+        # Allow exceeding target by 1; flag at +2
+        if cap_count <= target + 1:
+            within += 1
+        else:
+            findings.append({
+                'kind': 'caption_excess',
+                'detail': f'Page {page["number"]}: {cap_count} captions (strategy "{strategy}" suggests ≤ {target})',
+                'severity': 'low' if cap_count <= target + 2 else 'medium',
+            })
+        # Strategy=none: any caption is a failure
+        if strategy == 'none' and cap_count > 0:
+            findings.append({
+                'kind': 'caption_when_none',
+                'detail': f'Page {page["number"]}: {cap_count} captions; strategy is "none"',
+                'severity': 'high',
+            })
+            within = max(within - 1, 0)
+    score = within / len(pages)
+    return {'principle': 'caption_economy', 'score': score, 'findings': findings}
+
+
+def score_panel_composition_depth(parsed, brief_row=None, script_text=None):
+    """Composition prose word count. Sweet spot: 15-50 words per panel."""
+    MIN_WORDS = 15
+    MAX_WORDS = 50
+    panels = [(page['number'], panel)
+              for page in parsed['pages'] for panel in page['panels']]
+    if not panels:
+        return {'principle': 'panel_composition_depth', 'score': 1.0, 'findings': []}
+    findings = []
+    within = 0
+    for page_num, panel in panels:
+        w = len(panel['composition'].split())
+        if MIN_WORDS <= w <= MAX_WORDS:
+            within += 1
+        elif w < MIN_WORDS:
+            findings.append({
+                'kind': 'composition_too_sparse',
+                'detail': f'Page {page_num} panel {panel["number"]}: {w} words (artist needs more visual detail)',
+                'severity': 'medium',
+            })
+        else:  # w > MAX_WORDS
+            findings.append({
+                'kind': 'composition_too_dense',
+                'detail': f'Page {page_num} panel {panel["number"]}: {w} words (consider tightening)',
+                'severity': 'low',
+            })
+    score = within / len(panels)
+    return {'principle': 'panel_composition_depth', 'score': score, 'findings': findings}
+
+
+SCORERS = {
+    'brief_fidelity': score_brief_fidelity,
+    'panel_density': score_panel_density,
+    'dialogue_compression': score_dialogue_compression,
+    'layout_rhythm': score_layout_rhythm,
+    'caption_economy': score_caption_economy,
+    'panel_composition_depth': score_panel_composition_depth,
+}
+
+
+def score_scene(scene_id, parsed_script, brief_row, script_text):
+    """Run all scorers on one scene. Returns dict of principle → score+findings."""
+    return {
+        principle: fn(parsed_script, brief_row, script_text)
+        for principle, fn in SCORERS.items()
+    }
+
+
+def score_project(project_dir):
+    """Top-level entry — matches the contract used by novel-mode scorers."""
+    if get_medium(project_dir) != 'graphic-novel':
+        return {'skipped': True, 'reason': 'not a graphic-novel project'}
+    # Actual scoring orchestration lives in cmd_score_gn — this is just the contract.
+    return {'principles': list(PRINCIPLES)}
+```
+
+**Tests** (`tests/test_scoring_gn.py`):
+
+- Test each scorer in isolation with crafted parsed_script + brief_row inputs that exercise:
+  - All-pass case (score should be 1.0)
+  - Boundary cases (just at threshold)
+  - Failure case (score should drop and findings should appear)
+- Test the `score_project()` entry contract (skipped for non-GN)
+
+Aim for ~15 tests covering the six principles.
+
+**Commit:** `Add scoring_gn module with six deterministic principles`
+
+---
+
+### Task 2: `cmd_score_gn.py` orchestration
+
+**Files:**
+- Create: `scripts/lib/python/storyforge/cmd_score_gn.py`
+- Create: `tests/test_cmd_score_gn.py`
+
+Same CLI surface as novel mode `cmd_score`:
+```
+storyforge score                      # score all drafted scenes
+storyforge score scene-id             # score one scene
+storyforge score --scenes a,b,c       # multiple scenes
+storyforge score --principles X,Y     # only certain principles
+storyforge score --dry-run            # show what would be scored
+```
+
+For each target scene:
+1. Read `scenes/{id}.md`
+2. Parse via `script_format.parse_script`
+3. Read the brief row
+4. Run `scoring_gn.score_scene(...)`
+5. Write output to `working/scores/latest/{scene_id}.json` with the structure:
+   ```json
+   {
+     "scene_id": "...",
+     "scored_at": "2026-05-21T...",
+     "scores": {
+       "brief_fidelity": {"score": 0.75, "findings": [...]},
+       ...
+     },
+     "overall_score": 0.82,  // weighted average using craft-weights-gn.csv
+     "findings": [...]  // flat list across all principles
+   }
+   ```
+6. After all scenes scored, write `working/scores/latest/summary.csv` with per-scene scores
+7. Print a human-readable summary
+
+Use the existing weights helpers in `storyforge.common` (look at `get_coaching_level` for the pattern; weights live in `working/craft-weights.csv` per project, with `references/default-craft-weights-gn.csv` as the default).
+
+Refuse to run on non-GN projects with a clear error.
+
+**Tests** (~5 tests): full-fixture scoring run produces expected output files; per-principle filter; dry-run no-op; non-GN refusal; scene without draft is skipped.
+
+**Commit:** `Add cmd_score_gn for graphic-novel scoring`
+
+---
+
+### Task 3: `default-craft-weights-gn.csv`
+
+**Files:**
+- Create: `references/default-craft-weights-gn.csv`
+
+Six rows in the same format as `default-craft-weights.csv`:
+
+```
+section|principle|weight|author_weight|notes
+gn_craft|brief_fidelity|8||Brief contract is load-bearing
+gn_craft|panel_density|5||Pacing-critical
+gn_craft|dialogue_compression|6||Lettering reality check
+gn_craft|layout_rhythm|5||Page-to-page variety
+gn_craft|caption_economy|5||Strategy adherence
+gn_craft|panel_composition_depth|6||Artist actionability
+```
+
+**Commit:** `Add default GN craft weights`
+
+---
+
+### Task 4: Evaluator persona markdown files
+
+**Files:**
+- Create: `scripts/prompts/evaluators-gn/panel-composition-critic.md`
+- Create: `scripts/prompts/evaluators-gn/pacing-critic.md`
+- Create: `scripts/prompts/evaluators-gn/dialogue-critic.md`
+
+Each ~80-120 lines. Read the existing `scripts/prompts/evaluators/line-editor.md` and `developmental-editor.md` for format. Each file is a complete system-prompt persona that:
+- Establishes the evaluator's domain expertise
+- Defines what they look for (specific criteria for GN)
+- Specifies output format: structured JSON findings with `severity`, `fix_location`, `message`, `scene_id`, optional `page`/`panel` anchor
+
+Substantive guidance per persona:
+
+**panel-composition-critic.md** — silhouette consistency, costume continuity, composition specificity (enough for the artist), visual storytelling (does the panel show what dialogue says — or compete with it?), location/setting fidelity. Outputs `fix_location: composition`.
+
+**pacing-critic.md** — page-to-page rhythm, splash placement (earned vs. wasted), page-turn beat payoff, panel-to-panel transition variety (à la McCloud — moment/action/subject/scene/aspect), beat density vs. emotional arc. Outputs `fix_location: pacing` or `layout`.
+
+**dialogue-critic.md** — balloon economy, character voice differentiation (do speakers sound distinct?), caption strategy alignment, SFX appropriateness, OFF-PANEL usage. Outputs `fix_location: dialogue`.
+
+**Commit:** `Add three GN evaluator personas`
+
+---
+
+### Task 5: `cmd_evaluate_gn.py`
+
+**Files:**
+- Create: `scripts/lib/python/storyforge/cmd_evaluate_gn.py`
+- Create: `tests/test_cmd_evaluate_gn.py`
+
+Same CLI surface as novel mode `cmd_evaluate`:
+```
+storyforge evaluate                      # all drafted scenes
+storyforge evaluate scene-id             # one scene
+storyforge evaluate --scenes a,b,c
+storyforge evaluate --personas A,B       # only specific evaluators
+storyforge evaluate --dry-run
+```
+
+For each target scene:
+1. Read `scenes/{id}.md`
+2. Read brief, intent, scene metadata
+3. For each evaluator persona (all 3 by default):
+   a. Load persona system prompt from `scripts/prompts/evaluators-gn/{name}.md`
+   b. Build user prompt: scene metadata + brief + script + visual references
+   c. Invoke API via `api.invoke_to_file`
+   d. Parse structured JSON findings from response
+4. Aggregate findings into `working/evaluations/latest/{scene_id}.json`
+5. Print summary
+
+Mock-friendly: prompts/responses go through `api.invoke_to_file` so they can be stubbed in tests.
+
+Refuse non-GN projects.
+
+**Tests** (~4 tests): full-fixture eval with mocked API, single-evaluator filter, dry-run, non-GN refusal.
+
+**Commit:** `Add cmd_evaluate_gn for graphic-novel evaluation panel`
+
+---
+
+### Task 6: Dispatcher routing
+
+**Files:**
+- Modify: `scripts/lib/python/storyforge/__main__.py`
+- Modify: `tests/test_medium.py`
+
+Remove `'score'` and `'evaluate'` from `GN_UNSUPPORTED_COMMANDS`.
+
+Add to `GN_ROUTED_COMMANDS`:
+```python
+GN_ROUTED_COMMANDS = {
+    'write': 'storyforge.cmd_write_gn',
+    'assemble': 'storyforge.cmd_script_package',
+    'score': 'storyforge.cmd_score_gn',
+    'evaluate': 'storyforge.cmd_evaluate_gn',
+}
+```
+
+Update `test_dispatcher_blocks_unsupported_commands_in_gn_mode` parametrize: remove `'score'`, `'evaluate'`.
+
+Add `test_dispatcher_routes_score_to_gn_in_gn_mode` and `test_dispatcher_routes_evaluate_to_gn_in_gn_mode` mirroring the write/assemble routing tests.
+
+**Commit:** `Route score and evaluate to GN modules when medium is graphic-novel`
+
+---
+
+### Task 7: Skill update
+
+**Files:**
+- Modify: `skills/score/SKILL.md`
+
+Add a `## Graphic-novel mode` section explaining:
+- The 6 GN-specific principles (vs. novel's 25)
+- All principles are deterministic (no API calls; scoring is fast)
+- Where output lives (`working/scores/latest/`)
+- That `evaluate` complements scoring with multi-agent commentary
+
+**Commit:** `Update score skill with graphic-novel section`
+
+---
+
+### Task 8: Version, CLAUDE.md, PR
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json` — bump 1.21.0 → 1.22.0
+- Modify: `CLAUDE.md` — move `score`, `evaluate` from "Not yet supported" to "Supported"; mention scoring_gn principles
+
+Open draft PR closing #209 (partial — note revise is deferred and create new followup issue).
+
+**Commit:** `Bump version to 1.22.0; document GN scoring and evaluation`
+
+---
+
+## Self-Review
+
+- Coverage: every part of issue #209's v1-scope (score + evaluate, not revise) has a task
+- Type/name consistency: `score_scene` returns dict; scorers expose `(parsed, brief_row, script_text)` signature uniformly; findings have `kind`/`detail`/`severity`
+- Sequencing: Tasks 1-3 must land before 2 (cmd_score_gn imports scoring_gn); Tasks 4 before 5; Task 6 needs both commands; Tasks 7-8 last
+- Followup issue: open a new issue at end for `cmd_revise_gn` with notes on what scoring/evaluation produced (so the revise design has real data)

--- a/references/default-craft-weights-gn.csv
+++ b/references/default-craft-weights-gn.csv
@@ -1,0 +1,7 @@
+section|principle|weight|author_weight|notes
+gn_craft|brief_fidelity|8||Brief contract is load-bearing
+gn_craft|panel_density|5||Pacing-critical
+gn_craft|dialogue_compression|6||Lettering reality check
+gn_craft|layout_rhythm|5||Page-to-page variety
+gn_craft|caption_economy|5||Strategy adherence
+gn_craft|panel_composition_depth|6||Artist actionability

--- a/scripts/lib/python/storyforge/__main__.py
+++ b/scripts/lib/python/storyforge/__main__.py
@@ -11,7 +11,7 @@ import sys
 # When a project's medium is graphic-novel, these commands return a clear
 # error instead of silently running novel-mode logic on the wrong data.
 GN_UNSUPPORTED_COMMANDS = frozenset({
-    'evaluate', 'revise',
+    'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 })
 
@@ -20,6 +20,7 @@ GN_ROUTED_COMMANDS = {
     'write': 'storyforge.cmd_write_gn',
     'assemble': 'storyforge.cmd_script_package',
     'score': 'storyforge.cmd_score_gn',
+    'evaluate': 'storyforge.cmd_evaluate_gn',
 }
 
 COMMANDS = {

--- a/scripts/lib/python/storyforge/__main__.py
+++ b/scripts/lib/python/storyforge/__main__.py
@@ -11,7 +11,7 @@ import sys
 # When a project's medium is graphic-novel, these commands return a clear
 # error instead of silently running novel-mode logic on the wrong data.
 GN_UNSUPPORTED_COMMANDS = frozenset({
-    'evaluate', 'score', 'revise',
+    'evaluate', 'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 })
 
@@ -19,6 +19,7 @@ GN_UNSUPPORTED_COMMANDS = frozenset({
 GN_ROUTED_COMMANDS = {
     'write': 'storyforge.cmd_write_gn',
     'assemble': 'storyforge.cmd_script_package',
+    'score': 'storyforge.cmd_score_gn',
 }
 
 COMMANDS = {

--- a/scripts/lib/python/storyforge/cmd_evaluate_gn.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate_gn.py
@@ -1,0 +1,515 @@
+"""storyforge evaluate (graphic-novel mode) — 3-persona LLM evaluation panel.
+
+Runs three evaluator personas (panel-composition, pacing, dialogue) against
+drafted panel scripts and writes per-scene JSON findings files.
+
+Usage (identical CLI surface to novel-mode evaluate):
+    storyforge evaluate                        # all drafted scenes, all 3 personas
+    storyforge evaluate scene-id               # one scene
+    storyforge evaluate --scenes a,b,c
+    storyforge evaluate --personas panel-composition,pacing  # filter
+    storyforge evaluate --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+from storyforge.common import (
+    detect_project_root, log, set_log_file, select_model,
+    install_signal_handlers, get_medium, get_plugin_dir,
+)
+from storyforge.csv_cli import get_field, get_row, list_ids
+from storyforge.scene_filter import build_scene_list, apply_scene_filter
+from storyforge.api import invoke_to_file, extract_text_from_file
+from storyforge.costs import log_operation
+
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='storyforge evaluate',
+        description='Run 3-persona evaluation panel against GN panel scripts.',
+    )
+    parser.add_argument('positional', nargs='*', default=[],
+                        help='Scene ID(s) to evaluate')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would be evaluated without calling the API')
+    parser.add_argument('--scenes', type=str, default=None,
+                        help='Comma-separated scene IDs')
+    parser.add_argument('--act', '--part', type=str, default=None,
+                        help='Evaluate all scenes in act/part N')
+    parser.add_argument('--from-seq', type=str, default=None,
+                        help='Start from sequence number (N or N-M range)')
+    parser.add_argument('--personas', type=str, default=None,
+                        help='Comma-separated persona names to run '
+                             '(default: all discovered)')
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# CSV row helper (mirrors cmd_write_gn._row_to_dict)
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(csv_path, row_id):
+    """Read a CSV row by ID and return as a dict. Returns {} if not found."""
+    if not os.path.isfile(csv_path):
+        return {}
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = raw.splitlines()
+    if not lines:
+        return {}
+    headers = lines[0].split('|')
+    for line in lines[1:]:
+        fields = line.split('|')
+        if fields and fields[0] == row_id:
+            return dict(zip(headers, fields))
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Persona discovery
+# ---------------------------------------------------------------------------
+
+def _discover_personas(plugin_dir):
+    """List persona names from evaluators-gn/*.md.
+
+    Returns list of (persona_name, prompt_file_path) tuples.
+    Persona name is derived from the filename stem by stripping '-critic'.
+
+    E.g. panel-composition-critic.md -> 'panel-composition'
+    """
+    evaluators_dir = os.path.join(plugin_dir, 'scripts', 'prompts', 'evaluators-gn')
+    if not os.path.isdir(evaluators_dir):
+        log(f'ERROR: evaluators-gn directory not found: {evaluators_dir}')
+        return []
+
+    personas = []
+    for fname in sorted(os.listdir(evaluators_dir)):
+        if not fname.endswith('.md'):
+            continue
+        stem = fname[:-3]  # strip .md
+        # Strip trailing '-critic' suffix to get the persona name
+        if stem.endswith('-critic'):
+            persona_name = stem[:-7]  # strip '-critic'
+        else:
+            persona_name = stem
+        prompt_path = os.path.join(evaluators_dir, fname)
+        personas.append((persona_name, prompt_path))
+
+    return personas
+
+
+# ---------------------------------------------------------------------------
+# Bibles and voice loading
+# ---------------------------------------------------------------------------
+
+def _build_visual_refs(project_dir):
+    """Read character-bible.md and world-bible.md for visual reference."""
+    ref_dir = os.path.join(project_dir, 'reference')
+    chars_path = os.path.join(ref_dir, 'character-bible.md')
+    world_path = os.path.join(ref_dir, 'world-bible.md')
+    char_text = open(chars_path, encoding='utf-8').read() if os.path.isfile(chars_path) else ''
+    world_text = open(world_path, encoding='utf-8').read() if os.path.isfile(world_path) else ''
+    return char_text, world_text
+
+
+def _build_voice_text(project_dir):
+    """Read voice-profile.csv as raw text for the prompt."""
+    voice_path = os.path.join(project_dir, 'reference', 'voice-profile.csv')
+    if os.path.isfile(voice_path):
+        return open(voice_path, encoding='utf-8').read()
+    return ''
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+def _build_evaluation_prompt(scene_id, scene_row, intent_row, brief_row,
+                              script_text, char_text, world_text, voice_text):
+    """Build the user prompt for a single (scene, persona) evaluation call."""
+    parts = []
+
+    # Scene metadata block
+    parts.append('## Scene Metadata')
+    parts.append(f'- **scene_id:** {scene_id}')
+    parts.append(f'- **title:** {scene_row.get("title", "")}')
+    parts.append(f'- **target_pages:** {scene_row.get("target_pages", "")}')
+    parts.append(f'- **pov:** {scene_row.get("pov", "")}')
+    parts.append(f'- **location:** {scene_row.get("location", "")}')
+    parts.append(f'- **type:** {scene_row.get("type", "")}')
+    parts.append('')
+
+    # Intent
+    if intent_row:
+        parts.append('## Scene Intent')
+        for k, v in intent_row.items():
+            if k != 'id' and v:
+                parts.append(f'- **{k}:** {v}')
+        parts.append('')
+
+    # Brief (the scene contract — persona uses this to evaluate fidelity)
+    if brief_row:
+        parts.append('## Scene Brief')
+        for k, v in brief_row.items():
+            if k != 'id' and v:
+                parts.append(f'- **{k}:** {v}')
+        parts.append('')
+
+    # Visual references
+    if char_text:
+        parts.append('## Character Bible')
+        parts.append(char_text.strip())
+        parts.append('')
+
+    if world_text:
+        parts.append('## World Bible')
+        parts.append(world_text.strip())
+        parts.append('')
+
+    if voice_text:
+        parts.append('## Voice Profile')
+        parts.append(voice_text.strip())
+        parts.append('')
+
+    # The script itself
+    parts.append('## Panel Script')
+    parts.append(script_text.strip())
+    parts.append('')
+
+    parts.append(
+        'Evaluate the script above according to your persona\'s focus areas. '
+        'Return a JSON object with a single top-level key `findings` '
+        '(an array of finding objects as specified in your persona description). '
+        'Set `scene_id` on every finding to: ' + json.dumps(scene_id)
+    )
+
+    return '\n'.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# JSON findings parsing
+# ---------------------------------------------------------------------------
+
+def _parse_findings(response_text, persona_name, scene_id):
+    """Extract the findings array from a persona's API response.
+
+    Tries:
+      1. Direct json.loads
+      2. Fenced block extraction (```json ... ``` or ``` ... ```)
+      3. Log warning and return [] on failure
+    """
+    if not response_text:
+        log(f'  WARNING [{persona_name}]: empty response for {scene_id}')
+        return []
+
+    # Attempt 1: direct parse
+    try:
+        data = json.loads(response_text)
+        findings = data.get('findings', [])
+        # Ensure scene_id is stamped on each finding
+        for f in findings:
+            f.setdefault('scene_id', scene_id)
+        return findings
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # Attempt 2: extract from fenced code block (```json ... ``` or ``` ... ```)
+    # The block may contain nested JSON objects, so we take everything inside the fences.
+    fenced = re.search(r'```(?:json)?\s*\n(.*?)\n```', response_text, re.DOTALL)
+    if fenced:
+        try:
+            data = json.loads(fenced.group(1).strip())
+            findings = data.get('findings', [])
+            for f in findings:
+                f.setdefault('scene_id', scene_id)
+            return findings
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    log(f'  WARNING [{persona_name}]: could not parse JSON findings for {scene_id} '
+        f'— skipping this persona\'s contribution')
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Scene resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_target_scenes(args, metadata_csv):
+    """Resolve which scenes to evaluate, in priority order:
+      1. Positional args
+      2. --scenes flag
+      3. --act / --from-seq
+      4. All scenes in metadata
+    """
+    all_ids = build_scene_list(metadata_csv)
+
+    if args.positional:
+        mode = 'scenes'
+        value = ','.join(args.positional)
+    elif args.scenes:
+        mode = 'scenes'
+        value = args.scenes
+    elif args.act:
+        mode = 'act'
+        value = args.act
+    elif hasattr(args, 'from_seq') and args.from_seq:
+        mode = 'from_seq'
+        value = args.from_seq
+    else:
+        mode = 'all'
+        value = None
+
+    return apply_scene_filter(metadata_csv, all_ids, mode, value)
+
+
+# ---------------------------------------------------------------------------
+# Per-scene evaluation
+# ---------------------------------------------------------------------------
+
+def _evaluate_scene(scene_id, project_dir, metadata_csv, personas, model,
+                    dry_run=False):
+    """Run all personas against one scene. Returns output dict or None on failure."""
+    scene_path = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+    if not os.path.isfile(scene_path):
+        log(f'  SKIP {scene_id}: scene file not found')
+        return None
+
+    with open(scene_path, encoding='utf-8') as f:
+        script_text = f.read()
+
+    ref_dir = os.path.join(project_dir, 'reference')
+    scene_row = _row_to_dict(os.path.join(ref_dir, 'scenes.csv'), scene_id)
+    intent_row = _row_to_dict(os.path.join(ref_dir, 'scene-intent.csv'), scene_id)
+    brief_row = _row_to_dict(os.path.join(ref_dir, 'scene-briefs.csv'), scene_id)
+
+    char_text, world_text = _build_visual_refs(project_dir)
+    voice_text = _build_voice_text(project_dir)
+
+    user_prompt = _build_evaluation_prompt(
+        scene_id, scene_row, intent_row, brief_row,
+        script_text, char_text, world_text, voice_text,
+    )
+
+    log_base_dir = os.path.join(project_dir, 'working', 'logs', 'evaluate-gn')
+    os.makedirs(log_base_dir, exist_ok=True)
+
+    all_findings = []
+    personas_run = []
+
+    for persona_name, prompt_path in personas:
+        # Read persona system prompt
+        with open(prompt_path, encoding='utf-8') as f:
+            system_prompt_text = f.read()
+
+        # The API system parameter is a list of content blocks
+        system_blocks = [{'type': 'text', 'text': system_prompt_text}]
+
+        if dry_run:
+            log(f'  DRY RUN: would call {persona_name} persona for {scene_id}')
+            continue
+
+        log_file = os.path.join(log_base_dir, f'{scene_id}-{persona_name}.json')
+
+        try:
+            invoke_to_file(
+                user_prompt, model, log_file, max_tokens=4096,
+                system=system_blocks,
+            )
+        except Exception as e:
+            log(f'  WARNING [{persona_name}]: API call failed for {scene_id}: {e}')
+            continue
+
+        response_text = extract_text_from_file(log_file)
+        findings = _parse_findings(response_text, persona_name, scene_id)
+
+        # Tag each finding with the persona that produced it
+        for finding in findings:
+            finding['persona'] = persona_name
+
+        all_findings.extend(findings)
+        personas_run.append(persona_name)
+
+        # Cost tracking
+        try:
+            with open(log_file, encoding='utf-8') as f:
+                resp = json.load(f)
+            from storyforge.api import extract_usage, calculate_cost_from_usage
+            usage = extract_usage(resp)
+            cost = calculate_cost_from_usage(usage, model)
+            log_operation(
+                project_dir, 'evaluate-gn', model,
+                usage['input_tokens'], usage['output_tokens'], cost,
+                target=scene_id,
+                cache_read=usage.get('cache_read', 0),
+                cache_create=usage.get('cache_create', 0),
+            )
+        except Exception:
+            pass
+
+    if dry_run:
+        return None
+
+    return {
+        'scene_id': scene_id,
+        'evaluated_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'personas_run': personas_run,
+        'findings': all_findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary printing
+# ---------------------------------------------------------------------------
+
+def _print_summary(results):
+    """Print per-scene summary grouped by severity."""
+    print('')
+    for r in results:
+        sid = r['scene_id']
+        findings = r['findings']
+        if not findings:
+            print(f'  {sid}: 0 findings')
+            continue
+        by_sev = {}
+        for f in findings:
+            sev = f.get('severity', 'unknown')
+            by_sev[sev] = by_sev.get(sev, 0) + 1
+        sev_str = ', '.join(
+            f'{count} {sev}' for sev, count in sorted(by_sev.items())
+        )
+        print(f'  {sid}: {len(findings)} finding(s) ({sev_str})')
+    print('')
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    install_signal_handlers()
+
+    project_dir = detect_project_root()
+
+    # GN guard
+    medium = get_medium(project_dir)
+    if medium != 'graphic-novel':
+        log(f'ERROR: This command is only for graphic-novel projects '
+            f'(project.medium = "{medium}").')
+        log('For novel projects, use the standard `storyforge evaluate` command.')
+        sys.exit(1)
+
+    log(f'Project root: {project_dir}')
+    log('Medium: graphic-novel — using GN evaluation panel')
+
+    plugin_dir = get_plugin_dir()
+
+    # Set up logging
+    log_dir = os.path.join(project_dir, 'working', 'logs')
+    os.makedirs(log_dir, exist_ok=True)
+    set_log_file(os.path.join(log_dir, 'evaluate-gn-log.txt'))
+
+    # Discover personas
+    all_personas = _discover_personas(plugin_dir)
+    if not all_personas:
+        log('ERROR: No evaluator persona files found in evaluators-gn/.')
+        sys.exit(1)
+
+    # Apply --personas filter
+    if args.personas:
+        requested = [p.strip() for p in args.personas.split(',') if p.strip()]
+        known_names = {name for name, _ in all_personas}
+        unknown = [p for p in requested if p not in known_names]
+        if unknown:
+            log(f'ERROR: Unknown persona(s): {", ".join(unknown)}')
+            log(f'Available personas: {", ".join(sorted(known_names))}')
+            sys.exit(1)
+        personas = [(name, path) for name, path in all_personas if name in requested]
+    else:
+        personas = all_personas
+
+    log(f'Personas: {", ".join(name for name, _ in personas)}')
+
+    # Resolve target scenes
+    metadata_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+
+    candidate_ids = _resolve_target_scenes(args, metadata_csv)
+
+    # Filter to only drafted scenes
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    scene_ids = []
+    for sid in candidate_ids:
+        status = get_field(metadata_csv, sid, 'status') or ''
+        if status != 'drafted':
+            log(f'  SKIP {sid}: status is "{status}" (not drafted)')
+            continue
+        if not os.path.isfile(os.path.join(scenes_dir, f'{sid}.md')):
+            log(f'  SKIP {sid}: scene file not found')
+            continue
+        scene_ids.append(sid)
+
+    if not scene_ids:
+        log('ERROR: No drafted scenes found for the selected scope.')
+        sys.exit(1)
+
+    log(f'Scenes to evaluate: {len(scene_ids)}')
+
+    # Dry-run: print plan and exit
+    if args.dry_run:
+        log('DRY RUN — no API calls will be made')
+        for sid in scene_ids:
+            title = get_field(metadata_csv, sid, 'title') or sid
+            log(f'  - {sid} ({title})')
+        log(f'Personas: {", ".join(name for name, _ in personas)}')
+        return
+
+    # Prepare output directory
+    output_dir = os.path.join(project_dir, 'working', 'evaluations', 'latest')
+    os.makedirs(output_dir, exist_ok=True)
+
+    model = select_model('analytical')
+    log(f'Model: {model}')
+
+    # Evaluate each scene
+    results = []
+    for sid in scene_ids:
+        log(f'  Evaluating {sid}...')
+        result = _evaluate_scene(
+            sid, project_dir, metadata_csv, personas, model,
+            dry_run=False,
+        )
+        if result is None:
+            continue
+
+        # Write per-scene JSON
+        json_path = os.path.join(output_dir, f'{sid}.json')
+        with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump(result, f, indent=2)
+
+        results.append(result)
+        log(f'  {sid}: {len(result["findings"])} finding(s) '
+            f'from {len(result["personas_run"])} persona(s)')
+
+    if not results:
+        log('ERROR: No scenes were successfully evaluated.')
+        sys.exit(1)
+
+    # Print summary
+    _print_summary(results)
+
+    log(f'Evaluation complete. Results in {output_dir}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/lib/python/storyforge/cmd_evaluate_gn.py
+++ b/scripts/lib/python/storyforge/cmd_evaluate_gn.py
@@ -214,12 +214,16 @@ def _parse_findings(response_text, persona_name, scene_id):
     # Attempt 1: direct parse
     try:
         data = json.loads(response_text)
-        findings = data.get('findings', [])
+        findings = data.get('findings', []) or []
+        if not isinstance(findings, list):
+            log(f'  WARNING [{persona_name}]: findings is not a list for {scene_id}; '
+                f'got {type(findings).__name__}')
+            return []
         # Ensure scene_id is stamped on each finding
         for f in findings:
             f.setdefault('scene_id', scene_id)
         return findings
-    except (json.JSONDecodeError, AttributeError):
+    except (json.JSONDecodeError, AttributeError, TypeError):
         pass
 
     # Attempt 2: extract from fenced code block (```json ... ``` or ``` ... ```)
@@ -228,11 +232,15 @@ def _parse_findings(response_text, persona_name, scene_id):
     if fenced:
         try:
             data = json.loads(fenced.group(1).strip())
-            findings = data.get('findings', [])
+            findings = data.get('findings', []) or []
+            if not isinstance(findings, list):
+                log(f'  WARNING [{persona_name}]: findings is not a list for {scene_id}; '
+                    f'got {type(findings).__name__}')
+                return []
             for f in findings:
                 f.setdefault('scene_id', scene_id)
             return findings
-        except (json.JSONDecodeError, AttributeError):
+        except (json.JSONDecodeError, AttributeError, TypeError):
             pass
 
     log(f'  WARNING [{persona_name}]: could not parse JSON findings for {scene_id} '
@@ -311,8 +319,15 @@ def _evaluate_scene(scene_id, project_dir, metadata_csv, personas, model,
         with open(prompt_path, encoding='utf-8') as f:
             system_prompt_text = f.read()
 
-        # The API system parameter is a list of content blocks
-        system_blocks = [{'type': 'text', 'text': system_prompt_text}]
+        # The API system parameter is a list of content blocks.
+        # cache_control marks the persona prompt for prompt caching — it is
+        # reused across every scene, so this saves significant cost on
+        # multi-scene runs.
+        system_blocks = [{
+            'type': 'text',
+            'text': system_prompt_text,
+            'cache_control': {'type': 'ephemeral'},
+        }]
 
         if dry_run:
             log(f'  DRY RUN: would call {persona_name} persona for {scene_id}')
@@ -492,10 +507,12 @@ def main(argv=None):
         if result is None:
             continue
 
-        # Write per-scene JSON
+        # Write per-scene JSON (atomic: write to .tmp then replace)
         json_path = os.path.join(output_dir, f'{sid}.json')
-        with open(json_path, 'w', encoding='utf-8') as f:
+        tmp_path = json_path + '.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as f:
             json.dump(result, f, indent=2)
+        os.replace(tmp_path, json_path)
 
         results.append(result)
         log(f'  {sid}: {len(result["findings"])} finding(s) '

--- a/scripts/lib/python/storyforge/cmd_score_gn.py
+++ b/scripts/lib/python/storyforge/cmd_score_gn.py
@@ -1,0 +1,404 @@
+"""storyforge score (graphic-novel mode) — Deterministic craft scoring for GN projects.
+
+Runs all six deterministic GN craft scorers against drafted panel scripts,
+writes per-scene JSON output and a summary CSV, and prints a human-readable
+table sorted by overall score (lowest first — most attention needed).
+
+No API calls — all scorers are fully deterministic.
+
+Usage (identical CLI surface to novel-mode score):
+    storyforge score                      # score all drafted scenes
+    storyforge score scene-id             # score one scene
+    storyforge score --scenes a,b,c       # multiple scenes
+    storyforge score --principles X,Y     # only certain principles
+    storyforge score --dry-run            # show what would be scored
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from storyforge.common import (
+    detect_project_root, log, set_log_file, install_signal_handlers,
+    get_medium, get_plugin_dir,
+)
+from storyforge.script_format import parse_script
+from storyforge.scoring_gn import score_scene, PRINCIPLES
+from storyforge.csv_cli import get_field, get_row, update_field
+from storyforge.scene_filter import build_scene_list, apply_scene_filter
+
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='storyforge score',
+        description='Score GN panel scripts against six craft principles.',
+    )
+    parser.add_argument('positional', nargs='*', default=[],
+                        help='Scene ID(s) to score')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would be scored without writing output')
+    parser.add_argument('--scenes', type=str, default=None,
+                        help='Comma-separated scene IDs')
+    parser.add_argument('--act', '--part', type=str, default=None,
+                        help='Score all scenes in act/part N')
+    parser.add_argument('--from-seq', type=str, default=None,
+                        help='Start from sequence number (N or N-M range)')
+    parser.add_argument('--principles', type=str, default=None,
+                        help='Comma-separated principles to score '
+                             '(default: all six)')
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# CSV row helper (mirrors cmd_write_gn._row_to_dict)
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(csv_path, row_id):
+    """Read a CSV row by ID and return as a dict. Returns {} if not found."""
+    if not os.path.isfile(csv_path):
+        return {}
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = raw.splitlines()
+    if not lines:
+        return {}
+    headers = lines[0].split('|')
+    for line in lines[1:]:
+        fields = line.split('|')
+        if fields and fields[0] == row_id:
+            return dict(zip(headers, fields))
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Weights loading
+# ---------------------------------------------------------------------------
+
+def _load_weights(project_dir, plugin_dir):
+    """Load craft weights. Project-local file takes precedence over default.
+
+    Returns dict of principle -> weight (float, normalised so sum == 1.0).
+    Falls back to equal weights if no file found.
+    """
+    # Try project-local overrides first
+    local_path = os.path.join(project_dir, 'working', 'craft-weights.csv')
+    default_path = os.path.join(plugin_dir, 'references', 'default-craft-weights-gn.csv')
+
+    weights_path = None
+    if os.path.isfile(local_path):
+        weights_path = local_path
+    elif os.path.isfile(default_path):
+        weights_path = default_path
+
+    if not weights_path:
+        # Fallback: equal weights
+        return {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
+
+    raw = {}
+    try:
+        with open(weights_path, encoding='utf-8') as f:
+            lines = f.read().replace('\r\n', '\n').replace('\r', '').splitlines()
+        if not lines:
+            raise ValueError('empty weights file')
+        headers = lines[0].split('|')
+        p_idx = headers.index('principle') if 'principle' in headers else 1
+        w_idx = headers.index('weight') if 'weight' in headers else 2
+        for line in lines[1:]:
+            fields = line.split('|')
+            if len(fields) > max(p_idx, w_idx):
+                p = fields[p_idx].strip()
+                w_str = fields[w_idx].strip()
+                if p and w_str:
+                    try:
+                        raw[p] = float(w_str)
+                    except ValueError:
+                        pass
+    except Exception as e:
+        log(f'WARNING: Failed to load weights from {weights_path}: {e}')
+        return {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
+
+    # Keep only GN principles, fill missing with 1.0
+    result = {}
+    for p in PRINCIPLES:
+        result[p] = raw.get(p, 1.0)
+
+    total = sum(result.values())
+    if total > 0:
+        result = {p: w / total for p, w in result.items()}
+    else:
+        result = {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-scene scoring
+# ---------------------------------------------------------------------------
+
+def _score_one_scene(scene_id, project_dir, briefs_csv, principles_filter, weights):
+    """Score a single scene. Returns the output dict, or None on failure."""
+    scene_path = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+    if not os.path.isfile(scene_path):
+        log(f'  SKIP {scene_id}: scene file not found')
+        return None
+
+    with open(scene_path, encoding='utf-8') as f:
+        script_text = f.read()
+
+    try:
+        parsed = parse_script(script_text)
+    except Exception as e:
+        log(f'  WARNING: parse_script failed for {scene_id}: {e}')
+        parsed = {'pages': []}
+
+    brief_row = _row_to_dict(briefs_csv, scene_id)
+    has_brief = bool(brief_row)
+
+    # Run scorers (filtered or all)
+    active_principles = principles_filter if principles_filter else list(PRINCIPLES)
+
+    # score_scene returns all six; we filter after
+    all_scores = score_scene(scene_id, parsed, brief_row, script_text)
+
+    scores_out = {}
+    all_findings = []
+    weighted_sum = 0.0
+    weight_used = 0.0
+
+    for p in active_principles:
+        if p == 'brief_fidelity' and not has_brief:
+            log(f'  NOTE {scene_id}: no brief row — skipping brief_fidelity')
+            continue
+        result = all_scores.get(p)
+        if result is None:
+            continue
+        scores_out[p] = {
+            'score': result['score'],
+            'findings': result.get('findings', []),
+        }
+        all_findings.extend(result.get('findings', []))
+        w = weights.get(p, 0.0)
+        weighted_sum += result['score'] * w
+        weight_used += w
+
+    overall = weighted_sum / weight_used if weight_used > 0 else 0.0
+
+    return {
+        'scene_id': scene_id,
+        'scored_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'scores': scores_out,
+        'overall_score': round(overall, 4),
+        'findings': all_findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary CSV
+# ---------------------------------------------------------------------------
+
+def _write_summary_csv(results, output_dir, principles_filter):
+    """Write working/scores/latest/summary.csv."""
+    active = list(principles_filter) if principles_filter else list(PRINCIPLES)
+    header = 'scene_id|overall_score|' + '|'.join(active)
+    lines = [header]
+    for r in results:
+        parts = [r['scene_id'], f"{r['overall_score']:.4f}"]
+        for p in active:
+            s = r['scores'].get(p, {}).get('score', '')
+            parts.append(f'{s:.4f}' if isinstance(s, float) else '')
+        lines.append('|'.join(parts))
+    path = os.path.join(output_dir, 'summary.csv')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines) + '\n')
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Human-readable table
+# ---------------------------------------------------------------------------
+
+def _print_summary_table(results, principles_filter):
+    """Print sorted table (lowest overall first — most attention needed)."""
+    active = list(principles_filter) if principles_filter else list(PRINCIPLES)
+    sorted_results = sorted(results, key=lambda r: r['overall_score'])
+
+    # Column widths
+    id_width = max(len('scene'), max(len(r['scene_id']) for r in results))
+    col_width = 7  # e.g. '0.8234'
+
+    # Header
+    cols = ['scene'.ljust(id_width), 'overall'.rjust(col_width)]
+    for p in active:
+        short = p[:col_width].rjust(col_width)
+        cols.append(short)
+    print('')
+    print('  ' + '  '.join(cols))
+    print('  ' + '-' * (id_width + (col_width + 2) * (len(active) + 1)))
+
+    for r in sorted_results:
+        row = [r['scene_id'].ljust(id_width),
+               f"{r['overall_score']:.4f}".rjust(col_width)]
+        for p in active:
+            s = r['scores'].get(p, {}).get('score', None)
+            val = f'{s:.4f}'.rjust(col_width) if s is not None else '     —'.rjust(col_width)
+            row.append(val)
+        print('  ' + '  '.join(row))
+
+    print('')
+    if results:
+        avg = sum(r['overall_score'] for r in results) / len(results)
+        print(f'  Average overall: {avg:.4f}  ({len(results)} scenes)')
+    print('')
+
+
+# ---------------------------------------------------------------------------
+# Scene resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_target_scenes(args, metadata_csv):
+    """Resolve which scenes to score, in priority order:
+      1. Positional args
+      2. --scenes flag
+      3. All scenes in metadata (default to all, not just drafted)
+    """
+    all_ids = build_scene_list(metadata_csv)
+
+    if args.positional:
+        # Single or multiple positional args
+        mode = 'scenes'
+        value = ','.join(args.positional)
+    elif args.scenes:
+        mode = 'scenes'
+        value = args.scenes
+    elif args.act:
+        mode = 'act'
+        value = args.act
+    elif hasattr(args, 'from_seq') and args.from_seq:
+        mode = 'from_seq'
+        value = args.from_seq
+    else:
+        mode = 'all'
+        value = None
+
+    filtered = apply_scene_filter(metadata_csv, all_ids, mode, value)
+    return filtered
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    install_signal_handlers()
+
+    project_dir = detect_project_root()
+
+    # GN guard
+    medium = get_medium(project_dir)
+    if medium != 'graphic-novel':
+        log(f'ERROR: This command is only for graphic-novel projects '
+            f'(project.medium = "{medium}").')
+        log('For novel projects, use the standard `storyforge score` command.')
+        sys.exit(1)
+
+    log(f'Project root: {project_dir}')
+    log('Medium: graphic-novel — using GN scoring pipeline')
+
+    plugin_dir = get_plugin_dir()
+
+    # Parse --principles filter
+    principles_filter = None
+    if args.principles:
+        requested = [p.strip() for p in args.principles.split(',') if p.strip()]
+        unknown = [p for p in requested if p not in PRINCIPLES]
+        if unknown:
+            log(f'ERROR: Unknown GN principle(s): {", ".join(unknown)}')
+            log(f'Known GN principles: {", ".join(PRINCIPLES)}')
+            sys.exit(1)
+        principles_filter = requested
+        log(f'Filtering to principles: {", ".join(principles_filter)}')
+
+    # Resolve scenes
+    metadata_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+
+    candidate_ids = _resolve_target_scenes(args, metadata_csv)
+
+    # Filter to only drafted scenes
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    scene_ids = []
+    for sid in candidate_ids:
+        status = get_field(metadata_csv, sid, 'status') or ''
+        if status != 'drafted':
+            log(f'  SKIP {sid}: status is "{status}" (not drafted)')
+            continue
+        if not os.path.isfile(os.path.join(scenes_dir, f'{sid}.md')):
+            log(f'  SKIP {sid}: scene file not found')
+            continue
+        scene_ids.append(sid)
+
+    if not scene_ids:
+        log('ERROR: No drafted scenes found for the selected scope.')
+        sys.exit(1)
+
+    log(f'Scenes to score: {len(scene_ids)}')
+
+    # Dry-run: print plan and exit
+    if args.dry_run:
+        log('DRY RUN — no output files will be written')
+        for sid in scene_ids:
+            title = get_field(metadata_csv, sid, 'title') or sid
+            log(f'  - {sid} ({title})')
+        active = principles_filter if principles_filter else list(PRINCIPLES)
+        log(f'Principles: {", ".join(active)}')
+        return
+
+    # Load weights
+    weights = _load_weights(project_dir, plugin_dir)
+
+    # Prepare output directory
+    output_dir = os.path.join(project_dir, 'working', 'scores', 'latest')
+    os.makedirs(output_dir, exist_ok=True)
+
+    log_dir = os.path.join(project_dir, 'working', 'logs')
+    os.makedirs(log_dir, exist_ok=True)
+
+    # Score each scene
+    results = []
+    for sid in scene_ids:
+        log(f'  Scoring {sid}...')
+        result = _score_one_scene(sid, project_dir, briefs_csv,
+                                  principles_filter, weights)
+        if result is None:
+            continue
+
+        # Write per-scene JSON
+        json_path = os.path.join(output_dir, f'{sid}.json')
+        with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump(result, f, indent=2)
+
+        results.append(result)
+        finding_count = len(result['findings'])
+        log(f'  {sid}: overall={result["overall_score"]:.3f}, '
+            f'{finding_count} finding(s)')
+
+    if not results:
+        log('ERROR: No scenes were successfully scored.')
+        sys.exit(1)
+
+    # Write summary CSV
+    summary_path = _write_summary_csv(results, output_dir, principles_filter)
+    log(f'Summary: {summary_path}')
+
+    # Print human-readable table
+    _print_summary_table(results, principles_filter)
+
+    log(f'Scoring complete. Results in {output_dir}')

--- a/scripts/lib/python/storyforge/cmd_score_gn.py
+++ b/scripts/lib/python/storyforge/cmd_score_gn.py
@@ -80,26 +80,8 @@ def _row_to_dict(csv_path, row_id):
 # Weights loading
 # ---------------------------------------------------------------------------
 
-def _load_weights(project_dir, plugin_dir):
-    """Load craft weights. Project-local file takes precedence over default.
-
-    Returns dict of principle -> weight (float, normalised so sum == 1.0).
-    Falls back to equal weights if no file found.
-    """
-    # Try project-local overrides first
-    local_path = os.path.join(project_dir, 'working', 'craft-weights.csv')
-    default_path = os.path.join(plugin_dir, 'references', 'default-craft-weights-gn.csv')
-
-    weights_path = None
-    if os.path.isfile(local_path):
-        weights_path = local_path
-    elif os.path.isfile(default_path):
-        weights_path = default_path
-
-    if not weights_path:
-        # Fallback: equal weights
-        return {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
-
+def _parse_weights_file(weights_path):
+    """Parse a pipe-delimited weights CSV and return {principle: float}."""
     raw = {}
     try:
         with open(weights_path, encoding='utf-8') as f:
@@ -121,20 +103,47 @@ def _load_weights(project_dir, plugin_dir):
                         pass
     except Exception as e:
         log(f'WARNING: Failed to load weights from {weights_path}: {e}')
-        return {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
+    return raw
 
-    # Keep only GN principles, fill missing with 1.0
-    result = {}
-    for p in PRINCIPLES:
-        result[p] = raw.get(p, 1.0)
 
-    total = sum(result.values())
-    if total > 0:
-        result = {p: w / total for p, w in result.items()}
+def _load_weights(project_dir, plugin_dir):
+    """Load craft weights using a layered approach.
+
+    1. Start from defaults in references/default-craft-weights-gn.csv
+    2. Overlay any GN principles found in working/craft-weights.csv
+
+    This means projects migrated from novel mode (which have a novel-style
+    weights file containing none of the GN principles) still get the curated
+    GN defaults rather than equal weights.
+
+    Returns dict of principle -> weight (float, normalised so sum == 1.0).
+    Falls back to equal weights if no default file found.
+    """
+    default_path = os.path.join(plugin_dir, 'references', 'default-craft-weights-gn.csv')
+    local_path = os.path.join(project_dir, 'working', 'craft-weights.csv')
+
+    # Step 1: load defaults
+    if os.path.isfile(default_path):
+        defaults = _parse_weights_file(default_path)
     else:
-        result = {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
+        defaults = {}
 
-    return result
+    # Fill any missing GN principles with 1.0 so all six are represented
+    raw = {}
+    for p in PRINCIPLES:
+        raw[p] = defaults.get(p, 1.0)
+
+    # Step 2: overlay local file — only for GN principles
+    if os.path.isfile(local_path):
+        local = _parse_weights_file(local_path)
+        for p in PRINCIPLES:
+            if p in local:
+                raw[p] = local[p]
+
+    total = sum(raw.values())
+    if total > 0:
+        return {p: w / total for p, w in raw.items()}
+    return {p: 1.0 / len(PRINCIPLES) for p in PRINCIPLES}
 
 
 # ---------------------------------------------------------------------------
@@ -380,10 +389,12 @@ def main(argv=None):
         if result is None:
             continue
 
-        # Write per-scene JSON
+        # Write per-scene JSON (atomic: write to .tmp then replace)
         json_path = os.path.join(output_dir, f'{sid}.json')
-        with open(json_path, 'w', encoding='utf-8') as f:
+        tmp_path = json_path + '.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as f:
             json.dump(result, f, indent=2)
+        os.replace(tmp_path, json_path)
 
         results.append(result)
         finding_count = len(result['findings'])

--- a/scripts/lib/python/storyforge/scoring_gn.py
+++ b/scripts/lib/python/storyforge/scoring_gn.py
@@ -1,0 +1,217 @@
+"""Deterministic craft scorers for graphic-novel mode.
+
+Each scorer takes a parsed script (via storyforge.script_format.parse_script)
+and a brief row, then returns a structured score dict with findings.
+
+Scorers expose `score_scene(parsed_script, brief_row, scene_id) -> dict` and
+the module exposes a top-level `score_project(project_dir) -> dict` for the
+dispatcher contract (returns {'skipped': True, 'reason': '...'} on errors,
+otherwise a structured score dict).
+"""
+
+import statistics
+from storyforge.script_format import parse_script, check_brief_fidelity
+from storyforge.common import get_medium
+
+PRINCIPLES = (
+    'brief_fidelity', 'panel_density', 'dialogue_compression',
+    'layout_rhythm', 'caption_economy', 'panel_composition_depth',
+)
+
+
+def score_brief_fidelity(parsed, brief_row, script_text):
+    """1.0 - (failures / total_brief_checks). 4 checks: dialogue, visuals, panels, page-turns."""
+    failures = check_brief_fidelity(brief_row, script_text)
+    total_checks = 4  # 4 kinds of fidelity failures possible
+    failure_count = len(failures)
+    score = max(0.0, 1.0 - (failure_count / total_checks))
+    findings = [
+        {'kind': f['kind'], 'detail': f['detail'], 'severity': f.get('severity', 'medium')}
+        for f in failures
+    ]
+    return {'principle': 'brief_fidelity', 'score': score, 'findings': findings}
+
+
+def score_panel_density(parsed, brief_row=None, script_text=None):
+    """Sweet spot: 4-7 panels per page. Score = 1.0 - (|avg - 5.5| / 5.5)."""
+    pages = parsed['pages']
+    if not pages:
+        return {'principle': 'panel_density', 'score': 1.0, 'findings': []}
+    densities = [len(p['panels']) for p in pages]
+    avg = sum(densities) / len(densities)
+    score = max(0.0, 1.0 - abs(avg - 5.5) / 5.5)
+    findings = []
+    for p in pages:
+        n = len(p['panels'])
+        if n > 9:
+            findings.append({
+                'kind': 'panel_density_high',
+                'detail': f'Page {p["number"]}: {n} panels (cramped)',
+                'severity': 'medium',
+            })
+        elif n == 0:
+            findings.append({
+                'kind': 'panel_density_zero',
+                'detail': f'Page {p["number"]}: no panels parsed',
+                'severity': 'high',
+            })
+    return {'principle': 'panel_density', 'score': score, 'findings': findings}
+
+
+def score_dialogue_compression(parsed, brief_row=None, script_text=None):
+    """Word balloons <= 25 words. Score = fraction under threshold."""
+    MAX_WORDS = 25
+    all_balloons = []
+    for page in parsed['pages']:
+        for panel in page['panels']:
+            for d in panel['dialogue']:
+                # Only count actual dialogue and captions — skip SFX
+                if d['prefix'] in ('SFX',):
+                    continue
+                word_count = len(d['text'].split())
+                all_balloons.append((page['number'], panel['number'],
+                                     d['prefix'], word_count))
+    if not all_balloons:
+        return {'principle': 'dialogue_compression', 'score': 1.0, 'findings': []}
+    under = sum(1 for _, _, _, w in all_balloons if w <= MAX_WORDS)
+    score = under / len(all_balloons)
+    findings = [
+        {
+            'kind': 'balloon_too_long',
+            'detail': f'Page {pg} panel {pn} {pre}: {w} words (max {MAX_WORDS})',
+            'severity': 'medium' if w <= 40 else 'high',
+        }
+        for pg, pn, pre, w in all_balloons if w > MAX_WORDS
+    ]
+    return {'principle': 'dialogue_compression', 'score': score, 'findings': findings}
+
+
+def score_layout_rhythm(parsed, brief_row=None, script_text=None):
+    """Stdev of panels-per-page. Penalize both extremes (<= 0.3 = mechanical,
+    >= 3.0 = chaotic). Sweet spot stdev ~1.0-2.0."""
+    pages = parsed['pages']
+    if len(pages) < 2:
+        return {'principle': 'layout_rhythm', 'score': 1.0, 'findings': []}
+    densities = [len(p['panels']) for p in pages]
+    stdev = statistics.stdev(densities)
+    # Triangle scoring: peak at stdev=1.5, falls off either side
+    if stdev <= 1.5:
+        score = max(0.0, stdev / 1.5)
+    else:
+        score = max(0.0, 1.0 - (stdev - 1.5) / 2.0)
+    findings = []
+    if stdev <= 0.3:
+        findings.append({
+            'kind': 'layout_too_uniform',
+            'detail': f'Panel-count stdev {stdev:.2f}: pages feel mechanically identical',
+            'severity': 'medium',
+        })
+    if stdev >= 3.0:
+        findings.append({
+            'kind': 'layout_too_chaotic',
+            'detail': f'Panel-count stdev {stdev:.2f}: wild variation may disorient',
+            'severity': 'low',
+        })
+    return {'principle': 'layout_rhythm', 'score': score, 'findings': findings}
+
+
+CAPTION_STRATEGY_TARGETS = {
+    'minimal': 1,
+    'journal-voiceover': 3,
+    'journal voiceover': 3,
+    'omniscient': 4,
+    'omniscient narration': 4,
+    'none': 0,
+}
+
+
+def score_caption_economy(parsed, brief_row, script_text=None):
+    """Captions per page. Strategy-aware target."""
+    strategy = (brief_row.get('caption_strategy') or 'minimal').strip().lower()
+    target = CAPTION_STRATEGY_TARGETS.get(strategy, 2)
+    pages = parsed['pages']
+    if not pages:
+        return {'principle': 'caption_economy', 'score': 1.0, 'findings': []}
+    findings = []
+    within = 0
+    for page in pages:
+        captions = [
+            d for panel in page['panels'] for d in panel['dialogue']
+            if d['prefix'] == 'CAPTION'
+        ]
+        cap_count = len(captions)
+        # Allow exceeding target by 1; flag at +2
+        if cap_count <= target + 1:
+            within += 1
+        else:
+            findings.append({
+                'kind': 'caption_excess',
+                'detail': f'Page {page["number"]}: {cap_count} captions (strategy "{strategy}" suggests <= {target})',
+                'severity': 'low' if cap_count <= target + 2 else 'medium',
+            })
+        # Strategy=none: any caption is a failure
+        if strategy == 'none' and cap_count > 0:
+            findings.append({
+                'kind': 'caption_when_none',
+                'detail': f'Page {page["number"]}: {cap_count} captions; strategy is "none"',
+                'severity': 'high',
+            })
+            within = max(within - 1, 0)
+    score = within / len(pages)
+    return {'principle': 'caption_economy', 'score': score, 'findings': findings}
+
+
+def score_panel_composition_depth(parsed, brief_row=None, script_text=None):
+    """Composition prose word count. Sweet spot: 15-50 words per panel."""
+    MIN_WORDS = 15
+    MAX_WORDS = 50
+    panels = [(page['number'], panel)
+              for page in parsed['pages'] for panel in page['panels']]
+    if not panels:
+        return {'principle': 'panel_composition_depth', 'score': 1.0, 'findings': []}
+    findings = []
+    within = 0
+    for page_num, panel in panels:
+        w = len(panel['composition'].split())
+        if MIN_WORDS <= w <= MAX_WORDS:
+            within += 1
+        elif w < MIN_WORDS:
+            findings.append({
+                'kind': 'composition_too_sparse',
+                'detail': f'Page {page_num} panel {panel["number"]}: {w} words (artist needs more visual detail)',
+                'severity': 'medium',
+            })
+        else:  # w > MAX_WORDS
+            findings.append({
+                'kind': 'composition_too_dense',
+                'detail': f'Page {page_num} panel {panel["number"]}: {w} words (consider tightening)',
+                'severity': 'low',
+            })
+    score = within / len(panels)
+    return {'principle': 'panel_composition_depth', 'score': score, 'findings': findings}
+
+
+SCORERS = {
+    'brief_fidelity': score_brief_fidelity,
+    'panel_density': score_panel_density,
+    'dialogue_compression': score_dialogue_compression,
+    'layout_rhythm': score_layout_rhythm,
+    'caption_economy': score_caption_economy,
+    'panel_composition_depth': score_panel_composition_depth,
+}
+
+
+def score_scene(scene_id, parsed_script, brief_row, script_text):
+    """Run all scorers on one scene. Returns dict of principle -> score+findings."""
+    return {
+        principle: fn(parsed_script, brief_row, script_text)
+        for principle, fn in SCORERS.items()
+    }
+
+
+def score_project(project_dir):
+    """Top-level entry -- matches the contract used by novel-mode scorers."""
+    if get_medium(project_dir) != 'graphic-novel':
+        return {'skipped': True, 'reason': 'not a graphic-novel project'}
+    # Actual scoring orchestration lives in cmd_score_gn -- this is just the contract.
+    return {'principles': list(PRINCIPLES)}

--- a/scripts/lib/python/storyforge/scoring_gn.py
+++ b/scripts/lib/python/storyforge/scoring_gn.py
@@ -20,11 +20,16 @@ PRINCIPLES = (
 
 
 def score_brief_fidelity(parsed, brief_row, script_text):
-    """1.0 - (failures / total_brief_checks). 4 checks: dialogue, visuals, panels, page-turns."""
+    """1.0 - (distinct_failing_kinds / 4). 4 kinds: dialogue, visuals, panels, page-turns.
+
+    Multiple failures of the same kind (e.g. 5 missing dialogue lines) count
+    as a single distinct failure kind so the score degrades by category, not
+    by raw count.
+    """
     failures = check_brief_fidelity(brief_row, script_text)
-    total_checks = 4  # 4 kinds of fidelity failures possible
-    failure_count = len(failures)
-    score = max(0.0, 1.0 - (failure_count / total_checks))
+    total_kinds = 4  # dialogue_missing, visual_keyword_missing, panel_count_mismatch, page_turn_missing
+    distinct_kinds = len({f['kind'] for f in failures}) if failures else 0
+    score = max(0.0, 1.0 - distinct_kinds / total_kinds)
     findings = [
         {'kind': f['kind'], 'detail': f['detail'], 'severity': f.get('severity', 'medium')}
         for f in failures
@@ -140,16 +145,7 @@ def score_caption_economy(parsed, brief_row, script_text=None):
             if d['prefix'] == 'CAPTION'
         ]
         cap_count = len(captions)
-        # Allow exceeding target by 1; flag at +2
-        if cap_count <= target + 1:
-            within += 1
-        else:
-            findings.append({
-                'kind': 'caption_excess',
-                'detail': f'Page {page["number"]}: {cap_count} captions (strategy "{strategy}" suggests <= {target})',
-                'severity': 'low' if cap_count <= target + 2 else 'medium',
-            })
-        # Strategy=none: any caption is a failure
+        # Strategy=none: any caption is a failure (takes priority over generic excess check)
         if strategy == 'none' and cap_count > 0:
             findings.append({
                 'kind': 'caption_when_none',
@@ -157,6 +153,16 @@ def score_caption_economy(parsed, brief_row, script_text=None):
                 'severity': 'high',
             })
             within = max(within - 1, 0)
+        else:
+            # Allow exceeding target by 1; flag at +2
+            if cap_count <= target + 1:
+                within += 1
+            else:
+                findings.append({
+                    'kind': 'caption_excess',
+                    'detail': f'Page {page["number"]}: {cap_count} captions (strategy "{strategy}" suggests <= {target})',
+                    'severity': 'low' if cap_count <= target + 2 else 'medium',
+                })
     score = within / len(pages)
     return {'principle': 'caption_economy', 'score': score, 'findings': findings}
 

--- a/scripts/prompts/evaluators-gn/dialogue-critic.md
+++ b/scripts/prompts/evaluators-gn/dialogue-critic.md
@@ -1,0 +1,71 @@
+You are a dialogue critic and letterer's advocate with 18 years of experience editing comics scripts and consulting on balloon layout. You understand comics dialogue from two angles simultaneously: as a craft element that must reveal character and serve the story, and as a physical object that must fit inside a balloon that must fit inside a panel. You have watched beautiful artwork get buried under word-stuffed balloons, and you have watched scenes fail because every character sounded like a different draft of the same voice. Your job is to protect both the art and the words.
+
+## Your Evaluation Focus
+
+- **Balloon economy:** Every balloon should ideally contain under 15 words; the hard ceiling is 25 words. Anything above 25 words will fight the art for page real estate. When a balloon runs long, the letterer must either shrink the font (damaging readability), shrink the panel (damaging composition), or balloon-chain (breaking flow). Captions follow the same rule. Flag every balloon over 25 words, noting the word count and a suggestion for how to cut or split the line.
+
+- **Character voice differentiation:** Given only the dialogue text — stripped of attribution — could you identify who is speaking? Each character should have a distinct verbal register: vocabulary range, sentence length preference, hedging patterns, formality level, cadence. Pull from the provided `voice-profile.csv` for per-character voice anchors. Characters who sound interchangeable are not yet characters; they are placeholders. Flag any page where two or more characters' lines could be swapped without the reader noticing.
+
+- **Caption strategy alignment:** The scene brief declares a `caption_strategy`. If the brief says `"minimal"`, no page should carry more than one caption; if it says `"none"`, any caption is a violation; if it says `"journal-voiceover"`, captions should read as first-person reflection, not omniscient narration. When the actual caption usage diverges from the declared strategy — in quantity, tone, or register — flag it. Misalignment often means the brief was set without thinking through the lettering load, or the script drifted from the brief during drafting.
+
+- **SFX appropriateness:** Sound effects (SFX) are a seasoning, not a main course. One or two per scene is usually right; more than four in a single scene typically signals that visual storytelling is being replaced by verbal cues. An SFX should represent a sound the artist cannot convey through composition alone. "CRASH" when a vase falls is legitimate; "WHOOSH" when a character runs suggests the composition failed to read as fast. Flag overuse, and flag SFX that substitute for visual storytelling the composition should be doing.
+
+- **OFF-PANEL dialogue usage:** An OFF-PANEL attribution means the speaker is intentionally out of frame — heard but not seen. This is a legitimate device for spatial storytelling, building dread, or keeping a reveal. But OFF-PANEL used as a default escape from drawing the speaker is a scripting shortcut that costs visual storytelling depth. Flag patterns: any single scene where more than one-third of a character's lines are OFF-PANEL without a clear dramatic reason.
+
+- **Thought balloon and internal dialogue usage:** Modern comics have largely retired the traditional thought bubble in favor of caption boxes for interiority. Thought bubbles used occasionally are a stylistic choice; used in every other panel, they signal telling-not-showing — the writer is reporting the character's internal state rather than dramatizing it externally. Flag scenes where thought balloons (or equivalent internal-dialogue captions attributed to a character) appear in more than three panels per page.
+
+## What NOT to Flag
+
+- **Consistently used thought balloons as a declared stylistic feature.** If the scene brief or script header identifies first-person interior monologue as a structural device (e.g., a noir-voice comic in the tradition of Sin City or Black Hole), do not flag it as over-reliance. Note once that the choice is consistent, then move on.
+- **Caption density when the strategy explicitly permits it.** If `caption_strategy` is `"journal-voiceover"` or `"omniscient"`, do not flag caption-heavy pages that fall within the strategy's expected range.
+- **Short SFX that serve genuine acoustic beats.** A single well-placed SFX on a violent or percussive panel is craft. Only flag accumulation or substitution.
+
+## Output Format
+
+Return a JSON object with a single top-level key `findings`. Each finding is an object with the following fields:
+
+- `severity` — one of `"high"`, `"medium"`, or `"low"`
+- `fix_location` — always `"dialogue"` for this evaluator
+- `message` — a clear, actionable description of the problem and what to do about it
+- `scene_id` — the scene being evaluated (provided in the input)
+- `page` — (optional) the page number where the issue occurs
+- `panel` — (optional) the panel number within that page
+
+Return only the JSON object. No prose preamble, no summary, no markdown fencing.
+
+### Example Output
+
+```json
+{
+  "findings": [
+    {
+      "severity": "high",
+      "fix_location": "dialogue",
+      "message": "Page 2, panel 3: Lena's balloon is 38 words — nearly double the 25-word ceiling. This will force the letterer to compress the font or shrink the panel. Cut to the essential clause: she needs to communicate distrust, not provide three supporting reasons for it. Suggested cut: drop the second and third sentences entirely; the first sentence ('I don't trust anyone who shows up without a name') does the work alone.",
+      "scene_id": "the-meeting-at-noon",
+      "page": 2,
+      "panel": 3
+    },
+    {
+      "severity": "medium",
+      "fix_location": "dialogue",
+      "message": "Pages 4-5: Lena and Marcus use near-identical sentence length and vocabulary throughout their exchange. Both average eight-word declarative sentences with no contractions. Per voice-profile.csv, Marcus should favor clipped two-to-three-word responses and rhetorical questions; Lena should use longer qualifying constructions. Redraft Marcus's lines to use his documented register so readers can distinguish speakers without attribution.",
+      "scene_id": "the-meeting-at-noon",
+      "page": 4,
+      "panel": null
+    },
+    {
+      "severity": "low",
+      "fix_location": "dialogue",
+      "message": "Scene brief declares caption_strategy: 'minimal' (≤1 caption per page). Page 6 carries four captions. Three are redundant with what the composition already shows (isolation, cold, waiting). Remove captions 2-4; the image earns the silence.",
+      "scene_id": "the-meeting-at-noon",
+      "page": 6,
+      "panel": null
+    }
+  ]
+}
+```
+
+## Your Tone
+
+Economical, precise, and deeply practical. You know how lettering works and you write your findings with the letterer's realities in mind. When you flag a balloon as too long, you say what to cut — not just that it should be shorter. When you flag voice sameness, you point to the specific lines that prove it and what the documented voice profile says they should sound like instead. You are not a language prescriptivist; you are a communications pragmatist. Words must earn their space.

--- a/scripts/prompts/evaluators-gn/pacing-critic.md
+++ b/scripts/prompts/evaluators-gn/pacing-critic.md
@@ -1,0 +1,69 @@
+You are a pacing critic with 20 years of experience as a comics editor and sequential art theorist. Your mental model for panel transitions is Scott McCloud's taxonomy from Understanding Comics; your model for page architecture is the page-turn as the fundamental unit of dramatic surprise in print comics. You have killed many a wasted splash page in your career, and you have also saved many a quiet page that other editors would have cut. You know the difference between pacing that reflects genre and pacing that reflects inattention.
+
+## Your Evaluation Focus
+
+- **Page-to-page rhythm:** A well-paced script alternates energy levels — action pages followed by reaction pages, dense panel grids followed by single-image beats, dialogue-heavy pages followed by near-silent pages. A script that holds the same energy level for more than three consecutive pages will fatigue the reader. Flag stretches of sustained tension without decompression, and stretches of quiet without a payoff beat to justify them.
+
+- **Splash page placement:** A splash page (one panel filling the full page) is the comics equivalent of a cinematic freeze-frame. It should be EARNED — reserved for the scene's climactic moment, an emotionally overwhelming reveal, or a visual so striking that a full page is the only honest response to it. A splash used on a routine entrance, a generic establishing shot, or mid-scene dialogue wastes the only cinematic tool unique to comics. When a splash is unearned, say so and specify what moment on that page actually deserves the space.
+
+- **Page-turn beat payoff:** When the scene brief specifies a page-turn beat — a reveal intended to land when the reader flips the page — the first panel on the following recto must carry sufficient weight. A page-turn beat that resolves into a medium-shot of two characters talking has been defused. Flag page-turn beats where the promised reveal does not deliver. Conversely, flag scripts that have no page-turn beats at all across more than six pages; the reader has no reason to hurry.
+
+- **Panel-to-panel transition variety:** Using McCloud's taxonomy: moment-to-moment (consecutive instants of action), action-to-action (cause and effect within a single sequence), subject-to-subject (cutting between characters or objects), scene-to-scene (time or location jump), aspect-to-aspect (atmospheric — different facets of a single moment), non-sequitur (no clear relationship). Each transition type creates a different reading pace. Over-reliance on action-to-action produces a driven, mainstream-American register. Over-reliance on moment-to-moment produces a slow, manga-influenced register. Flag pages where five or more consecutive transitions are the same type — unless the effect is clearly intentional (e.g., a slow-motion action sequence using deliberate moment-to-moment).
+
+- **Beat density vs. emotional arc:** The script's page layout should reflect the emotional shape of the scene. High-density panel pages (six or more panels) compress time and imply urgency; low-density pages (two or three panels) expand a moment and imply weight. If the scene brief identifies the scene's emotional peak at page four but page four has the same panel density as pages one through three, the pacing is working against the story. The geometry of the page should honor the geometry of the emotion.
+
+## What NOT to Flag
+
+- **Genre-appropriate pacing.** Literary graphic novels run slower than action-adventure. A twelve-page scene with mostly four-panel grids and no splash is appropriate for a quiet, character-driven work. Do not flag literary pacing for failing action-genre standards.
+- **Author-intentional repetition.** Some scripts use metronomic panel counts as a deliberate formal constraint (think Chris Ware). If the scene brief or script header signals this as a structural choice, note it once but do not flag it as a problem.
+- **Reasonable splash usage near act climaxes.** If a splash falls within two pages of the scene's stated climax or turning point, assume intent before flagging.
+
+## Output Format
+
+Return a JSON object with a single top-level key `findings`. Each finding is an object with the following fields:
+
+- `severity` — one of `"high"`, `"medium"`, or `"low"`
+- `fix_location` — `"pacing"` for rhythm and beat issues; `"layout"` when the issue is specifically about panel-count choices or splash placement
+- `message` — a clear, actionable description of the problem and what to do about it
+- `scene_id` — the scene being evaluated (provided in the input)
+- `page` — (optional) the page number where the issue occurs
+- `panel` — (optional) the panel number within that page, when the issue is panel-specific
+
+Return only the JSON object. No prose preamble, no summary, no markdown fencing.
+
+### Example Output
+
+```json
+{
+  "findings": [
+    {
+      "severity": "high",
+      "fix_location": "layout",
+      "message": "Page 4 is a full-page splash on a routine exterior establishing shot — a street scene with no dramatic significance. The scene's actual emotional peak (the confrontation at the door) occurs on page 6 in a six-panel grid. Swap priorities: compress the establishing shot to one panel of a dense grid and give page 6's confrontation the splash it has earned.",
+      "scene_id": "the-crossing",
+      "page": 4,
+      "panel": null
+    },
+    {
+      "severity": "medium",
+      "fix_location": "pacing",
+      "message": "Pages 8-11 are four consecutive dialogue-heavy pages at uniform four-panel density with no action beat, no page-turn surprise, and no visual punctuation. The scene's brief marks page 10 as the scene's emotional turn; that turn is invisible in the current layout. Consider reducing pages 8-9 to three panels each (buying two extra panels of space) and inserting a two-panel reaction beat at the bottom of page 10 to mark the shift.",
+      "scene_id": "the-crossing",
+      "page": 10,
+      "panel": null
+    },
+    {
+      "severity": "low",
+      "fix_location": "pacing",
+      "message": "Panels 1-6 on page 3 all use action-to-action transitions (each panel is the next beat of the same chase). Six consecutive action-to-action transitions produce a mainstream-thriller register that may be appropriate but dulls impact by the end of the page. Consider inserting one aspect-to-aspect panel — a close on a spilled coffee cup, a reflection in glass — to punctuate the chase rhythmically.",
+      "scene_id": "the-crossing",
+      "page": 3,
+      "panel": null
+    }
+  ]
+}
+```
+
+## Your Tone
+
+Structural, precise, and rhythm-aware. You think in shapes and energy levels, not just word counts. When you flag a pacing problem, you specify the emotional consequence — not just that something is slow, but what the reader loses because of it. You respect genre conventions and treat them as context, not excuses.

--- a/scripts/prompts/evaluators-gn/panel-composition-critic.md
+++ b/scripts/prompts/evaluators-gn/panel-composition-critic.md
@@ -1,0 +1,69 @@
+You are a panel composition critic with 22 years of experience in comics editorial and sequential art direction. You have worked with artists at every skill level — from debut cartoonists to seasoned industry veterans — and you know exactly what a panel description needs to say to be drawable. You have edited for publishers across literary, mainstream, and alternative genres, and you have seen every species of underdescribed composition. Your job is to protect the artist's workflow and protect the visual story's coherence.
+
+## Your Evaluation Focus
+
+- **Composition specificity:** Does each panel description give an artist enough to work from? A useful composition note names the shot type (close-up, medium, wide, bird's-eye), identifies the dominant figure, specifies the emotional register, and anchors the scene in its setting. Under 15 words of composition prose is a red flag — the artist is being left to guess. Over 60 words can mean the writer is over-directing or conflating composition with dialogue intent; the artist cannot serve two masters at once.
+
+- **Visual storytelling vs. dialogue redundancy:** Comics derive their power from the interplay between image and word. A panel that shows a character crying while the caption reads "She was devastated" is not visual storytelling — it is duplication. Flag any panel where the composition and the dialogue/caption carry the exact same beat. Good panel writing leaves space: one channel carries the overt meaning, the other carries something the reader must feel.
+
+- **Character continuity:** The script must maintain each character's established silhouette, costume, and signature visual elements across every panel they appear in. Costume changes should be intentional and marked. A character described as wearing a heavy coat in one panel cannot shed it without explanation in the next. Use the provided `character-bible.md` as the reference for silhouette, costume, and distinguishing traits.
+
+- **Setting fidelity:** Each location should visually echo the keywords established in `world-bible.md`. A scene set in "the archive" that describes clean modern shelving contradicts the bible's "crumbling stone walls and gas-lamp sconces." Catch these drifts before they reach the artist. Inconsistency between script and bible forces mid-production retcons and erodes visual cohesion.
+
+- **Compositional variety:** If every panel defaults to medium-shot (figure from waist up, straight-on), the page reads as a series of talking heads. A strong script varies its shot vocabulary: close-ups for interiority, wides for geography, over-shoulder for power dynamics, bird's-eye or worm's-eye for disorientation. Flag pages where all panels share the same shot type. Variety is not novelty for its own sake — it is the difference between a readable page and a monotonous one.
+
+## What NOT to Flag
+
+- **Intentional brevity for punctuation panels.** A single-image beat panel — a door, a skyline, a dropped object — may need only a handful of words. If the script clearly intends the panel to function as a pause beat, brevity is correct.
+- **Deliberate style overrides.** If the scene brief explicitly contradicts the character or world bible (e.g., the character is disguised, the setting has changed), do not flag the contradiction. The brief is the authoritative source for that scene.
+- **Stylistic leanings.** Some artists prefer more latitude; some prefer tighter direction. If a script is consistently brief across all panels in a way that reads as intentional, note the pattern once rather than flagging each instance.
+
+## Output Format
+
+Return a JSON object with a single top-level key `findings`. Each finding is an object with the following fields:
+
+- `severity` — one of `"high"`, `"medium"`, or `"low"`
+- `fix_location` — always `"composition"` for this evaluator
+- `message` — a clear, actionable description of the problem and what to do about it
+- `scene_id` — the scene being evaluated (provided in the input)
+- `page` — (optional) the page number where the issue occurs
+- `panel` — (optional) the panel number within that page
+
+Return only the JSON object. No prose preamble, no summary, no markdown fencing.
+
+### Example Output
+
+```json
+{
+  "findings": [
+    {
+      "severity": "high",
+      "fix_location": "composition",
+      "message": "Composition is 8 words with no shot type, no dominant figure, and no setting anchor. The artist cannot draw this without guessing. Add shot type, specify who is in frame and how they are posed, and name one environmental detail.",
+      "scene_id": "the-archive-break-in",
+      "page": 3,
+      "panel": 2
+    },
+    {
+      "severity": "medium",
+      "fix_location": "composition",
+      "message": "Composition describes Mira weeping; dialogue balloon reads 'I can't do this anymore.' Both channels carry the same grief beat. Consider either removing the dialogue and letting the image work alone, or shifting the composition to an oblique angle (her back to the reader, fists at her sides) so the image and text say different things.",
+      "scene_id": "the-archive-break-in",
+      "page": 5,
+      "panel": 4
+    },
+    {
+      "severity": "low",
+      "fix_location": "composition",
+      "message": "All six panels on this page use medium shot, straight-on. Consider varying at least one panel — a close-up on Mira's hands for the key-exchange beat, or a wide establishing the corridor's length — to break the talking-heads rhythm.",
+      "scene_id": "the-archive-break-in",
+      "page": 7,
+      "panel": null
+    }
+  ]
+}
+```
+
+## Your Tone
+
+Precise, craft-focused, and artist-aware. You write for the person who will have to draw this. When you flag a problem, you say what an artist would need to see instead — not just that something is missing. You respect the writer's intentions and assume good faith; your job is to close the gap between intent and drawability.

--- a/skills/score/SKILL.md
+++ b/skills/score/SKILL.md
@@ -253,6 +253,29 @@ Every time you modify weights, record author scores, or make any file changes, c
 
 3. Then continue to the next piece of work.
 
+## Graphic-novel mode
+
+When `project.medium: graphic-novel` is set, scoring runs a completely different pipeline. The novel's 25-44 LLM-evaluated principles are replaced by 6 GN-specific deterministic scorers in `scoring_gn.py`. All six principles run without any API calls — scoring is instant and completely cost-free.
+
+**The 6 GN principles:**
+
+| Principle | What it measures |
+|---|---|
+| `brief_fidelity` | Script honors the brief: key dialogue present, visual keywords appear, panel breakdown matches, page-turn beats delivered |
+| `panel_density` | Average panels per page — sweet spot is 4-7 (score peaks at 5.5 avg) |
+| `dialogue_compression` | Word balloons ≤ 25 words; long balloons break lettering reality and slow pacing |
+| `layout_rhythm` | Variation in per-page panel counts; stdev ≈ 1.5 is ideal (too uniform = mechanical, too chaotic = disorienting) |
+| `caption_economy` | Captions per page matched against the brief's `caption_strategy` (none / minimal / journal-voiceover / omniscient) |
+| `panel_composition_depth` | Composition prose 15-50 words per panel — enough visual detail for the artist, not so much it crowds them out |
+
+**Output:** Per-scene JSON at `working/scores/latest/{scene_id}.json` and an aggregate `working/scores/latest/summary.csv`.
+
+**Complement with `evaluate`:** `./storyforge evaluate` runs three subjective evaluator personas — panel-composition, pacing, and dialogue critics — that flag issues the deterministic scorers can't catch (inconsistent character silhouettes, page-turn beat quality, voice differentiation). Run both for full feedback.
+
+**Run mode in GN projects:** Present Option A / Option B as usual, but note there is no API cost for scoring. The evaluate command does invoke Claude (3 personas per scene).
+
+---
+
 ## Coaching Level Behavior
 
 Adapt your approach based on `project.coaching_level` in storyforge.yaml:

--- a/tests/test_cmd_evaluate_gn.py
+++ b/tests/test_cmd_evaluate_gn.py
@@ -1,0 +1,327 @@
+"""End-to-end tests for cmd_evaluate_gn: GN evaluation panel orchestration."""
+
+import json
+import os
+
+import pytest
+
+from storyforge.csv_cli import update_field
+
+
+# ---------------------------------------------------------------------------
+# Fake API response — what personas are instructed to output
+# ---------------------------------------------------------------------------
+
+FAKE_EVAL_RESPONSE = {
+    'content': [{'type': 'text', 'text': '{"findings": [{"severity": "medium", "fix_location": "composition", "message": "Panel 3 composition is sparse", "scene_id": "the-blank-page", "page": 1, "panel": 3}]}'}],
+    'usage': {'input_tokens': 200, 'output_tokens': 100, 'cache_read_input_tokens': 0, 'cache_creation_input_tokens': 0},
+}
+
+
+def _make_fake_invoke(response=None):
+    """Return a fake invoke_to_file function that writes the given response JSON."""
+    if response is None:
+        response = FAKE_EVAL_RESPONSE
+
+    def fake_invoke_to_file(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+
+    return fake_invoke_to_file
+
+
+# ---------------------------------------------------------------------------
+# Minimal drafted panel scripts (mirrors test_cmd_score_gn)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_THE_BLANK_PAGE = """\
+# Scene: the-blank-page
+
+**Target pages:** 2 | **Layout intent:** splash p1, 4-grid p2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1**
+The cartographer at his desk in lamplit study with blank parchment spread before him.
+
+- CAPTION: *The map remained blank.*
+
+---
+
+## Page 2 — 4-GRID
+
+**Panel 1**
+Close on his trembling hand resting on the table edge.
+
+- CAPTION: *Forty years of practice.*
+
+**Panel 2**
+Brush touches paper.
+
+**Panel 3**
+A single line appears.
+
+**Panel 4**
+He stares at the line.
+
+- CARTOGRAPHER: No.
+"""
+
+_SCRIPT_SHADOWS_ARRIVE = """\
+# Scene: shadows-arrive
+
+**Target pages:** 1 | **Layout intent:** 6-grid
+
+---
+
+## Page 1 — 6-GRID
+
+**Panel 1**
+Door from outside the frame.
+
+**Panel 2**
+Shadow deepens under the door.
+
+**Panel 3**
+The lamp flame gutters.
+
+**Panel 4**
+Cartographer turns to face the door.
+
+- CARTOGRAPHER: Who's there?
+
+**Panel 5**
+Listens. Silence.
+
+**Panel 6**
+He stands, pushing back the chair.
+"""
+
+
+def _write_scenes(project_dir, scripts=None):
+    """Write fake drafted scene files and set status=drafted in scenes.csv."""
+    if scripts is None:
+        scripts = {
+            'the-blank-page': _SCRIPT_THE_BLANK_PAGE,
+            'shadows-arrive': _SCRIPT_SHADOWS_ARRIVE,
+        }
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    for sid, text in scripts.items():
+        path = os.path.join(scenes_dir, f'{sid}.md')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+        update_field(meta_csv, sid, 'status', 'drafted')
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestEvaluateAllDraftedScenes:
+    def test_evaluate_all_drafted_scenes(self, project_dir_gn, monkeypatch):
+        """Evaluating all drafted scenes runs each persona on each scene and writes JSON output."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        fake = _make_fake_invoke()
+        from storyforge import api as storyforge_api
+        from storyforge import cmd_evaluate_gn
+        monkeypatch.setattr(storyforge_api, 'invoke_to_file', fake)
+        monkeypatch.setattr(cmd_evaluate_gn, 'invoke_to_file', fake)
+
+        from storyforge import cmd_evaluate_gn
+        cmd_evaluate_gn.main([])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'evaluations', 'latest')
+
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert os.path.isfile(json_path), 'Missing evaluation JSON for the-blank-page'
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert data['scene_id'] == 'the-blank-page'
+        assert 'evaluated_at' in data
+        assert isinstance(data['personas_run'], list)
+        assert len(data['personas_run']) == 3, (
+            f'Expected 3 personas, got {data["personas_run"]}'
+        )
+
+        # Findings come from all 3 personas
+        assert isinstance(data['findings'], list)
+        # Each persona produced one finding from FAKE_EVAL_RESPONSE
+        assert len(data['findings']) == 3, (
+            f'Expected 3 findings (one per persona), got {len(data["findings"])}'
+        )
+
+        # Each finding should be tagged with its persona
+        personas_in_findings = {f['persona'] for f in data['findings']}
+        assert personas_in_findings == set(data['personas_run'])
+
+        # All findings should have scene_id set
+        for finding in data['findings']:
+            assert 'scene_id' in finding
+
+
+class TestEvaluatePersonaFilter:
+    def test_persona_filter_runs_only_requested_persona(self, project_dir_gn, monkeypatch):
+        """--personas pacing only invokes the pacing persona."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        call_log = []
+
+        def tracking_invoke(prompt, model, log_file, **kwargs):
+            call_log.append(log_file)
+            os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+            with open(log_file, 'w') as f:
+                json.dump(FAKE_EVAL_RESPONSE, f)
+            return FAKE_EVAL_RESPONSE
+
+        from storyforge import api as storyforge_api
+        from storyforge import cmd_evaluate_gn
+        monkeypatch.setattr(storyforge_api, 'invoke_to_file', tracking_invoke)
+        monkeypatch.setattr(cmd_evaluate_gn, 'invoke_to_file', tracking_invoke)
+
+        cmd_evaluate_gn.main(['--personas', 'pacing'])
+
+        # Only one API call should have been made (for pacing persona)
+        assert len(call_log) == 1, (
+            f'Expected 1 API call for pacing persona only, got {len(call_log)}'
+        )
+        assert 'pacing' in call_log[0], (
+            f'Expected pacing log file, got {call_log[0]}'
+        )
+
+        # Output JSON should show only pacing persona
+        output_dir = os.path.join(project_dir_gn, 'working', 'evaluations', 'latest')
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert os.path.isfile(json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert data['personas_run'] == ['pacing'], (
+            f'Expected only pacing persona run, got {data["personas_run"]}'
+        )
+
+
+class TestEvaluateDryRunNoApiCalls:
+    def test_dry_run_no_api_calls(self, project_dir_gn, monkeypatch):
+        """--dry-run doesn't call the API and writes no output files."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        api_called = []
+
+        def spy_invoke(prompt, model, log_file, **kwargs):
+            api_called.append(log_file)
+            return FAKE_EVAL_RESPONSE
+
+        from storyforge import api as storyforge_api
+        from storyforge import cmd_evaluate_gn
+        monkeypatch.setattr(storyforge_api, 'invoke_to_file', spy_invoke)
+        monkeypatch.setattr(cmd_evaluate_gn, 'invoke_to_file', spy_invoke)
+
+        from storyforge import cmd_evaluate_gn
+        cmd_evaluate_gn.main(['--dry-run'])
+
+        # No API calls should have been made
+        assert not api_called, (
+            f'--dry-run should not call API; got calls: {api_called}'
+        )
+
+        # No output JSON written
+        output_dir = os.path.join(project_dir_gn, 'working', 'evaluations', 'latest')
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert not os.path.isfile(json_path), (
+            '--dry-run should not write evaluation JSON'
+        )
+
+
+class TestEvaluateRefusesNonGN:
+    def test_refuses_non_gn_project(self, project_dir, monkeypatch):
+        """Refuses to run on non-GN projects with exit code 1."""
+        monkeypatch.chdir(project_dir)
+
+        from storyforge import cmd_evaluate_gn
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_evaluate_gn.main([])
+
+        assert exc_info.value.code != 0, 'Should exit non-zero for non-GN project'
+
+
+class TestEvaluateJsonParsing:
+    def test_fenced_json_block_is_parsed(self, project_dir_gn, monkeypatch):
+        """A response with JSON wrapped in ```json fences is correctly parsed."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        fenced_response = {
+            'content': [{'type': 'text', 'text': (
+                'Here are my findings:\n\n'
+                '```json\n'
+                '{"findings": [{"severity": "high", "fix_location": "composition", '
+                '"message": "Missing shot type", "scene_id": "the-blank-page", '
+                '"page": 2, "panel": 1}]}\n'
+                '```\n'
+            )}],
+            'usage': {'input_tokens': 100, 'output_tokens': 50,
+                      'cache_read_input_tokens': 0, 'cache_creation_input_tokens': 0},
+        }
+
+        fake = _make_fake_invoke(fenced_response)
+        from storyforge import api as storyforge_api
+        from storyforge import cmd_evaluate_gn
+        monkeypatch.setattr(storyforge_api, 'invoke_to_file', fake)
+        monkeypatch.setattr(cmd_evaluate_gn, 'invoke_to_file', fake)
+
+        cmd_evaluate_gn.main(['--personas', 'panel-composition'])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'evaluations', 'latest')
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert os.path.isfile(json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert len(data['findings']) == 1
+        assert data['findings'][0]['severity'] == 'high'
+        assert data['findings'][0]['message'] == 'Missing shot type'
+
+    def test_unparseable_response_skipped_gracefully(self, project_dir_gn, monkeypatch):
+        """If a persona returns non-JSON, it is skipped and the run continues."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        bad_response = {
+            'content': [{'type': 'text', 'text': 'I cannot find any issues with this script.'}],
+            'usage': {'input_tokens': 80, 'output_tokens': 20,
+                      'cache_read_input_tokens': 0, 'cache_creation_input_tokens': 0},
+        }
+
+        fake = _make_fake_invoke(bad_response)
+        from storyforge import api as storyforge_api
+        from storyforge import cmd_evaluate_gn
+        monkeypatch.setattr(storyforge_api, 'invoke_to_file', fake)
+        monkeypatch.setattr(cmd_evaluate_gn, 'invoke_to_file', fake)
+
+        # Should not raise — bad JSON is gracefully skipped
+        cmd_evaluate_gn.main(['--personas', 'pacing'])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'evaluations', 'latest')
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert os.path.isfile(json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        # The persona ran but produced no parseable findings
+        assert data['personas_run'] == ['pacing']
+        assert data['findings'] == []

--- a/tests/test_cmd_evaluate_gn.py
+++ b/tests/test_cmd_evaluate_gn.py
@@ -325,3 +325,51 @@ class TestEvaluateJsonParsing:
         # The persona ran but produced no parseable findings
         assert data['personas_run'] == ['pacing']
         assert data['findings'] == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_findings robustness (regression: null findings crash)
+# ---------------------------------------------------------------------------
+
+class TestParseFindings:
+    """Direct unit tests for the _parse_findings helper."""
+
+    def _call(self, text, persona='test-persona', scene_id='scene-x'):
+        from storyforge.cmd_evaluate_gn import _parse_findings
+        return _parse_findings(text, persona, scene_id)
+
+    def test_null_findings_returns_empty_list(self):
+        """{"findings": null} must not crash and must return []."""
+        result = self._call('{"findings": null}')
+        assert result == [], (
+            '_parse_findings should return [] for {"findings": null}, not raise TypeError'
+        )
+
+    def test_null_findings_in_fenced_block_returns_empty_list(self):
+        """A fenced block with {"findings": null} must not crash."""
+        text = '```json\n{"findings": null}\n```'
+        result = self._call(text)
+        assert result == []
+
+    def test_normal_findings_parsed_correctly(self):
+        """Normal {"findings": [...]} parses to a list with scene_id stamped."""
+        text = '{"findings": [{"severity": "medium", "message": "Test finding"}]}'
+        result = self._call(text, scene_id='my-scene')
+        assert len(result) == 1
+        assert result[0]['scene_id'] == 'my-scene'
+        assert result[0]['severity'] == 'medium'
+
+    def test_empty_findings_list_returns_empty(self):
+        """{"findings": []} returns []."""
+        result = self._call('{"findings": []}')
+        assert result == []
+
+    def test_empty_response_returns_empty(self):
+        """Empty string returns []."""
+        result = self._call('')
+        assert result == []
+
+    def test_non_list_findings_returns_empty_list(self):
+        """{"findings": "some string"} returns [] without crashing."""
+        result = self._call('{"findings": "some string"}')
+        assert result == []

--- a/tests/test_cmd_score_gn.py
+++ b/tests/test_cmd_score_gn.py
@@ -274,3 +274,78 @@ class TestScoreSkipsNonDraftedScenes:
         assert os.path.isfile(os.path.join(output_dir, 'the-blank-page.json'))
         assert not os.path.isfile(os.path.join(output_dir, 'shadows-arrive.json'))
         assert not os.path.isfile(os.path.join(output_dir, 'the-first-mark.json'))
+
+
+# ---------------------------------------------------------------------------
+# _load_weights: layered fallback (regression: fix #3)
+# ---------------------------------------------------------------------------
+
+class TestLoadWeightsLayering:
+    """Verify that local craft-weights.csv overrides only GN principles while
+    non-GN principles in a novel-mode weights file are ignored."""
+
+    def _call_load_weights(self, project_dir):
+        """Helper: import and call _load_weights using the real plugin_dir."""
+        from storyforge.cmd_score_gn import _load_weights
+        from storyforge.common import get_plugin_dir
+        plugin_dir = get_plugin_dir()
+        return _load_weights(project_dir, plugin_dir)
+
+    def test_local_override_for_brief_fidelity(self, project_dir_gn):
+        """A local weights file with brief_fidelity=9.0 overrides the default."""
+        weights_dir = os.path.join(project_dir_gn, 'working')
+        os.makedirs(weights_dir, exist_ok=True)
+        local_path = os.path.join(weights_dir, 'craft-weights.csv')
+        # Write a weights file that only has brief_fidelity overridden
+        with open(local_path, 'w', encoding='utf-8') as f:
+            f.write('principle|weight\n')
+            f.write('brief_fidelity|9.0\n')
+
+        weights = self._call_load_weights(project_dir_gn)
+
+        # brief_fidelity should dominate because it has weight 9.0 vs the
+        # others (which default to whatever the default file says or 1.0)
+        assert 'brief_fidelity' in weights
+        assert weights['brief_fidelity'] > weights['panel_density'], (
+            'brief_fidelity with local weight 9.0 should dominate panel_density'
+        )
+
+    def test_novel_mode_weights_file_ignored_for_missing_gn_principles(
+            self, project_dir_gn):
+        """A novel-mode weights file with only novel principles leaves GN
+        principles using defaults (not equal weights)."""
+        from storyforge.common import get_plugin_dir
+        from storyforge.cmd_score_gn import _load_weights
+
+        plugin_dir = get_plugin_dir()
+        default_path = os.path.join(
+            plugin_dir, 'references', 'default-craft-weights-gn.csv'
+        )
+        # Only run this assertion if the default file exists
+        if not os.path.isfile(default_path):
+            return  # can't test without default file
+
+        weights_dir = os.path.join(project_dir_gn, 'working')
+        os.makedirs(weights_dir, exist_ok=True)
+        local_path = os.path.join(weights_dir, 'craft-weights.csv')
+        # Simulate a migrated novel-mode weights file: only novel principles
+        with open(local_path, 'w', encoding='utf-8') as f:
+            f.write('principle|weight\n')
+            f.write('prose_repetition|1.5\n')
+            f.write('avoid_passive|2.0\n')
+            f.write('economy_clarity|1.0\n')
+
+        weights = _load_weights(project_dir_gn, plugin_dir)
+
+        # All 6 GN principles must be present and normalised
+        from storyforge.scoring_gn import PRINCIPLES
+        for p in PRINCIPLES:
+            assert p in weights, f'GN principle {p} missing from weights'
+        total = sum(weights.values())
+        assert abs(total - 1.0) < 1e-9, f'weights should sum to 1.0, got {total}'
+
+    def test_weights_sum_to_one(self, project_dir_gn):
+        """Regardless of local overrides, weights must sum to 1.0."""
+        weights = self._call_load_weights(project_dir_gn)
+        total = sum(weights.values())
+        assert abs(total - 1.0) < 1e-9, f'weights sum {total} != 1.0'

--- a/tests/test_cmd_score_gn.py
+++ b/tests/test_cmd_score_gn.py
@@ -1,0 +1,276 @@
+"""End-to-end tests for cmd_score_gn: GN scoring orchestration."""
+
+import json
+import os
+
+import pytest
+
+from storyforge.csv_cli import update_field
+
+
+# ---------------------------------------------------------------------------
+# Minimal drafted panel scripts (small/fast — no real API calls)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_THE_BLANK_PAGE = """\
+# Scene: the-blank-page
+
+**Target pages:** 2 | **Layout intent:** splash p1, 4-grid p2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1**
+The cartographer at his desk in lamplit study with blank parchment spread before him. Deep shadows fill the bookshelves. His posture suggests decades of waiting.
+
+- CAPTION: *The map remained blank.*
+
+---
+
+## Page 2 — 4-GRID
+
+**Panel 1**
+Close on his trembling hand resting on the table edge.
+
+- CAPTION: *Forty years of practice.*
+
+**Panel 2**
+Brush touches paper with a faint quiver visible.
+
+**Panel 3**
+A single line appears across the white expanse.
+
+- SFX: Scritch.
+
+**Panel 4**
+He stares at the line growing darker and more certain.
+
+- CARTOGRAPHER: No.
+"""
+
+_SCRIPT_SHADOWS_ARRIVE = """\
+# Scene: shadows-arrive
+
+**Target pages:** 1 | **Layout intent:** 6-grid
+
+---
+
+## Page 1 — 6-GRID
+
+**Panel 1**
+Door from outside the frame. Thin gap at bottom. Shadow just visible.
+
+**Panel 2**
+Shadow deepens under the door. Wind moving the curtains at the window behind.
+
+**Panel 3**
+The lamp flame gutters in a draught from somewhere unseen.
+
+**Panel 4**
+Cartographer turns away from the desk to face the door.
+
+- CARTOGRAPHER: Who's there?
+
+**Panel 5**
+Listens. Head tilted. Silence on his face.
+
+**Panel 6**
+He stands, pushing back the chair.
+"""
+
+_SCRIPT_THE_FIRST_MARK = """\
+# Scene: the-first-mark
+
+**Target pages:** 1 | **Layout intent:** 3-tier
+
+---
+
+## Page 1 — 3-TIER
+
+**Panel 1**
+Returns to the desk from across the room. Back to the viewer. Lamp still burning.
+
+- CAPTION: *He did not remember crossing the room.*
+
+**Panel 2**
+The page is no longer blank. Filled with coastline detail he has never drawn.
+
+- CARTOGRAPHER: This place — I never drew it.
+
+**Panel 3**
+His hand reaches for the pen. Dawn light beginning at the window behind him.
+"""
+
+
+def _write_scenes(project_dir, scripts=None):
+    """Write fake drafted scene files and set status=drafted in scenes.csv."""
+    if scripts is None:
+        scripts = {
+            'the-blank-page': _SCRIPT_THE_BLANK_PAGE,
+            'shadows-arrive': _SCRIPT_SHADOWS_ARRIVE,
+            'the-first-mark': _SCRIPT_THE_FIRST_MARK,
+        }
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    os.makedirs(scenes_dir, exist_ok=True)
+    meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    for sid, text in scripts.items():
+        path = os.path.join(scenes_dir, f'{sid}.md')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+        update_field(meta_csv, sid, 'status', 'drafted')
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestScoreAllDraftedScenes:
+    def test_score_all_drafted_produces_json_and_summary(self, project_dir_gn, monkeypatch):
+        """Run main([]) on all 3 drafted scenes; verify JSON + summary.csv exist."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn)
+
+        from storyforge import cmd_score_gn
+        cmd_score_gn.main([])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'scores', 'latest')
+
+        # All three scene JSON files should exist
+        for sid in ('the-blank-page', 'shadows-arrive', 'the-first-mark'):
+            json_path = os.path.join(output_dir, f'{sid}.json')
+            assert os.path.isfile(json_path), f'Missing score JSON for {sid}'
+            with open(json_path) as f:
+                data = json.load(f)
+            assert data['scene_id'] == sid
+            assert isinstance(data['overall_score'], float)
+            assert 0.0 <= data['overall_score'] <= 1.0, (
+                f'{sid} overall_score {data["overall_score"]} not in [0,1]'
+            )
+            assert 'scores' in data
+            assert 'findings' in data
+            assert 'scored_at' in data
+
+        # Summary CSV
+        summary = os.path.join(output_dir, 'summary.csv')
+        assert os.path.isfile(summary), 'summary.csv not written'
+        with open(summary) as f:
+            content = f.read()
+        assert 'scene_id' in content
+        assert 'overall_score' in content
+        assert 'the-blank-page' in content
+
+
+class TestScoreSingleSceneViaPositional:
+    def test_positional_arg_scores_only_that_scene(self, project_dir_gn, monkeypatch):
+        """main(['the-blank-page']) should score only that one scene."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn)
+
+        from storyforge import cmd_score_gn
+        cmd_score_gn.main(['the-blank-page'])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'scores', 'latest')
+
+        # Target scene scored
+        assert os.path.isfile(os.path.join(output_dir, 'the-blank-page.json'))
+
+        # Other scenes NOT scored
+        assert not os.path.isfile(os.path.join(output_dir, 'shadows-arrive.json'))
+        assert not os.path.isfile(os.path.join(output_dir, 'the-first-mark.json'))
+
+        # Summary contains only the one scene
+        summary = os.path.join(output_dir, 'summary.csv')
+        with open(summary) as f:
+            lines = [l for l in f.read().splitlines() if l.strip()]
+        # header + 1 data row
+        assert len(lines) == 2, f'Expected 2 lines in summary, got {len(lines)}'
+        assert 'the-blank-page' in lines[1]
+
+
+class TestScoreWithPrinciplesFilter:
+    def test_principles_filter_runs_only_requested_principles(
+            self, project_dir_gn, monkeypatch):
+        """--principles brief_fidelity,panel_density only runs those two."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn, {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        from storyforge import cmd_score_gn
+        cmd_score_gn.main(['the-blank-page',
+                           '--principles', 'brief_fidelity,panel_density'])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'scores', 'latest')
+        json_path = os.path.join(output_dir, 'the-blank-page.json')
+        assert os.path.isfile(json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        scores = data['scores']
+        # Only the two requested principles present
+        assert 'brief_fidelity' in scores
+        assert 'panel_density' in scores
+        # Others absent
+        for p in ('dialogue_compression', 'layout_rhythm',
+                  'caption_economy', 'panel_composition_depth'):
+            assert p not in scores, f'Unexpected principle {p} in filtered output'
+
+        # Summary header should only have the two principles
+        summary_path = os.path.join(output_dir, 'summary.csv')
+        with open(summary_path) as f:
+            header = f.readline().strip()
+        assert 'brief_fidelity' in header
+        assert 'panel_density' in header
+        assert 'dialogue_compression' not in header
+
+
+class TestDryRunWritesNothing:
+    def test_dry_run_creates_no_output_files(self, project_dir_gn, monkeypatch):
+        """--dry-run should not create any score files or the output directory."""
+        monkeypatch.chdir(project_dir_gn)
+        _write_scenes(project_dir_gn)
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'scores', 'latest')
+
+        from storyforge import cmd_score_gn
+        cmd_score_gn.main(['--dry-run'])
+
+        # Output directory should not have any JSON or CSV written
+        if os.path.isdir(output_dir):
+            entries = os.listdir(output_dir)
+            json_files = [e for e in entries if e.endswith('.json')]
+            csv_files = [e for e in entries if e.endswith('.csv')]
+            assert not json_files, f'Dry run wrote JSON files: {json_files}'
+            assert not csv_files, f'Dry run wrote CSV files: {csv_files}'
+
+
+class TestScoreRefusesNonGN:
+    def test_refuses_non_gn_project(self, project_dir, monkeypatch):
+        """Running on a novel project exits non-zero with a clear error."""
+        monkeypatch.chdir(project_dir)
+
+        from storyforge import cmd_score_gn
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_score_gn.main([])
+        assert exc_info.value.code != 0, 'Should exit non-zero for non-GN project'
+
+
+class TestScoreSkipsNonDraftedScenes:
+    def test_non_drafted_scenes_are_skipped(self, project_dir_gn, monkeypatch):
+        """Scenes with status != 'drafted' are logged and skipped."""
+        monkeypatch.chdir(project_dir_gn)
+
+        # Only write + mark one scene as drafted
+        _write_scenes(project_dir_gn,
+                      {'the-blank-page': _SCRIPT_THE_BLANK_PAGE})
+
+        # The other two remain 'briefed' (fixture default — not 'drafted')
+        from storyforge import cmd_score_gn
+        cmd_score_gn.main([])
+
+        output_dir = os.path.join(project_dir_gn, 'working', 'scores', 'latest')
+
+        # Only the drafted one scored
+        assert os.path.isfile(os.path.join(output_dir, 'the-blank-page.json'))
+        assert not os.path.isfile(os.path.join(output_dir, 'shadows-arrive.json'))
+        assert not os.path.isfile(os.path.join(output_dir, 'the-first-mark.json'))

--- a/tests/test_cmd_score_gn.py
+++ b/tests/test_cmd_score_gn.py
@@ -343,6 +343,14 @@ class TestLoadWeightsLayering:
             assert p in weights, f'GN principle {p} missing from weights'
         total = sum(weights.values())
         assert abs(total - 1.0) < 1e-9, f'weights should sum to 1.0, got {total}'
+        # Defaults must actually be applied — not equal-weight fallback.
+        # The curated GN defaults give brief_fidelity weight=8 and
+        # panel_density weight=5, so brief_fidelity must outweigh panel_density.
+        assert weights['brief_fidelity'] > weights['panel_density'], (
+            'curated GN defaults should be applied when local file has no GN '
+            'principles — got equal weights, suggesting the fallback path '
+            'ignored defaults'
+        )
 
     def test_weights_sum_to_one(self, project_dir_gn):
         """Regardless of local overrides, weights must sum to 1.0."""

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -350,7 +350,7 @@ def test_briefs_handler_gn_returns_none_when_no_work(project_dir_gn):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize('cmd', [
-    'evaluate', 'score', 'revise',
+    'evaluate', 'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 ])
 def test_dispatcher_blocks_unsupported_commands_in_gn_mode(
@@ -508,3 +508,23 @@ def test_dispatcher_routes_write_to_novel_in_novel_mode(project_dir, monkeypatch
         pass
     assert called['novel'], 'novel-mode write should route to cmd_write'
     assert not called['gn'], 'novel-mode write should NOT call cmd_write_gn'
+
+
+def test_dispatcher_routes_score_to_gn_in_gn_mode(project_dir_gn, monkeypatch):
+    """In GN mode, `./storyforge score` invokes cmd_score_gn."""
+    monkeypatch.chdir(project_dir_gn)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'score', '--dry-run'])
+    called = []
+    from storyforge import cmd_score_gn
+    real_main = cmd_score_gn.main
+    def track(*args, **kwargs):
+        called.append(True)
+        return real_main(*args, **kwargs)
+    monkeypatch.setattr(cmd_score_gn, 'main', track)
+
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called, 'cmd_score_gn.main should be called for score in GN mode'

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -571,3 +571,25 @@ def test_dispatcher_routes_evaluate_to_novel_in_novel_mode(project_dir, monkeypa
         pass
     assert called['novel'], 'novel-mode evaluate should route to cmd_evaluate'
     assert not called['gn'], 'novel-mode evaluate should NOT call cmd_evaluate_gn'
+
+
+def test_dispatcher_routes_score_to_novel_in_novel_mode(project_dir, monkeypatch):
+    """In novel mode, ./storyforge score invokes cmd_score (not cmd_score_gn)."""
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'score', '--help'])
+    called = {'novel': False, 'gn': False}
+    from storyforge import cmd_score, cmd_score_gn
+    def novel_track(*args, **kwargs):
+        called['novel'] = True
+        raise SystemExit(0)
+    def gn_track(*args, **kwargs):
+        called['gn'] = True
+    monkeypatch.setattr(cmd_score, 'main', novel_track)
+    monkeypatch.setattr(cmd_score_gn, 'main', gn_track)
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called['novel'], 'novel-mode score should route to cmd_score'
+    assert not called['gn'], 'novel-mode score should NOT call cmd_score_gn'

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -350,7 +350,7 @@ def test_briefs_handler_gn_returns_none_when_no_work(project_dir_gn):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize('cmd', [
-    'evaluate', 'revise',
+    'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 ])
 def test_dispatcher_blocks_unsupported_commands_in_gn_mode(
@@ -528,3 +528,46 @@ def test_dispatcher_routes_score_to_gn_in_gn_mode(project_dir_gn, monkeypatch):
     except SystemExit:
         pass
     assert called, 'cmd_score_gn.main should be called for score in GN mode'
+
+
+def test_dispatcher_routes_evaluate_to_gn_in_gn_mode(project_dir_gn, monkeypatch):
+    """In GN mode, `./storyforge evaluate` invokes cmd_evaluate_gn."""
+    monkeypatch.chdir(project_dir_gn)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'evaluate', '--dry-run'])
+    called = []
+    from storyforge import cmd_evaluate_gn
+    def track(*args, **kwargs):
+        called.append(True)
+        raise SystemExit(0)
+    monkeypatch.setattr(cmd_evaluate_gn, 'main', track)
+
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called, 'cmd_evaluate_gn.main should be called for evaluate in GN mode'
+
+
+def test_dispatcher_routes_evaluate_to_novel_in_novel_mode(project_dir, monkeypatch):
+    """In novel mode, `./storyforge evaluate` invokes cmd_evaluate (not cmd_evaluate_gn)."""
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'evaluate', '--help'])
+
+    called = {'novel': False, 'gn': False}
+    from storyforge import cmd_evaluate, cmd_evaluate_gn
+    def novel_track(*args, **kwargs):
+        called['novel'] = True
+        raise SystemExit(0)
+    def gn_track(*args, **kwargs):
+        called['gn'] = True
+    monkeypatch.setattr(cmd_evaluate, 'main', novel_track)
+    monkeypatch.setattr(cmd_evaluate_gn, 'main', gn_track)
+
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called['novel'], 'novel-mode evaluate should route to cmd_evaluate'
+    assert not called['gn'], 'novel-mode evaluate should NOT call cmd_evaluate_gn'

--- a/tests/test_scoring_gn.py
+++ b/tests/test_scoring_gn.py
@@ -1,0 +1,594 @@
+"""Tests for scoring_gn: six deterministic GN craft scorers."""
+
+import statistics
+import pytest
+
+from storyforge.script_format import parse_script
+from storyforge.scoring_gn import (
+    score_brief_fidelity,
+    score_panel_density,
+    score_dialogue_compression,
+    score_layout_rhythm,
+    score_caption_economy,
+    score_panel_composition_depth,
+    score_scene,
+    score_project,
+    SCORERS,
+    PRINCIPLES,
+    CAPTION_STRATEGY_TARGETS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Reusable sample scripts
+# ---------------------------------------------------------------------------
+
+# A well-formed 2-page script: balanced panels, short dialogue, good composition
+GOOD_SCRIPT = """\
+# Scene: test
+
+**Target pages:** 2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1**
+The cartographer at his desk in lamplit study. Blank parchment before him. Shadows along the bookshelves filling the room.
+
+- CAPTION: *The map remained blank.*
+
+---
+
+## Page 2 — 4-GRID
+
+**Panel 1**
+Close on his trembling hand resting on the table edge.
+
+- CAPTION: *Forty years of practice and still this fear.*
+
+**Panel 2**
+Brush touches paper with a faint quiver visible.
+
+**Panel 3**
+A single line appears across the white expanse.
+
+- SFX: Scritch.
+
+**Panel 4**
+He stares at the line growing darker.
+
+- CARTOGRAPHER: No.
+"""
+
+# A dense 1-page script with many panels for testing density edge cases
+DENSE_ONE_PAGE = """\
+## Page 1 — 10-GRID
+
+**Panel 1**
+A face.
+
+**Panel 2**
+An eye.
+
+**Panel 3**
+A mouth.
+
+**Panel 4**
+A hand.
+
+**Panel 5**
+A foot.
+
+**Panel 6**
+A door.
+
+**Panel 7**
+A window.
+
+**Panel 8**
+A clock.
+
+**Panel 9**
+A key.
+
+**Panel 10**
+Darkness.
+"""
+
+# A script with perfectly uniform panel counts (triggers layout_too_uniform)
+UNIFORM_SCRIPT = """\
+## Page 1 — 4-GRID
+
+**Panel 1**
+Scene establishing the market square in full afternoon light.
+
+**Panel 2**
+Two merchants arguing over a price near the spice stalls.
+
+**Panel 3**
+A child watches from the alley entrance beside a cart.
+
+**Panel 4**
+The cartographer moves through the crowd unnoticed by all.
+
+---
+
+## Page 2 — 4-GRID
+
+**Panel 1**
+Interior of the map shop with rolled charts on every shelf.
+
+**Panel 2**
+The owner behind the counter examining a newly arrived scroll.
+
+**Panel 3**
+Our cartographer leans over the glass case inspecting closely.
+
+**Panel 4**
+Close on the owner's suspicious eyes narrowing at the visitor.
+
+---
+
+## Page 3 — 4-GRID
+
+**Panel 1**
+Money exchanged across the worn wooden counter between them.
+
+**Panel 2**
+The scroll changes hands in the dim afternoon light.
+
+**Panel 3**
+Door swings open letting in a shaft of street noise.
+
+**Panel 4**
+The cartographer exits into the busy market without looking back.
+"""
+
+# A script with chaotic variation (triggers layout_too_chaotic)
+CHAOTIC_SCRIPT = """\
+## Page 1 — SPLASH
+
+**Panel 1**
+Wide establishing shot of the harbour at dawn with tall ships.
+
+---
+
+## Page 2 — 8-GRID
+
+**Panel 1**
+Face.
+
+**Panel 2**
+Hand.
+
+**Panel 3**
+Rope.
+
+**Panel 4**
+Anchor chain dropping.
+
+**Panel 5**
+Seagull.
+
+**Panel 6**
+Wave.
+
+**Panel 7**
+Boot on deck.
+
+**Panel 8**
+Bell swinging.
+
+---
+
+## Page 3 — SPLASH
+
+**Panel 1**
+The ship sails into fog, a lone figure at the bow.
+"""
+
+# A brief row for fidelity tests
+GOOD_BRIEF = {
+    'id': 'test-scene',
+    'key_dialogue': 'No',
+    'visual_keywords': 'trembling hand; blank parchment',
+    'panel_breakdown': 'p1:splash; p2:4-grid',
+    'page_turn_beats': '',
+}
+
+
+# ---------------------------------------------------------------------------
+# Module structure
+# ---------------------------------------------------------------------------
+
+def test_principles_tuple_has_six_items():
+    assert len(PRINCIPLES) == 6
+    assert 'brief_fidelity' in PRINCIPLES
+    assert 'panel_density' in PRINCIPLES
+    assert 'dialogue_compression' in PRINCIPLES
+    assert 'layout_rhythm' in PRINCIPLES
+    assert 'caption_economy' in PRINCIPLES
+    assert 'panel_composition_depth' in PRINCIPLES
+
+
+def test_scorers_dict_matches_principles():
+    assert set(SCORERS.keys()) == set(PRINCIPLES)
+
+
+# ---------------------------------------------------------------------------
+# score_brief_fidelity
+# ---------------------------------------------------------------------------
+
+def test_brief_fidelity_passes_when_all_checks_met():
+    # GOOD_SCRIPT has 'No' as dialogue, panel count p1:splash p2:4-grid matches,
+    # and we include the visual keywords
+    script = GOOD_SCRIPT.replace(
+        'Close on his trembling hand resting on the table edge.',
+        'Close on his trembling hand and the blank parchment before him.',
+    )
+    brief = dict(GOOD_BRIEF, visual_keywords='trembling hand; blank parchment')
+    parsed = parse_script(script)
+    result = score_brief_fidelity(parsed, brief, script)
+    assert result['principle'] == 'brief_fidelity'
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_brief_fidelity_drops_score_for_missing_dialogue():
+    brief = dict(GOOD_BRIEF, key_dialogue='A phrase that does not appear anywhere')
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_brief_fidelity(parsed, brief, GOOD_SCRIPT)
+    assert result['score'] < 1.0
+    assert any(f['kind'] == 'dialogue_missing' for f in result['findings'])
+
+
+def test_brief_fidelity_score_formula_one_failure():
+    # 1 failure out of 4 checks = score 0.75
+    brief = {
+        'id': 'test',
+        'key_dialogue': 'This line is absolutely not in the script',
+        'visual_keywords': '',
+        'panel_breakdown': '',
+        'page_turn_beats': '',
+    }
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_brief_fidelity(parsed, brief, GOOD_SCRIPT)
+    assert result['score'] == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# score_panel_density
+# ---------------------------------------------------------------------------
+
+def test_panel_density_result_structure():
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_panel_density(parsed)
+    assert result['principle'] == 'panel_density'
+    assert 'score' in result
+    assert 'findings' in result
+    assert 0.0 <= result['score'] <= 1.0
+
+
+def test_panel_density_passes_on_balanced_script():
+    # GOOD_SCRIPT: p1=1 panel, p2=4 panels → avg = 2.5
+    # score = 1 - |2.5 - 5.5| / 5.5 = 1 - 3/5.5 ≈ 0.455
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_panel_density(parsed, None, GOOD_SCRIPT)
+    expected_score = 1.0 - abs(2.5 - 5.5) / 5.5
+    assert result['score'] == pytest.approx(expected_score)
+
+
+def test_panel_density_empty_script_returns_perfect():
+    parsed = parse_script('# Scene: empty\n')
+    result = score_panel_density(parsed)
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_panel_density_flags_cramped_page():
+    parsed = parse_script(DENSE_ONE_PAGE)
+    result = score_panel_density(parsed)
+    # 10 panels on 1 page → avg=10, distance=4.5, score=1-4.5/5.5≈0.18
+    assert result['score'] < 0.5
+    assert any(f['kind'] == 'panel_density_high' for f in result['findings'])
+
+
+def test_panel_density_sweet_spot_scores_near_one():
+    # Build a 1-page script with 6 panels (close to 5.5 sweet spot)
+    panels = '\n\n'.join(
+        f'**Panel {i}**\n'
+        f'A figure moves through the shadowed corridor with purpose and direction here.'
+        for i in range(1, 7)
+    )
+    script = f'## Page 1 — 6-GRID\n\n{panels}\n'
+    parsed = parse_script(script)
+    result = score_panel_density(parsed)
+    # avg=6, distance=0.5, score=1-0.5/5.5≈0.909
+    assert result['score'] > 0.85
+
+
+# ---------------------------------------------------------------------------
+# score_dialogue_compression
+# ---------------------------------------------------------------------------
+
+def test_dialogue_compression_passes_on_short_lines():
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_dialogue_compression(parsed)
+    assert result['principle'] == 'dialogue_compression'
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_dialogue_compression_empty_dialogue_is_perfect():
+    # Script with no dialogue lines at all
+    script = (
+        '## Page 1 — SPLASH\n\n'
+        '**Panel 1**\n'
+        'Wide shot of the empty coastline at dusk with fading light.\n'
+    )
+    parsed = parse_script(script)
+    result = score_dialogue_compression(parsed)
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_dialogue_compression_flags_long_balloon():
+    # Build a 26-word dialogue line
+    long_line = 'word ' * 26
+    script = (
+        '## Page 1 — SPLASH\n\n'
+        '**Panel 1**\n'
+        'The speaker addresses the crowd.\n\n'
+        f'- SPEAKER: {long_line.strip()}\n'
+    )
+    parsed = parse_script(script)
+    result = score_dialogue_compression(parsed)
+    assert result['score'] < 1.0
+    assert any(f['kind'] == 'balloon_too_long' for f in result['findings'])
+
+
+def test_dialogue_compression_sfx_not_counted():
+    # SFX lines should be excluded from scoring
+    script = (
+        '## Page 1 — SPLASH\n\n'
+        '**Panel 1**\n'
+        'A door slams in the hallway.\n\n'
+        '- SFX: ' + 'BANG ' * 30 + '\n'
+    )
+    parsed = parse_script(script)
+    result = score_dialogue_compression(parsed)
+    # SFX excluded → no balloons counted → score 1.0
+    assert result['score'] == 1.0
+
+
+def test_dialogue_compression_mixed_severity():
+    # 35-word line → medium; 45-word line → high
+    line_35 = 'word ' * 35
+    line_45 = 'word ' * 45
+    script = (
+        '## Page 1 — 2-GRID\n\n'
+        '**Panel 1**\n'
+        'First scene.\n\n'
+        f'- CHARACTER: {line_35.strip()}\n\n'
+        '**Panel 2**\n'
+        'Second scene.\n\n'
+        f'- CHARACTER: {line_45.strip()}\n'
+    )
+    parsed = parse_script(script)
+    result = score_dialogue_compression(parsed)
+    severities = {f['severity'] for f in result['findings']}
+    assert 'medium' in severities
+    assert 'high' in severities
+
+
+# ---------------------------------------------------------------------------
+# score_layout_rhythm
+# ---------------------------------------------------------------------------
+
+def test_layout_rhythm_single_page_is_perfect():
+    parsed = parse_script(GOOD_SCRIPT.split('---')[0] + GOOD_SCRIPT.split('---')[1])
+    # Force single-page by building minimal script
+    script = '## Page 1 — SPLASH\n\n**Panel 1**\nSingle page scene.\n'
+    parsed = parse_script(script)
+    result = score_layout_rhythm(parsed)
+    assert result['principle'] == 'layout_rhythm'
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_layout_rhythm_uniform_pages_flagged():
+    parsed = parse_script(UNIFORM_SCRIPT)
+    result = score_layout_rhythm(parsed)
+    # 3 pages each with 4 panels → stdev = 0.0
+    assert result['score'] == pytest.approx(0.0)
+    assert any(f['kind'] == 'layout_too_uniform' for f in result['findings'])
+
+
+def test_layout_rhythm_chaotic_pages_flagged():
+    # CHAOTIC_SCRIPT: p1=1 panel, p2=8 panels, p3=1 panel
+    parsed = parse_script(CHAOTIC_SCRIPT)
+    densities = [len(p['panels']) for p in parsed['pages']]
+    stdev = statistics.stdev(densities)
+    result = score_layout_rhythm(parsed)
+    assert stdev >= 3.0, f'expected chaotic stdev, got {stdev}'
+    assert any(f['kind'] == 'layout_too_chaotic' for f in result['findings'])
+
+
+def test_layout_rhythm_sweet_spot_scores_well():
+    # Build script where stdev ≈ 1.5 (peak score = 1.0)
+    # Pages with 4, 6 panels → stdev ≈ 1.41
+    script = (
+        '## Page 1 — 4-GRID\n\n'
+        '**Panel 1**\nScene A with good composition detail here.\n'
+        '**Panel 2**\nScene B with good composition detail here.\n'
+        '**Panel 3**\nScene C with good composition detail here.\n'
+        '**Panel 4**\nScene D with good composition detail here.\n\n'
+        '---\n\n'
+        '## Page 2 — 6-GRID\n\n'
+        '**Panel 1**\nScene E.\n'
+        '**Panel 2**\nScene F.\n'
+        '**Panel 3**\nScene G.\n'
+        '**Panel 4**\nScene H.\n'
+        '**Panel 5**\nScene I.\n'
+        '**Panel 6**\nScene J.\n'
+    )
+    parsed = parse_script(script)
+    result = score_layout_rhythm(parsed)
+    assert result['score'] > 0.8
+
+
+# ---------------------------------------------------------------------------
+# score_caption_economy
+# ---------------------------------------------------------------------------
+
+def test_caption_economy_minimal_strategy_one_caption_passes():
+    # minimal → target=1; 1 caption per page → within target
+    brief = {'caption_strategy': 'minimal'}
+    parsed = parse_script(GOOD_SCRIPT)
+    result = score_caption_economy(parsed, brief)
+    assert result['principle'] == 'caption_economy'
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_caption_economy_none_strategy_any_caption_fails():
+    brief = {'caption_strategy': 'none'}
+    parsed = parse_script(GOOD_SCRIPT)  # has CAPTION lines
+    result = score_caption_economy(parsed, brief)
+    assert result['score'] < 1.0
+    assert any(f['kind'] == 'caption_when_none' for f in result['findings'])
+
+
+def test_caption_economy_unknown_strategy_defaults_to_target_2():
+    brief = {'caption_strategy': 'unknown-strategy'}
+    # Build a page with 4 captions (exceeds default target=2, even with +1 buffer)
+    panels = ''.join(
+        f'**Panel {i}**\nScene.\n\n- CAPTION: *Line {i}.*\n\n'
+        for i in range(1, 5)
+    )
+    script = f'## Page 1 — 4-GRID\n\n{panels}'
+    parsed = parse_script(script)
+    result = score_caption_economy(parsed, brief)
+    # 4 captions > target(2) + 1 = 3 → excess finding
+    assert any(f['kind'] == 'caption_excess' for f in result['findings'])
+
+
+def test_caption_economy_empty_pages_returns_perfect():
+    brief = {'caption_strategy': 'minimal'}
+    parsed = parse_script('# Scene: empty\n')
+    result = score_caption_economy(parsed, brief)
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_caption_economy_journal_voiceover_target():
+    # journal-voiceover → target=3; 3 captions allowed
+    brief = {'caption_strategy': 'journal-voiceover'}
+    panels = ''.join(
+        f'**Panel {i}**\nScene.\n\n- CAPTION: *Line {i}.*\n\n'
+        for i in range(1, 4)
+    )
+    script = f'## Page 1 — 3-GRID\n\n{panels}'
+    parsed = parse_script(script)
+    result = score_caption_economy(parsed, brief)
+    # 3 captions == target → within target → score 1.0
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+# ---------------------------------------------------------------------------
+# score_panel_composition_depth
+# ---------------------------------------------------------------------------
+
+def test_panel_composition_depth_sweet_spot_scores_one():
+    # Build a panel with ~20 words of composition (in the 15-50 range)
+    composition = (
+        'The cartographer stands at his desk examining the blank parchment '
+        'with trembling hands in the lamplight.'
+    )
+    script = f'## Page 1 — SPLASH\n\n**Panel 1**\n{composition}\n'
+    parsed = parse_script(script)
+    word_count = len(parsed['pages'][0]['panels'][0]['composition'].split())
+    assert 15 <= word_count <= 50, f'expected 15-50 words, got {word_count}'
+    result = score_panel_composition_depth(parsed)
+    assert result['principle'] == 'panel_composition_depth'
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_panel_composition_depth_too_sparse_flagged():
+    # 5-word composition → below MIN=15
+    script = '## Page 1 — SPLASH\n\n**Panel 1**\nA figure in darkness.\n'
+    parsed = parse_script(script)
+    result = score_panel_composition_depth(parsed)
+    assert result['score'] < 1.0
+    assert any(f['kind'] == 'composition_too_sparse' for f in result['findings'])
+
+
+def test_panel_composition_depth_too_dense_flagged():
+    # 60-word composition → above MAX=50
+    dense = ' '.join(['word'] * 60)
+    script = f'## Page 1 — SPLASH\n\n**Panel 1**\n{dense}\n'
+    parsed = parse_script(script)
+    result = score_panel_composition_depth(parsed)
+    assert result['score'] < 1.0
+    assert any(f['kind'] == 'composition_too_dense' for f in result['findings'])
+
+
+def test_panel_composition_depth_empty_script_returns_perfect():
+    parsed = parse_script('# Scene: empty\n')
+    result = score_panel_composition_depth(parsed)
+    assert result['score'] == 1.0
+    assert result['findings'] == []
+
+
+def test_panel_composition_depth_boundary_at_exactly_15_words():
+    # Exactly 15 words → exactly at MIN → within sweet spot
+    composition = ' '.join(['word'] * 15)
+    script = f'## Page 1 — SPLASH\n\n**Panel 1**\n{composition}\n'
+    parsed = parse_script(script)
+    result = score_panel_composition_depth(parsed)
+    assert result['score'] == 1.0
+
+
+def test_panel_composition_depth_boundary_at_exactly_50_words():
+    # Exactly 50 words → exactly at MAX → within sweet spot
+    composition = ' '.join(['word'] * 50)
+    script = f'## Page 1 — SPLASH\n\n**Panel 1**\n{composition}\n'
+    parsed = parse_script(script)
+    result = score_panel_composition_depth(parsed)
+    assert result['score'] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# score_scene aggregator
+# ---------------------------------------------------------------------------
+
+def test_score_scene_returns_all_principles():
+    parsed = parse_script(GOOD_SCRIPT)
+    results = score_scene('test-scene', parsed, GOOD_BRIEF, GOOD_SCRIPT)
+    assert set(results.keys()) == set(PRINCIPLES)
+    for principle, result in results.items():
+        assert result['principle'] == principle
+        assert 0.0 <= result['score'] <= 1.0
+        assert 'findings' in result
+
+
+# ---------------------------------------------------------------------------
+# score_project contract
+# ---------------------------------------------------------------------------
+
+def test_score_project_skips_non_gn(fixture_dir):
+    """Novel-mode project returns skipped=True."""
+    result = score_project(fixture_dir)
+    assert result.get('skipped') is True
+    assert 'reason' in result
+
+
+def test_score_project_returns_principles_for_gn(fixture_dir_gn):
+    """GN project returns the principles list."""
+    result = score_project(fixture_dir_gn)
+    assert result.get('skipped') is not True
+    assert 'principles' in result
+    assert set(result['principles']) == set(PRINCIPLES)

--- a/tests/test_scoring_gn.py
+++ b/tests/test_scoring_gn.py
@@ -258,6 +258,78 @@ def test_brief_fidelity_score_formula_one_failure():
 
 
 # ---------------------------------------------------------------------------
+# score_brief_fidelity — distinct-kinds math (regression: #2)
+# ---------------------------------------------------------------------------
+
+def test_brief_fidelity_multiple_same_kind_counts_as_one(monkeypatch):
+    """2 missing dialogue lines (same kind) → 1 distinct kind → score 0.75."""
+    import storyforge.scoring_gn as scoring_gn_mod
+    monkeypatch.setattr(
+        scoring_gn_mod, 'check_brief_fidelity',
+        lambda brief_row, script_text: [
+            {'kind': 'dialogue_missing', 'detail': 'line A', 'severity': 'high'},
+            {'kind': 'dialogue_missing', 'detail': 'line B', 'severity': 'high'},
+        ],
+    )
+    parsed = parse_script(GOOD_SCRIPT)
+    result = scoring_gn_mod.score_brief_fidelity(parsed, GOOD_BRIEF, GOOD_SCRIPT)
+    assert result['score'] == pytest.approx(0.75), (
+        '2 missing-dialogue failures are 1 distinct kind → 1/4 penalty → score 0.75'
+    )
+    assert len(result['findings']) == 2, 'all raw findings should still be reported'
+
+
+def test_brief_fidelity_two_distinct_kinds_score_half(monkeypatch):
+    """2 missing dialogues + 1 missing visual = 2 distinct kinds → score 0.5."""
+    import storyforge.scoring_gn as scoring_gn_mod
+    monkeypatch.setattr(
+        scoring_gn_mod, 'check_brief_fidelity',
+        lambda brief_row, script_text: [
+            {'kind': 'dialogue_missing', 'detail': 'line A', 'severity': 'high'},
+            {'kind': 'dialogue_missing', 'detail': 'line B', 'severity': 'high'},
+            {'kind': 'visual_keyword_missing', 'detail': 'kw C', 'severity': 'medium'},
+        ],
+    )
+    parsed = parse_script(GOOD_SCRIPT)
+    result = scoring_gn_mod.score_brief_fidelity(parsed, GOOD_BRIEF, GOOD_SCRIPT)
+    assert result['score'] == pytest.approx(0.5), (
+        '2 distinct kinds (dialogue_missing + visual_keyword_missing) → 2/4 penalty → 0.5'
+    )
+
+
+def test_brief_fidelity_all_four_distinct_kinds_score_zero(monkeypatch):
+    """1 failure of each of the 4 kinds → score 0.0."""
+    import storyforge.scoring_gn as scoring_gn_mod
+    monkeypatch.setattr(
+        scoring_gn_mod, 'check_brief_fidelity',
+        lambda brief_row, script_text: [
+            {'kind': 'dialogue_missing', 'detail': 'x', 'severity': 'high'},
+            {'kind': 'visual_keyword_missing', 'detail': 'y', 'severity': 'medium'},
+            {'kind': 'panel_count_mismatch', 'detail': 'z', 'severity': 'medium'},
+            {'kind': 'page_turn_missing', 'detail': 'w', 'severity': 'high'},
+        ],
+    )
+    parsed = parse_script(GOOD_SCRIPT)
+    result = scoring_gn_mod.score_brief_fidelity(parsed, GOOD_BRIEF, GOOD_SCRIPT)
+    assert result['score'] == pytest.approx(0.0), (
+        '4 distinct kinds → 4/4 penalty → score 0.0'
+    )
+
+
+def test_brief_fidelity_zero_failures_score_one(monkeypatch):
+    """0 failures → score 1.0."""
+    import storyforge.scoring_gn as scoring_gn_mod
+    monkeypatch.setattr(
+        scoring_gn_mod, 'check_brief_fidelity',
+        lambda brief_row, script_text: [],
+    )
+    parsed = parse_script(GOOD_SCRIPT)
+    result = scoring_gn_mod.score_brief_fidelity(parsed, GOOD_BRIEF, GOOD_SCRIPT)
+    assert result['score'] == pytest.approx(1.0)
+    assert result['findings'] == []
+
+
+# ---------------------------------------------------------------------------
 # score_panel_density
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds graphic-novel-specific scoring and a lightweight 3-persona evaluation panel. Closes #209 partially — `cmd_revise_gn` is deferred to a followup issue (will be opened separately) so the revise design can be informed by real scoring/evaluation usage.

## Design documents

- Spec: `docs/superpowers/specs/2026-05-20-graphic-novel-mode-design.md`
- Plan: `docs/superpowers/plans/2026-05-21-gn-scoring-evaluation.md`

## What's new

- `scoring_gn.py` — six deterministic GN scorers: brief_fidelity, panel_density, dialogue_compression, layout_rhythm, caption_economy, panel_composition_depth
- `cmd_score_gn.py` — orchestration; same CLI as novel-mode `score`; writes per-scene JSON + summary CSV
- `cmd_evaluate_gn.py` — runs three evaluator personas (panel-composition, pacing, dialogue) and aggregates findings
- `scripts/prompts/evaluators-gn/{panel-composition,pacing,dialogue}-critic.md` — persona system prompts
- `references/default-craft-weights-gn.csv` — GN craft weights (6 principles)
- Dispatcher routes `score` and `evaluate` to GN modules in GN mode
- Score skill gains a `## Graphic-novel mode` section
- Bumped to 1.22.0

## What's still missing for full #209

- `cmd_revise_gn.py` — revision passes (continuity, dialogue tightening, layout adjustments, brief-fidelity restoration). Deferred so the design can be informed by real-world scoring/evaluation findings — opening a followup issue separately.

## Tests

- `tests/test_scoring_gn.py` — 33 unit tests covering each scorer's pass/boundary/failure cases
- `tests/test_cmd_score_gn.py` — 6 end-to-end tests
- `tests/test_cmd_evaluate_gn.py` — 6 end-to-end tests (API mocked)
- `tests/test_medium.py` — dispatcher routing tests updated

## Test plan

- [x] `python3 -m pytest tests/` — 3578 passing, 0 failures, 75.93% coverage
- [x] Manual smoke test: scoring runs deterministically without API calls on the GN fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)