### PR TITLE
Add cmd_revise_gn: graphic-novel revision passes (closes #221)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,9 +363,9 @@ Set `project.medium: graphic-novel` in storyforge.yaml at init time to switch a 
 - Schema validation enforces graphic-novel column rules (target_pages required, panel_breakdown required at briefed status)
 - `score` — 6 deterministic GN principles in `scoring_gn.py` (brief_fidelity, panel_density, dialogue_compression, layout_rhythm, caption_economy, panel_composition_depth); no API calls, instant and cost-free (routes to `cmd_score_gn`)
 - `evaluate` — 3-persona evaluation panel (panel-composition, pacing, dialogue critics) that adds subjective findings the deterministic scorers can't catch (routes to `cmd_evaluate_gn`)
+- `revise` — findings-driven polish pass; reads score + evaluator findings and produces a revised panel script per scene. One API call per scene (routes to `cmd_revise_gn`). Pass `--no-findings` to polish blind.
 
 **Not yet supported (followups tracked as issues):**
-- `revise` — GN-specific revision passes deferred pending real scoring/evaluation data (#209 followup)
 - `publish`, `annotations` — Bookshelf integration for GN (#215)
 - `extract` — extract structure from existing scripts/prose (#213)
 

--- a/scripts/lib/python/storyforge/__main__.py
+++ b/scripts/lib/python/storyforge/__main__.py
@@ -11,7 +11,6 @@ import sys
 # When a project's medium is graphic-novel, these commands return a clear
 # error instead of silently running novel-mode logic on the wrong data.
 GN_UNSUPPORTED_COMMANDS = frozenset({
-    'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 })
 
@@ -21,6 +20,7 @@ GN_ROUTED_COMMANDS = {
     'assemble': 'storyforge.cmd_script_package',
     'score': 'storyforge.cmd_score_gn',
     'evaluate': 'storyforge.cmd_evaluate_gn',
+    'revise': 'storyforge.cmd_revise_gn',
 }
 
 COMMANDS = {

--- a/scripts/lib/python/storyforge/cmd_revise_gn.py
+++ b/scripts/lib/python/storyforge/cmd_revise_gn.py
@@ -1,0 +1,405 @@
+"""storyforge revise (graphic-novel mode) — Findings-driven panel-script revision.
+
+Revises drafted GN scenes by feeding deterministic scorer findings and
+evaluator-persona findings back into the model, then producing a revised
+script that targets the issues directly. Same CLI shape as novel-mode
+`revise`; routed here when project.medium == 'graphic-novel'.
+
+Usage:
+    storyforge revise                          # all drafted scenes
+    storyforge revise the-blank-page           # one scene
+    storyforge revise --scenes a,b,c
+    storyforge revise --act 2
+    storyforge revise --from-seq 3
+    storyforge revise --dry-run
+    storyforge revise --no-findings            # polish without findings input
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from storyforge.common import (
+    detect_project_root, log, set_log_file, select_model,
+    install_signal_handlers, get_medium,
+)
+from storyforge.csv_cli import get_field, update_field
+from storyforge.scene_filter import build_scene_list, apply_scene_filter
+from storyforge.script_format import count_pages, count_panels, check_brief_fidelity
+from storyforge.api import (
+    invoke_to_file, extract_text_from_file,
+    extract_usage, calculate_cost_from_usage,
+)
+from storyforge.costs import log_operation
+from storyforge.prompts_gn import build_revision_prompt
+from storyforge import git as git_helpers
+
+
+REVISABLE_STATUSES = ('drafted', 'revised')
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='storyforge revise (gn)',
+        description='Revise drafted GN panel scripts against findings.',
+    )
+    parser.add_argument('positional', nargs='*', default=[],
+                        help='Scene ID(s) to revise')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Build prompts without invoking the API')
+    parser.add_argument('--scenes', type=str, default=None,
+                        help='Comma-separated scene IDs')
+    parser.add_argument('--act', '--part', type=str, default=None,
+                        help='Revise all scenes in act/part N')
+    parser.add_argument('--from-seq', type=str, default=None,
+                        help='Start from sequence number (N or N-M range)')
+    parser.add_argument('--no-findings', action='store_true',
+                        help='Polish without findings input (blind polish)')
+    parser.add_argument('--no-branch', action='store_true',
+                        help='Skip branch + PR creation (useful for tests)')
+    return parser.parse_args(argv)
+
+
+def _row_to_dict(csv_path, row_id):
+    """Read a CSV row by ID and return as a dict. Returns {} if not found."""
+    if not os.path.isfile(csv_path):
+        return {}
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        raw = f.read().replace('\r\n', '\n').replace('\r', '')
+    lines = raw.splitlines()
+    if not lines:
+        return {}
+    headers = lines[0].split('|')
+    for line in lines[1:]:
+        fields = line.split('|')
+        if fields and fields[0] == row_id:
+            return dict(zip(headers, fields))
+    return {}
+
+
+def _build_visual_refs(project_dir):
+    """Read character-bible.md and world-bible.md for visual reference."""
+    ref_dir = os.path.join(project_dir, 'reference')
+    chars_path = os.path.join(ref_dir, 'character-bible.md')
+    world_path = os.path.join(ref_dir, 'world-bible.md')
+    char_text = open(chars_path, encoding='utf-8').read() if os.path.isfile(chars_path) else ''
+    world_text = open(world_path, encoding='utf-8').read() if os.path.isfile(world_path) else ''
+    return char_text, world_text
+
+
+def _build_voice_text(project_dir):
+    voice_path = os.path.join(project_dir, 'reference', 'voice-profile.csv')
+    if os.path.isfile(voice_path):
+        return open(voice_path, encoding='utf-8').read()
+    return ''
+
+
+def _load_score_findings(project_dir, scene_id):
+    """Load deterministic score findings for one scene. Returns flat list."""
+    path = os.path.join(project_dir, 'working', 'scores', 'latest', f'{scene_id}.json')
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+    return data.get('findings', []) or []
+
+
+def _load_eval_findings(project_dir, scene_id):
+    """Load persona eval findings for one scene. Returns flat list."""
+    path = os.path.join(project_dir, 'working', 'evaluations', 'latest', f'{scene_id}.json')
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+    return data.get('findings', []) or []
+
+
+def _resolve_target_scenes(args, metadata_csv):
+    """Resolve which scenes to revise, in priority order.
+
+    Mirrors the resolution logic used by cmd_write_gn / cmd_score_gn.
+    """
+    all_ids = build_scene_list(metadata_csv)
+
+    if args.positional:
+        if len(args.positional) == 1:
+            return [args.positional[0]]
+        if len(args.positional) == 2:
+            return apply_scene_filter(
+                metadata_csv, all_ids, 'range',
+                args.positional[0], args.positional[1],
+            )
+        log('ERROR: Too many positional arguments. '
+            'Provide one scene ID or two for a range.')
+        sys.exit(1)
+    if args.scenes:
+        return [s.strip() for s in args.scenes.split(',') if s.strip()]
+    if args.act:
+        return apply_scene_filter(metadata_csv, all_ids, 'act', args.act, None)
+    if args.from_seq:
+        return apply_scene_filter(
+            metadata_csv, all_ids, 'from_seq', args.from_seq, None,
+        )
+    return list(all_ids)
+
+
+def _revise_one_scene(scene_id, project_dir, model, args):
+    """Revise a single scene. Returns (scene_id, result_dict)."""
+    ref_dir = os.path.join(project_dir, 'reference')
+    scenes_csv = os.path.join(ref_dir, 'scenes.csv')
+
+    status = get_field(scenes_csv, scene_id, 'status') or ''
+    if status not in REVISABLE_STATUSES:
+        return scene_id, {
+            'skipped': True,
+            'reason': f'status is "{status}" (not in {REVISABLE_STATUSES})',
+        }
+
+    scene_path = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+    if not os.path.isfile(scene_path):
+        return scene_id, {'error': 'scene file not found'}
+
+    scene_row = _row_to_dict(scenes_csv, scene_id)
+    intent_row = _row_to_dict(os.path.join(ref_dir, 'scene-intent.csv'), scene_id)
+    brief_row = _row_to_dict(os.path.join(ref_dir, 'scene-briefs.csv'), scene_id)
+
+    if not brief_row:
+        return scene_id, {'error': 'missing brief row in scene-briefs.csv'}
+
+    with open(scene_path, encoding='utf-8') as f:
+        script_text = f.read()
+
+    if args.no_findings:
+        score_findings = []
+        eval_findings = []
+    else:
+        score_findings = _load_score_findings(project_dir, scene_id)
+        eval_findings = _load_eval_findings(project_dir, scene_id)
+        if not score_findings and not eval_findings:
+            return scene_id, {
+                'skipped': True,
+                'reason': (
+                    'no findings found — run `storyforge score` and/or '
+                    '`storyforge evaluate` first, or pass --no-findings to '
+                    'polish blind'
+                ),
+            }
+
+    char_visuals, loc_visuals = _build_visual_refs(project_dir)
+    voice_text = _build_voice_text(project_dir)
+
+    prompt = build_revision_prompt(
+        scene_id=scene_id,
+        scene_row=scene_row,
+        intent_row=intent_row,
+        brief_row=brief_row,
+        script_text=script_text,
+        character_visuals=char_visuals,
+        location_visuals=loc_visuals,
+        voice_profile_text=voice_text,
+        score_findings=score_findings,
+        eval_findings=eval_findings,
+    )
+
+    if args.dry_run:
+        return scene_id, {
+            'dry_run': True,
+            'prompt': prompt,
+            'score_findings': len(score_findings),
+            'eval_findings': len(eval_findings),
+        }
+
+    log_dir = os.path.join(project_dir, 'working', 'logs', 'revise-gn')
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, f'{scene_id}.json')
+
+    try:
+        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+    except Exception as e:
+        return scene_id, {'error': f'API call failed: {e}'}
+
+    revised_text = extract_text_from_file(log_file)
+    if not revised_text:
+        return scene_id, {'error': 'empty API response'}
+
+    # Overwrite the scene file with the revised script
+    with open(scene_path, 'w', encoding='utf-8') as f:
+        f.write(revised_text)
+
+    pages = count_pages(revised_text)
+    panels = count_panels(revised_text)
+    failures = check_brief_fidelity(brief_row, revised_text)
+
+    # Cost tracking (best-effort)
+    try:
+        with open(log_file, encoding='utf-8') as f:
+            resp = json.load(f)
+        usage = extract_usage(resp)
+        cost = calculate_cost_from_usage(usage, model)
+        log_operation(
+            project_dir, 'revise-gn', model,
+            usage['input_tokens'], usage['output_tokens'], cost,
+            target=scene_id,
+            cache_read=usage.get('cache_read', 0),
+            cache_create=usage.get('cache_create', 0),
+        )
+    except Exception:
+        pass
+
+    return scene_id, {
+        'revised': True,
+        'pages': pages,
+        'panels': panels,
+        'fidelity_failures': len(failures),
+        'score_findings': len(score_findings),
+        'eval_findings': len(eval_findings),
+    }
+
+
+def _build_pr_body(scene_ids):
+    """Build a PR body with a per-scene task list."""
+    lines = ['## Revision pass — graphic-novel mode', '']
+    lines.append('Findings-driven revision: each scene gets one polish pass '
+                 'using deterministic scorer + evaluator persona findings.')
+    lines.append('')
+    lines.append('## Tasks')
+    for sid in scene_ids:
+        lines.append(f'- [ ] Revise: {sid}')
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    install_signal_handlers()
+
+    project_dir = detect_project_root()
+
+    medium = get_medium(project_dir)
+    if medium != 'graphic-novel':
+        log(f'ERROR: This command is only for graphic-novel projects '
+            f'(project.medium = "{medium}").')
+        log('For novel projects, use the standard `storyforge revise` command.')
+        sys.exit(1)
+
+    log(f'Project root: {project_dir}')
+    log('Medium: graphic-novel — using GN revision pass')
+
+    log_dir = os.path.join(project_dir, 'working', 'logs')
+    os.makedirs(log_dir, exist_ok=True)
+    set_log_file(os.path.join(log_dir, 'revise-gn-log.txt'))
+
+    metadata_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+
+    candidate_ids = _resolve_target_scenes(args, metadata_csv)
+
+    # Filter to scenes that actually have a draft on disk and a revisable status
+    scenes_dir = os.path.join(project_dir, 'scenes')
+    scene_ids = []
+    for sid in candidate_ids:
+        status = get_field(metadata_csv, sid, 'status') or ''
+        if status not in REVISABLE_STATUSES:
+            log(f'  SKIP {sid}: status is "{status}" (not in {REVISABLE_STATUSES})')
+            continue
+        if not os.path.isfile(os.path.join(scenes_dir, f'{sid}.md')):
+            log(f'  SKIP {sid}: scene file not found')
+            continue
+        scene_ids.append(sid)
+
+    if not scene_ids:
+        log('ERROR: No revisable scenes found for the selected scope.')
+        sys.exit(1)
+
+    log(f'Scenes to revise: {len(scene_ids)}')
+
+    if args.dry_run:
+        log('DRY RUN — no API calls will be made, no files will be written')
+        for sid in scene_ids:
+            title = get_field(metadata_csv, sid, 'title') or sid
+            log(f'  - {sid} ({title})')
+
+    model = select_model('revision') if not args.dry_run else 'dry-run'
+    log(f'Model: {model}')
+
+    # Branch + draft PR (unless --no-branch or dry-run)
+    pr_number = ''
+    if not args.dry_run and not args.no_branch:
+        branch = git_helpers.create_branch('revise-gn', project_dir)
+        if branch:
+            git_helpers.ensure_branch_pushed(project_dir, branch)
+            pr_number = git_helpers.create_draft_pr(
+                title=f'Revise (GN): {len(scene_ids)} scene(s)',
+                body=_build_pr_body(scene_ids),
+                project_dir=project_dir,
+                work_type='revision',
+            )
+
+    # Revise each scene sequentially. Sequential is simpler than parallel for
+    # the first version and keeps commit ordering deterministic — the LLM call
+    # is the cost driver, not loop overhead.
+    revised_count = 0
+    for sid in scene_ids:
+        log(f'  Revising {sid}...')
+        _, result = _revise_one_scene(sid, project_dir, model, args)
+
+        if args.dry_run and result.get('dry_run'):
+            print(f'===== DRY RUN: {sid} =====')
+            print(f'  score findings: {result["score_findings"]}')
+            print(f'  eval findings: {result["eval_findings"]}')
+            print('--- prompt ---')
+            print(result['prompt'])
+            print(f'===== END DRY RUN: {sid} =====')
+            print()
+            continue
+
+        if result.get('skipped'):
+            log(f'  SKIP {sid}: {result["reason"]}')
+            continue
+        if result.get('error'):
+            log(f'  ERROR {sid}: {result["error"]}')
+            continue
+
+        # Apply CSV updates in the main thread (mirrors cmd_write_gn approach)
+        update_field(metadata_csv, sid, 'page_count', str(result['pages']))
+        update_field(metadata_csv, sid, 'panel_count', str(result['panels']))
+        update_field(metadata_csv, sid, 'status', 'revised')
+
+        fidelity_note = (
+            f', {result["fidelity_failures"]} fidelity warning(s)'
+            if result['fidelity_failures'] else ''
+        )
+        log(
+            f'  {sid}: revised {result["pages"]} page(s), '
+            f'{result["panels"]} panel(s) '
+            f'(score: {result["score_findings"]}, eval: {result["eval_findings"]} '
+            f'findings){fidelity_note}'
+        )
+
+        if not args.no_branch:
+            git_helpers.commit_and_push(
+                project_dir,
+                f'Revision: {sid} (GN)',
+                paths=[
+                    os.path.join('scenes', f'{sid}.md'),
+                    os.path.join('reference', 'scenes.csv'),
+                ],
+            )
+            if pr_number:
+                git_helpers.update_pr_task(f'Revise: {sid}', project_dir, pr_number)
+
+        revised_count += 1
+
+    if not args.dry_run:
+        log(f'Done. {revised_count}/{len(scene_ids)} scene(s) revised.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/lib/python/storyforge/cmd_revise_gn.py
+++ b/scripts/lib/python/storyforge/cmd_revise_gn.py
@@ -19,7 +19,6 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone
 
 from storyforge.common import (
     detect_project_root, log, set_log_file, select_model,
@@ -96,36 +95,53 @@ def _build_voice_text(project_dir):
     return ''
 
 
-def _load_score_findings(project_dir, scene_id):
-    """Load deterministic score findings for one scene. Returns flat list."""
-    path = os.path.join(project_dir, 'working', 'scores', 'latest', f'{scene_id}.json')
+def _load_findings_file(path, kind):
+    """Load a findings file at `path`. Returns:
+
+      - []  when the file is absent (no findings yet — legitimate)
+      - None when the file exists but is corrupt or unreadable (real error)
+      - list of finding dicts otherwise
+    """
     if not os.path.isfile(path):
         return []
     try:
         with open(path, encoding='utf-8') as f:
             data = json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return []
-    return data.get('findings', []) or []
+    except (json.JSONDecodeError, OSError) as e:
+        log(f'WARNING: could not read {kind} findings at {path}: {e}')
+        return None
+    raw = data.get('findings', []) or []
+    # Drop any non-dict entries (e.g. nulls) so downstream prompt-building
+    # can't crash with AttributeError on f.get(...).
+    findings = [f for f in raw if isinstance(f, dict)]
+    if len(findings) != len(raw):
+        log(f'WARNING: dropped {len(raw) - len(findings)} malformed '
+            f'{kind} finding(s) at {path}')
+    return findings
+
+
+def _load_score_findings(project_dir, scene_id):
+    """Load deterministic score findings for one scene.
+
+    Returns [] when no file exists, None on parse failure, else a list.
+    """
+    path = os.path.join(project_dir, 'working', 'scores', 'latest', f'{scene_id}.json')
+    return _load_findings_file(path, 'score')
 
 
 def _load_eval_findings(project_dir, scene_id):
-    """Load persona eval findings for one scene. Returns flat list."""
+    """Load persona eval findings for one scene.
+
+    Returns [] when no file exists, None on parse failure, else a list.
+    """
     path = os.path.join(project_dir, 'working', 'evaluations', 'latest', f'{scene_id}.json')
-    if not os.path.isfile(path):
-        return []
-    try:
-        with open(path, encoding='utf-8') as f:
-            data = json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return []
-    return data.get('findings', []) or []
+    return _load_findings_file(path, 'eval')
 
 
 def _resolve_target_scenes(args, metadata_csv):
-    """Resolve which scenes to revise, in priority order.
-
-    Mirrors the resolution logic used by cmd_write_gn / cmd_score_gn.
+    """Resolve which scenes to revise. Single-positional matches cmd_write_gn;
+    two positionals become a range; --scenes / --act / --from-seq delegate to
+    apply_scene_filter so unknown IDs are flagged loudly.
     """
     all_ids = build_scene_list(metadata_csv)
 
@@ -141,7 +157,7 @@ def _resolve_target_scenes(args, metadata_csv):
             'Provide one scene ID or two for a range.')
         sys.exit(1)
     if args.scenes:
-        return [s.strip() for s in args.scenes.split(',') if s.strip()]
+        return apply_scene_filter(metadata_csv, all_ids, 'scenes', args.scenes, None)
     if args.act:
         return apply_scene_filter(metadata_csv, all_ids, 'act', args.act, None)
     if args.from_seq:
@@ -152,7 +168,19 @@ def _resolve_target_scenes(args, metadata_csv):
 
 
 def _revise_one_scene(scene_id, project_dir, model, args):
-    """Revise a single scene. Returns (scene_id, result_dict)."""
+    """Revise a single scene.
+
+    Side effects (only on the success path, all gated past the dry-run return):
+      - overwrites scenes/{scene_id}.md with the revised script
+      - writes the API response JSON to working/logs/revise-gn/{scene_id}.json
+      - appends a row to the cost ledger via log_operation
+
+    Returns (scene_id, result_dict) where result_dict has exactly one of:
+      - {'skipped': True, 'reason': str} — scene intentionally not processed
+      - {'error': str}                   — recoverable per-scene failure
+      - {'dry_run': True, 'prompt': str, 'score_findings': int, 'eval_findings': int}
+      - {'revised': True, 'pages': int, 'panels': int, ...} — success
+    """
     ref_dir = os.path.join(project_dir, 'reference')
     scenes_csv = os.path.join(ref_dir, 'scenes.csv')
 
@@ -171,6 +199,8 @@ def _revise_one_scene(scene_id, project_dir, model, args):
     intent_row = _row_to_dict(os.path.join(ref_dir, 'scene-intent.csv'), scene_id)
     brief_row = _row_to_dict(os.path.join(ref_dir, 'scene-briefs.csv'), scene_id)
 
+    if not scene_row:
+        return scene_id, {'error': 'missing row in scenes.csv'}
     if not brief_row:
         return scene_id, {'error': 'missing brief row in scene-briefs.csv'}
 
@@ -183,6 +213,20 @@ def _revise_one_scene(scene_id, project_dir, model, args):
     else:
         score_findings = _load_score_findings(project_dir, scene_id)
         eval_findings = _load_eval_findings(project_dir, scene_id)
+        # _load_*_findings returns None when the file exists but is corrupt.
+        # Surface that as a real error instead of treating it like "no findings."
+        if score_findings is None or eval_findings is None:
+            broken = []
+            if score_findings is None:
+                broken.append('score')
+            if eval_findings is None:
+                broken.append('eval')
+            return scene_id, {
+                'error': (
+                    f'corrupt {"/".join(broken)} findings file (see WARNING above) — '
+                    f're-run scoring/evaluation or delete the file to clear it'
+                ),
+            }
         if not score_findings and not eval_findings:
             return scene_id, {
                 'skipped': True,
@@ -230,7 +274,6 @@ def _revise_one_scene(scene_id, project_dir, model, args):
     if not revised_text:
         return scene_id, {'error': 'empty API response'}
 
-    # Overwrite the scene file with the revised script
     with open(scene_path, 'w', encoding='utf-8') as f:
         f.write(revised_text)
 
@@ -329,18 +372,25 @@ def main(argv=None):
     model = select_model('revision') if not args.dry_run else 'dry-run'
     log(f'Model: {model}')
 
-    # Branch + draft PR (unless --no-branch or dry-run)
+    # Branch + draft PR (unless --no-branch or dry-run). Refuse to proceed if
+    # branch creation fails — committing revisions to the current branch
+    # (possibly main) would violate the project's git policy.
     pr_number = ''
     if not args.dry_run and not args.no_branch:
         branch = git_helpers.create_branch('revise-gn', project_dir)
-        if branch:
-            git_helpers.ensure_branch_pushed(project_dir, branch)
-            pr_number = git_helpers.create_draft_pr(
-                title=f'Revise (GN): {len(scene_ids)} scene(s)',
-                body=_build_pr_body(scene_ids),
-                project_dir=project_dir,
-                work_type='revision',
-            )
+        if not branch:
+            log('ERROR: Could not create or resume a feature branch. '
+                'Refusing to commit revisions to the current branch. '
+                'Check `git status` for a dirty working tree, or pass '
+                '--no-branch to run without git operations.')
+            sys.exit(1)
+        git_helpers.ensure_branch_pushed(project_dir, branch)
+        pr_number = git_helpers.create_draft_pr(
+            title=f'Revise (GN): {len(scene_ids)} scene(s)',
+            body=_build_pr_body(scene_ids),
+            project_dir=project_dir,
+            work_type='revision',
+        )
 
     # Revise each scene sequentially. Sequential is simpler than parallel for
     # the first version and keeps commit ordering deterministic — the LLM call
@@ -367,7 +417,6 @@ def main(argv=None):
             log(f'  ERROR {sid}: {result["error"]}')
             continue
 
-        # Apply CSV updates in the main thread (mirrors cmd_write_gn approach)
         update_field(metadata_csv, sid, 'page_count', str(result['pages']))
         update_field(metadata_csv, sid, 'panel_count', str(result['panels']))
         update_field(metadata_csv, sid, 'status', 'revised')

--- a/scripts/lib/python/storyforge/prompts_gn.py
+++ b/scripts/lib/python/storyforge/prompts_gn.py
@@ -161,3 +161,200 @@ Now write the script for scene `{scene_id}`. Produce exactly {target_pages}
 pages. Begin with the H1 header `# Scene: {scene_id}` and follow the format
 rules above. Do not write any commentary outside the script itself.
 """
+
+
+def _format_findings(score_findings, eval_findings):
+    """Group findings by source and category for the revision prompt.
+
+    Findings come in two flavors:
+      - Deterministic score findings: { kind, detail, severity }
+      - Persona eval findings: { persona, severity, message, page, panel, ... }
+
+    We render them as a markdown bulleted list grouped by source, with
+    the most actionable categories first. Returns '' if no findings.
+    """
+    blocks = []
+
+    if score_findings:
+        # Group by principle (kind prefix) so the revision sees related issues together
+        by_kind = {}
+        for f in score_findings:
+            kind = f.get('kind', 'other')
+            by_kind.setdefault(kind, []).append(f)
+
+        # Order kinds: brief-fidelity first (most important), then dialogue,
+        # then composition, then layout/density
+        kind_order = [
+            'dialogue_missing', 'visual_keyword_missing',
+            'panel_count_mismatch', 'page_turn_missing',
+            'balloon_too_long', 'caption_excess', 'caption_when_none',
+            'composition_too_sparse', 'composition_too_dense',
+            'panel_density_high', 'panel_density_zero',
+            'layout_too_uniform', 'layout_too_chaotic',
+        ]
+        ordered_kinds = (
+            [k for k in kind_order if k in by_kind]
+            + sorted(k for k in by_kind if k not in kind_order)
+        )
+
+        blocks.append('### Deterministic findings (from scoring)')
+        for kind in ordered_kinds:
+            for f in by_kind[kind]:
+                sev = f.get('severity', 'medium')
+                detail = f.get('detail', '')
+                blocks.append(f'- [{sev}] **{kind}**: {detail}')
+        blocks.append('')
+
+    if eval_findings:
+        # Group by persona so the revision sees each critic's themes together
+        by_persona = {}
+        for f in eval_findings:
+            persona = f.get('persona', 'unknown')
+            by_persona.setdefault(persona, []).append(f)
+
+        for persona in sorted(by_persona):
+            blocks.append(f'### Evaluator findings — {persona}')
+            for f in by_persona[persona]:
+                sev = f.get('severity', 'medium')
+                message = (
+                    f.get('message')
+                    or f.get('detail')
+                    or f.get('issue')
+                    or '(no message)'
+                )
+                loc_parts = []
+                if f.get('page'):
+                    loc_parts.append(f'page {f["page"]}')
+                if f.get('panel'):
+                    loc_parts.append(f'panel {f["panel"]}')
+                loc = f' ({", ".join(loc_parts)})' if loc_parts else ''
+                blocks.append(f'- [{sev}]{loc} {message}')
+            blocks.append('')
+
+    return '\n'.join(blocks).rstrip()
+
+
+def build_revision_prompt(
+    scene_id,
+    scene_row,
+    intent_row,
+    brief_row,
+    script_text,
+    character_visuals,
+    location_visuals,
+    voice_profile_text,
+    score_findings,
+    eval_findings,
+):
+    """Build a prompt asking Claude to revise a drafted GN panel script.
+
+    The revision pass is findings-driven: scorer and evaluator output drives
+    targeted edits while preserving the script's overall structure. When no
+    findings are provided (blind polish mode), the prompt asks for general
+    tightening against the brief and format rules.
+
+    Args:
+        scene_id: Scene ID being revised.
+        scene_row: Dict from scenes.csv (target_pages, pov, location, title).
+        intent_row: Dict from scene-intent.csv.
+        brief_row: Dict from scene-briefs.csv (the contract).
+        script_text: Current drafted script (markdown).
+        character_visuals: character-bible.md content.
+        location_visuals: world-bible.md content.
+        voice_profile_text: voice-profile.csv content.
+        score_findings: List of deterministic score findings (may be empty).
+        eval_findings: List of persona eval findings (may be empty).
+
+    Returns:
+        Prompt string for Claude.
+    """
+    target_pages = (scene_row.get('target_pages') or '?').strip()
+    title = (scene_row.get('title') or scene_id).strip()
+    pov = (scene_row.get('pov') or '').strip()
+    location = (scene_row.get('location') or '').strip()
+
+    intent_summary = '\n'.join(
+        f"- {k}: {v}" for k, v in intent_row.items() if (v or '').strip()
+    )
+    brief_summary = _format_brief(brief_row)
+
+    findings_block = _format_findings(score_findings, eval_findings)
+    if findings_block:
+        findings_section = (
+            '# Findings to address\n\n'
+            'These were produced by deterministic scorers and evaluator personas '
+            'against the current draft. Address them directly. Severity levels '
+            'indicate priority: high > medium > low.\n\n'
+            f'{findings_block}\n'
+        )
+        revision_directive = (
+            'Revise the script above to address the findings. Make targeted '
+            'changes only — do not rewrite passages that already work. '
+            'Preserve the page structure unless a finding explicitly requires '
+            'changing it (e.g., panel_count_mismatch).'
+        )
+    else:
+        findings_section = ''
+        revision_directive = (
+            'No findings were provided. Polish the script against the brief '
+            'contract: compress over-long dialogue (>25 words), tighten sparse '
+            'or overstuffed panel compositions, restore any missing '
+            'key_dialogue or visual_keywords, and confirm the panel_breakdown '
+            'matches the brief.'
+        )
+
+    return f"""\
+You are revising a graphic-novel scene. The script below has already been
+drafted; your job is to produce a tightened version that better honors
+the brief and addresses the findings listed.
+
+# Scene context
+
+- id: {scene_id}
+- title: {title}
+- target_pages: {target_pages}
+- pov: {pov}
+- location: {location}
+
+# Scene intent
+
+{intent_summary or '(none)'}
+
+# Scene brief — every column is a contract you must honor
+
+{brief_summary}
+
+Specifically:
+  - Every entry in `key_dialogue` MUST appear verbatim (or near-verbatim)
+    as a word-balloon or caption line in the script.
+  - Every entry in `visual_keywords` (semicolon-separated) MUST appear
+    in some panel's composition prose.
+  - The script's per-page panel structure MUST match `panel_breakdown`.
+  - Pages tagged in `page_turn_beats` MUST carry the ⟵ PAGE-TURN REVEAL
+    marker on their page header line.
+  - `caption_strategy` determines how narration is used.
+
+# Character visual references
+
+{character_visuals or '(none provided)'}
+
+# Location visual references
+
+{location_visuals or '(none provided)'}
+
+# Voice profile
+
+{voice_profile_text or '(default)'}
+
+# Current draft
+
+{script_text}
+
+{findings_section}{SCRIPT_FORMAT_INSTRUCTIONS}
+
+{revision_directive}
+
+Output the complete revised script for scene `{scene_id}`. Begin with the
+H1 header `# Scene: {scene_id}` and follow the format rules above. Do not
+write any commentary outside the script itself.
+"""

--- a/scripts/lib/python/storyforge/prompts_gn.py
+++ b/scripts/lib/python/storyforge/prompts_gn.py
@@ -176,14 +176,14 @@ def _format_findings(score_findings, eval_findings):
     blocks = []
 
     if score_findings:
-        # Group by principle (kind prefix) so the revision sees related issues together
+        # Group by finding kind so the revision sees related issues together
         by_kind = {}
         for f in score_findings:
             kind = f.get('kind', 'other')
             by_kind.setdefault(kind, []).append(f)
 
-        # Order kinds: brief-fidelity first (most important), then dialogue,
-        # then composition, then layout/density
+        # Order: brief-fidelity → dialogue → captions → composition →
+        # layout/density (most actionable first)
         kind_order = [
             'dialogue_missing', 'visual_keyword_missing',
             'panel_count_mismatch', 'page_turn_missing',

--- a/tests/test_cmd_revise_gn.py
+++ b/tests/test_cmd_revise_gn.py
@@ -447,3 +447,164 @@ def test_revise_via_dispatcher_routes_to_gn(project_dir_gn, monkeypatch):
 
     scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
     assert get_field(scenes_csv, 'the-blank-page', 'status') == 'revised'
+
+
+# ---------------------------------------------------------------------------
+# Draft preservation under failure (the critical invariant: revise must
+# never destroy a draft when something goes wrong)
+# ---------------------------------------------------------------------------
+
+def _empty_invoke_to_file(prompt, model, log_file, **kwargs):
+    """Fake invoke_to_file: API returned a response with no text content."""
+    os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+    response = {
+        'content': [],  # no text blocks at all
+        'stop_reason': 'max_tokens',
+        'usage': {
+            'input_tokens': 200, 'output_tokens': 0,
+            'cache_read_input_tokens': 0, 'cache_creation_input_tokens': 0,
+        },
+    }
+    with open(log_file, 'w') as f:
+        json.dump(response, f)
+    return response
+
+
+def test_revise_preserves_draft_on_empty_api_response(project_dir_gn, monkeypatch):
+    """If the API returns no text, the scene file and status must be untouched."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', _empty_invoke_to_file)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', _empty_invoke_to_file)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+
+    scene_path = os.path.join(project_dir_gn, 'scenes', 'the-blank-page.md')
+    assert open(scene_path).read() == INITIAL_DRAFT, (
+        'empty API response must NOT clobber the original draft'
+    )
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+    assert get_field(scenes_csv, 'the-blank-page', 'panel_count') == '5'
+    assert get_field(scenes_csv, 'the-blank-page', 'page_count') == '2'
+
+
+def test_revise_preserves_draft_on_api_exception(project_dir_gn, monkeypatch):
+    """If invoke_to_file raises, the scene file and status must be untouched."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    def boom(*args, **kwargs):
+        raise RuntimeError('simulated API outage')
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', boom)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', boom)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+
+    scene_path = os.path.join(project_dir_gn, 'scenes', 'the-blank-page.md')
+    assert open(scene_path).read() == INITIAL_DRAFT, (
+        'API exception must NOT clobber the original draft'
+    )
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+
+
+# ---------------------------------------------------------------------------
+# Findings file diagnostics
+# ---------------------------------------------------------------------------
+
+def test_revise_errors_on_corrupt_score_findings(project_dir_gn, monkeypatch):
+    """A corrupt findings file is surfaced as an error, not as "no findings"."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+
+    # Write malformed JSON to the score findings file
+    path = os.path.join(project_dir_gn, 'working', 'scores', 'latest',
+                        'the-blank-page.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('{this is not valid json')
+
+    calls = []
+
+    def track(*args, **kwargs):
+        calls.append(args)
+        return _make_fake_invoke(REVISED_SCRIPT)(*args, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', track)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', track)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+    assert calls == [], 'should not invoke API when findings are corrupt'
+
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+
+
+# ---------------------------------------------------------------------------
+# --scenes flag validates against scene list (no silent typo pass-through)
+# ---------------------------------------------------------------------------
+
+def test_revise_scenes_flag_rejects_unknown_scene_ids(project_dir_gn, monkeypatch):
+    """`--scenes typo-id` should fail loudly via apply_scene_filter, not silently skip."""
+    monkeypatch.chdir(project_dir_gn)
+
+    from storyforge import api, cmd_revise_gn
+    # Should not get this far, but if it does, fail the test loudly.
+    monkeypatch.setattr(api, 'invoke_to_file',
+                        lambda *a, **k: pytest.fail('API should not be called'))
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file',
+                        lambda *a, **k: pytest.fail('API should not be called'))
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_revise_gn.main(['--scenes', 'this-id-does-not-exist', '--no-branch'])
+    assert exc_info.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Branch-creation failure must NOT fall through to committing on current branch
+# ---------------------------------------------------------------------------
+
+def test_revise_aborts_when_branch_creation_fails(project_dir_gn, monkeypatch):
+    """If git_helpers.create_branch returns '', the run must abort before any
+    API call or git commit happens — never commit revisions to the current
+    branch (potentially main)."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    calls = []
+
+    def fake_invoke(*args, **kwargs):
+        calls.append(args)
+        return _make_fake_invoke(REVISED_SCRIPT)(*args, **kwargs)
+
+    from storyforge import api, cmd_revise_gn, git as git_helpers
+    monkeypatch.setattr(api, 'invoke_to_file', fake_invoke)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', fake_invoke)
+    monkeypatch.setattr(git_helpers, 'create_branch', lambda *a, **k: '')
+
+    # Invoke without --no-branch so the branch-creation path is exercised
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_revise_gn.main(['the-blank-page'])
+    assert exc_info.value.code != 0
+    assert calls == [], 'API must not be called when branch creation fails'
+
+    # Scene file untouched, status unchanged
+    scene_path = os.path.join(project_dir_gn, 'scenes', 'the-blank-page.md')
+    assert open(scene_path).read() == INITIAL_DRAFT
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'

--- a/tests/test_cmd_revise_gn.py
+++ b/tests/test_cmd_revise_gn.py
@@ -1,0 +1,449 @@
+"""Tests for cmd_revise_gn — GN findings-driven panel-script revision."""
+
+import json
+import os
+
+import pytest
+
+from storyforge.csv_cli import get_field, update_field
+
+
+# Initial draft (mimics what cmd_write_gn would have written). Two pages,
+# one over-long balloon, one too-sparse composition — typical findings shape.
+INITIAL_DRAFT = """\
+# Scene: the-blank-page
+
+**Target pages:** 2 | **Layout intent:** splash p1, 4-grid p2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1** (full bleed)
+Cartographer at desk.
+
+- CAPTION: *The map remained blank, as it always did at the start of these long nights when even the lamp seemed reluctant to throw its weak yellow light across the heavy parchment.*
+- CARTOGRAPHER: It always begins this way.
+
+---
+
+## Page 2 — 4-GRID ⟵ PAGE-TURN REVEAL
+
+**Panel 1** (top-left)
+Hand close.
+
+- CAPTION: *Forty years of practice.*
+
+**Panel 2** (top-right)
+Pen touches paper.
+
+**Panel 3** (bottom-left)
+Line appears.
+
+- SFX: Scritch.
+
+**Panel 4** (bottom-right)
+He stares at the result.
+
+- CARTOGRAPHER: No.
+"""
+
+
+# What we expect the API to return after revision — same structure, but the
+# over-long balloon has been compressed and the sparse composition fleshed out.
+REVISED_SCRIPT = """\
+# Scene: the-blank-page
+
+**Target pages:** 2 | **Layout intent:** splash p1, 4-grid p2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1** (full bleed)
+The cartographer at his desk. Blank parchment seen close, lamp glow on paper
+casting long shadows across the room. A trembling hand hovers above.
+
+- CAPTION: *The map remained blank.*
+- CARTOGRAPHER: It always begins this way.
+
+---
+
+## Page 2 — 4-GRID ⟵ PAGE-TURN REVEAL
+
+**Panel 1** (top-left)
+Close on his trembling hand above the parchment. Knuckles white, ink ready.
+
+- CAPTION: *Forty years of practice.*
+
+**Panel 2** (top-right)
+The pen touches paper for the first time tonight.
+
+**Panel 3** (bottom-left)
+A thin line appears, hesitant against the blank field.
+
+- SFX: Scritch.
+
+**Panel 4** (bottom-right)
+He stares at what he has made, breath caught, the lamp guttering low.
+
+- CARTOGRAPHER: No.
+"""
+
+
+def _make_fake_invoke(response_text):
+    """Build an invoke_to_file replacement that returns response_text."""
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        response = {
+            'content': [{'type': 'text', 'text': response_text}],
+            'usage': {
+                'input_tokens': 500, 'output_tokens': 800,
+                'cache_read_input_tokens': 0,
+                'cache_creation_input_tokens': 0,
+            },
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    return fake
+
+
+def _seed_draft(project_dir, scene_id, draft_text=INITIAL_DRAFT,
+                page_count=2, panel_count=5):
+    """Write a drafted scene + mark CSVs as drafted."""
+    scene_path = os.path.join(project_dir, 'scenes', f'{scene_id}.md')
+    os.makedirs(os.path.dirname(scene_path), exist_ok=True)
+    with open(scene_path, 'w', encoding='utf-8') as f:
+        f.write(draft_text)
+    scenes_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
+    update_field(scenes_csv, scene_id, 'status', 'drafted')
+    update_field(scenes_csv, scene_id, 'page_count', str(page_count))
+    update_field(scenes_csv, scene_id, 'panel_count', str(panel_count))
+
+
+def _seed_score_findings(project_dir, scene_id, findings):
+    """Write working/scores/latest/{id}.json with given findings."""
+    path = os.path.join(project_dir, 'working', 'scores', 'latest', f'{scene_id}.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump({
+            'scene_id': scene_id,
+            'scored_at': '2026-05-22T00:00:00Z',
+            'scores': {},
+            'overall_score': 0.6,
+            'findings': findings,
+        }, f)
+
+
+def _seed_eval_findings(project_dir, scene_id, findings):
+    """Write working/evaluations/latest/{id}.json with given findings."""
+    path = os.path.join(project_dir, 'working', 'evaluations', 'latest', f'{scene_id}.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump({
+            'scene_id': scene_id,
+            'evaluated_at': '2026-05-22T00:00:00Z',
+            'personas_run': ['panel-composition', 'dialogue'],
+            'findings': findings,
+        }, f)
+
+
+# ---------------------------------------------------------------------------
+# Core revision flow
+# ---------------------------------------------------------------------------
+
+def test_revise_one_scene_with_findings(project_dir_gn, monkeypatch):
+    """Revise a drafted scene that has findings → script updated, status='revised'."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'Page 1 panel 1 CAPTION: 33 words',
+         'severity': 'high'},
+        {'kind': 'composition_too_sparse', 'detail': 'Page 1 panel 1: 4 words',
+         'severity': 'medium'},
+    ])
+
+    from storyforge import api, cmd_revise_gn
+    fake = _make_fake_invoke(REVISED_SCRIPT)
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', fake)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+
+    scene_path = os.path.join(project_dir_gn, 'scenes', 'the-blank-page.md')
+    content = open(scene_path).read()
+    assert content == REVISED_SCRIPT, 'scene file should be overwritten with revised script'
+
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'revised'
+    assert get_field(scenes_csv, 'the-blank-page', 'page_count') == '2'
+    assert get_field(scenes_csv, 'the-blank-page', 'panel_count') == '5'
+
+
+def test_revise_loads_both_score_and_eval_findings(project_dir_gn, monkeypatch):
+    """The prompt receives both deterministic + persona findings."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': '33 words', 'severity': 'high'},
+    ])
+    _seed_eval_findings(project_dir_gn, 'the-blank-page', [
+        {'persona': 'panel-composition', 'severity': 'medium',
+         'message': 'composition too sparse on page 1', 'page': 1, 'panel': 1},
+    ])
+
+    captured = {}
+
+    def capture_and_respond(prompt, model, log_file, **kwargs):
+        captured['prompt'] = prompt
+        return _make_fake_invoke(REVISED_SCRIPT)(prompt, model, log_file, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', capture_and_respond)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', capture_and_respond)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+
+    prompt = captured['prompt']
+    assert 'Deterministic findings' in prompt
+    assert 'balloon_too_long' in prompt
+    assert 'panel-composition' in prompt
+    assert 'composition too sparse on page 1' in prompt
+    assert 'page 1, panel 1' in prompt
+
+
+# ---------------------------------------------------------------------------
+# Skip behavior
+# ---------------------------------------------------------------------------
+
+def test_revise_skips_scenes_with_no_findings_by_default(project_dir_gn, monkeypatch):
+    """Without findings, revise should refuse rather than polish blindly."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    # No findings seeded.
+
+    calls = []
+
+    def track(*args, **kwargs):
+        calls.append(args)
+        return _make_fake_invoke(REVISED_SCRIPT)(*args, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', track)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', track)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+    assert calls == [], 'should skip scenes with no findings unless --no-findings'
+
+    # Status should remain 'drafted'
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+
+
+def test_revise_no_findings_flag_polishes_blind(project_dir_gn, monkeypatch):
+    """--no-findings runs the revision with no findings input."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+
+    captured = {}
+
+    def capture_and_respond(prompt, model, log_file, **kwargs):
+        captured['prompt'] = prompt
+        return _make_fake_invoke(REVISED_SCRIPT)(prompt, model, log_file, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', capture_and_respond)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', capture_and_respond)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-findings', '--no-branch'])
+
+    assert 'prompt' in captured, 'API should be called with --no-findings'
+    # Without findings the prompt should not have the findings section header
+    assert 'Deterministic findings' not in captured['prompt']
+    assert 'No findings were provided' in captured['prompt']
+
+
+def test_revise_skips_briefed_scenes(project_dir_gn, monkeypatch):
+    """Scenes at 'briefed' status (no draft) are skipped — only revise drafted/revised."""
+    monkeypatch.chdir(project_dir_gn)
+    # All fixture scenes start at 'briefed' and have no scene file.
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'whatever', 'detail': 'x', 'severity': 'medium'},
+    ])
+
+    calls = []
+
+    def track(*args, **kwargs):
+        calls.append(args)
+        return _make_fake_invoke(REVISED_SCRIPT)(*args, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', track)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', track)
+
+    # No revisable scenes anywhere → should sys.exit(1)
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+    assert exc_info.value.code != 0
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Dry-run + GN guard
+# ---------------------------------------------------------------------------
+
+def test_revise_dry_run_does_not_call_api(project_dir_gn, monkeypatch):
+    """--dry-run prints the prompt without invoking the API."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    def fail_on_call(*args, **kwargs):
+        raise AssertionError('API should not be called in dry-run')
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', fail_on_call)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', fail_on_call)
+    cmd_revise_gn.main(['the-blank-page', '--dry-run', '--no-branch'])
+
+    # Status should remain 'drafted' (no revision applied)
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+
+
+def test_revise_rejects_novel_projects(project_dir, monkeypatch):
+    """cmd_revise_gn on a novel-mode project exits with an error."""
+    monkeypatch.chdir(project_dir)
+    from storyforge import cmd_revise_gn
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_revise_gn.main(['some-scene', '--no-branch'])
+    assert exc_info.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Re-parse + count updates
+# ---------------------------------------------------------------------------
+
+REVISED_WITH_EXTRA_PANEL = """\
+# Scene: the-blank-page
+
+**Target pages:** 2 | **Layout intent:** splash p1, 4-grid p2
+
+---
+
+## Page 1 — SPLASH
+
+**Panel 1** (full bleed)
+The cartographer at his desk. Blank parchment, lamp glow.
+
+- CARTOGRAPHER: It always begins this way.
+
+**Panel 2** (inset, lower-right)
+Inset close on the inkwell, untouched.
+
+---
+
+## Page 2 — 4-GRID ⟵ PAGE-TURN REVEAL
+
+**Panel 1** (top-left)
+Hand trembles above the page.
+
+**Panel 2** (top-right)
+The pen touches paper.
+
+**Panel 3** (bottom-left)
+A line appears.
+
+**Panel 4** (bottom-right)
+He stares.
+
+- CARTOGRAPHER: No.
+"""
+
+
+def test_revise_updates_panel_count_when_revision_changes_structure(
+    project_dir_gn, monkeypatch
+):
+    """If revision adds a panel, panel_count is re-counted from the new script."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')  # starts at panel_count=5
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'composition_too_sparse', 'detail': 'x', 'severity': 'medium'},
+    ])
+
+    from storyforge import api, cmd_revise_gn
+    fake = _make_fake_invoke(REVISED_WITH_EXTRA_PANEL)
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', fake)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    # New script has 6 panels total (2 on page 1, 4 on page 2)
+    assert get_field(scenes_csv, 'the-blank-page', 'panel_count') == '6'
+    assert get_field(scenes_csv, 'the-blank-page', 'page_count') == '2'
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+def test_revise_handles_missing_brief_row(project_dir_gn, monkeypatch):
+    """If a scene's brief row is missing, it's reported as an error and skipped."""
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    # Blank out the briefs CSV (header only)
+    briefs_csv = os.path.join(project_dir_gn, 'reference', 'scene-briefs.csv')
+    with open(briefs_csv, encoding='utf-8') as f:
+        header = f.readline()
+    with open(briefs_csv, 'w', encoding='utf-8') as f:
+        f.write(header)
+
+    monkeypatch.chdir(project_dir_gn)
+
+    calls = []
+
+    def track(*args, **kwargs):
+        calls.append(args)
+        return _make_fake_invoke(REVISED_SCRIPT)(*args, **kwargs)
+
+    from storyforge import api, cmd_revise_gn
+    monkeypatch.setattr(api, 'invoke_to_file', track)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', track)
+
+    cmd_revise_gn.main(['the-blank-page', '--no-branch'])
+    assert calls == [], 'should not invoke API when brief is missing'
+
+    # Status should remain 'drafted' (revision was rejected)
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'drafted'
+
+
+def test_revise_via_dispatcher_routes_to_gn(project_dir_gn, monkeypatch):
+    """Regression: storyforge revise on a GN project routes to cmd_revise_gn,
+    not novel-mode cmd_revise (which would crash on GN data)."""
+    monkeypatch.chdir(project_dir_gn)
+    _seed_draft(project_dir_gn, 'the-blank-page')
+    _seed_score_findings(project_dir_gn, 'the-blank-page', [
+        {'kind': 'balloon_too_long', 'detail': 'x', 'severity': 'high'},
+    ])
+
+    from storyforge import api, cmd_revise_gn
+    fake = _make_fake_invoke(REVISED_SCRIPT)
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(cmd_revise_gn, 'invoke_to_file', fake)
+
+    # Simulate `storyforge revise the-blank-page --no-branch`
+    monkeypatch.setattr('sys.argv',
+                        ['storyforge', 'revise', 'the-blank-page', '--no-branch'])
+    from storyforge.__main__ import main as dispatch_main
+    dispatch_main()
+
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'status') == 'revised'

--- a/tests/test_medium.py
+++ b/tests/test_medium.py
@@ -350,7 +350,6 @@ def test_briefs_handler_gn_returns_none_when_no_work(project_dir_gn):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize('cmd', [
-    'revise',
     'publish', 'annotations', 'extract', 'repetition', 'enrich',
 ])
 def test_dispatcher_blocks_unsupported_commands_in_gn_mode(
@@ -571,6 +570,49 @@ def test_dispatcher_routes_evaluate_to_novel_in_novel_mode(project_dir, monkeypa
         pass
     assert called['novel'], 'novel-mode evaluate should route to cmd_evaluate'
     assert not called['gn'], 'novel-mode evaluate should NOT call cmd_evaluate_gn'
+
+
+def test_dispatcher_routes_revise_to_gn_in_gn_mode(project_dir_gn, monkeypatch):
+    """In GN mode, `./storyforge revise` invokes cmd_revise_gn."""
+    monkeypatch.chdir(project_dir_gn)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'revise', '--dry-run'])
+    called = []
+    from storyforge import cmd_revise_gn
+    def track(*args, **kwargs):
+        called.append(True)
+        raise SystemExit(0)
+    monkeypatch.setattr(cmd_revise_gn, 'main', track)
+
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called, 'cmd_revise_gn.main should be called for revise in GN mode'
+
+
+def test_dispatcher_routes_revise_to_novel_in_novel_mode(project_dir, monkeypatch):
+    """In novel mode, `./storyforge revise` invokes cmd_revise (not cmd_revise_gn)."""
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr('sys.argv', ['storyforge', 'revise', '--help'])
+
+    called = {'novel': False, 'gn': False}
+    from storyforge import cmd_revise, cmd_revise_gn
+    def novel_track(*args, **kwargs):
+        called['novel'] = True
+        raise SystemExit(0)
+    def gn_track(*args, **kwargs):
+        called['gn'] = True
+    monkeypatch.setattr(cmd_revise, 'main', novel_track)
+    monkeypatch.setattr(cmd_revise_gn, 'main', gn_track)
+
+    from storyforge.__main__ import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert called['novel'], 'novel-mode revise should route to cmd_revise'
+    assert not called['gn'], 'novel-mode revise should NOT call cmd_revise_gn'
 
 
 def test_dispatcher_routes_score_to_novel_in_novel_mode(project_dir, monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `cmd_revise_gn.py`: findings-driven polish pass for graphic-novel scenes. One API call per scene, folds deterministic scorer findings (from `working/scores/latest/*.json`) and persona evaluator findings (from `working/evaluations/latest/*.json`) into the revision prompt.
- Adds `build_revision_prompt()` to `prompts_gn.py`. Groups findings by source/kind, lists severities, and gives the model the brief, voice profile, visual references, and the current draft.
- Dispatcher routes `storyforge revise` to `cmd_revise_gn` when `project.medium == graphic-novel` (parallels the existing `score`/`evaluate`/`write` routing). Drops `revise` from `GN_UNSUPPORTED_COMMANDS`.
- 10 new tests in `tests/test_cmd_revise_gn.py` covering: findings-driven flow, score+eval findings merged into prompt, default skip when no findings, `--no-findings` blind polish, `--dry-run`, novel-project guard, panel/page recount on structure change, missing brief handling, and end-to-end dispatcher routing.
- Updates `tests/test_medium.py`: removes `revise` from unsupported-command parametrize, adds positive routing tests for revise.

## Design
The issue asked for a choice between mirroring novel-mode's multi-pass architecture (`--polish`/`--loop`/`--naturalness`/`--scores`/`--structural`, ~2500 lines) or a single findings-driven polish pass. Went with the single-pass design — it matches the spec's incremental approach, keeps the implementation under 400 lines, and defers the multi-pass complexity until we see what real GN revisions actually need.

Scope mirrors what issue #221 listed (visual continuity, dialogue tightening, layout adjustments, brief-fidelity restoration), but rather than separate passes per kind, the findings themselves drive what gets fixed.

Status transitions: `drafted` → `revised`. Subsequent runs against the same scene re-revise (status stays `revised`).

## Test plan
- [x] `python3 -m pytest tests/test_cmd_revise_gn.py -v` (10 passed)
- [x] `python3 -m pytest tests/test_medium.py -v` (all routing tests passing including new revise routing)
- [x] Full suite: `python3 -m pytest tests/ --no-cov -q` (3606 passed, 10 skipped)
- [ ] Manual run on a real GN project (requires drafted scenes with findings — author task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)