### PR TITLE
Add storyforge sync: CSV ↔ scenes-review.md round-trip with pre-commit hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "author": {
     "name": "Ben Norris"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,8 +260,9 @@ Run: `./tests/run-tests.sh` or `python3 -m pytest tests/` or `pytest tests/test_
 | `storyforge cleanup` | `cmd_cleanup.py` | Project structure cleanup. `--scenes` strips writing-agent artifacts from scene files. `--csv` runs only the CSV integrity report (schema + row checks). |
 | `storyforge cover` | `cmd_cover.py` | Cover design |
 | `storyforge scenes-setup` | `cmd_scenes_setup.py` | Scene file and metadata setup |
-| `storyforge scenes-export` | `cmd_scenes_export.py` | Export scenes to markdown with metadata headers |
-| `storyforge scenes-import` | `cmd_scenes_import.py` | Import scenes from markdown with metadata headers |
+| `storyforge scenes-export` | `cmd_scenes_export.py` | Export scenes to `reference/scenes-review.md` (header-driven; round-trips every column present in the CSVs, including GN additions) |
+| `storyforge scenes-import` | `cmd_scenes_import.py` | Import edited `scenes-review.md` back into scene CSVs |
+| `storyforge sync` | `cmd_sync.py` | Sync scene CSVs ↔ `reference/scenes-review.md` against git HEAD. Exports when CSVs are dirty, imports when MD is dirty, writes `working/sync-conflict.md` and exits 1 when both moved. `--install-hook` drops a pre-commit hook that runs this on every commit. |
 | `storyforge review` | `cmd_review.py` | Pipeline review |
 | `storyforge migrate` | `cmd_migrate.py` | Project migration |
 

--- a/scripts/lib/python/storyforge/__main__.py
+++ b/scripts/lib/python/storyforge/__main__.py
@@ -47,6 +47,7 @@ COMMANDS = {
     'scenes-setup': 'storyforge.cmd_scenes_setup',
     'scenes-export': 'storyforge.cmd_scenes_export',
     'scenes-import': 'storyforge.cmd_scenes_import',
+    'sync': 'storyforge.cmd_sync',
     'publish': 'storyforge.cmd_publish',
 }
 

--- a/scripts/lib/python/storyforge/cmd_scenes_export.py
+++ b/scripts/lib/python/storyforge/cmd_scenes_export.py
@@ -3,6 +3,10 @@
 Merges scenes.csv, scene-intent.csv, and scene-briefs.csv into a single
 markdown file with one ## heading per scene, ordered by sequence number.
 
+The field set per section is read from each CSV's header row at runtime, so
+the export round-trips whatever columns are present — including the
+graphic-novel additions (target_pages, panel_breakdown, etc.).
+
 Usage:
     storyforge scenes-export                      # Export all scenes
     storyforge scenes-export --act 2              # Export only Act 2
@@ -21,31 +25,48 @@ from storyforge.scene_filter import apply_scene_filter, build_scene_list
 
 
 # ============================================================================
-# Column definitions
+# Section definitions
 # ============================================================================
 
-STRUCTURAL_FIELDS = [
-    'seq', 'title', 'part', 'pov', 'location', 'timeline_day',
-    'time_of_day', 'duration', 'type', 'status', 'word_count', 'target_words',
+# Sections that participate in the round-trip. Field lists are read from the
+# CSV's own header row by get_sections() — *do not* hardcode them here.
+SECTION_SPECS = [
+    ('Structural', 'reference/scenes.csv'),
+    ('Intent', 'reference/scene-intent.csv'),
+    ('Brief', 'reference/scene-briefs.csv'),
 ]
 
-INTENT_FIELDS = [
-    'function', 'action_sequel', 'emotional_arc', 'value_at_stake',
-    'value_shift', 'turning_point', 'characters', 'on_stage', 'mice_threads',
-]
+DEFAULT_OUTPUT_PATH = os.path.join('reference', 'scenes-review.md')
 
-BRIEF_FIELDS = [
-    'goal', 'conflict', 'outcome', 'crisis', 'decision', 'knowledge_in',
-    'knowledge_out', 'key_actions', 'key_dialogue', 'emotions', 'motifs',
-    'subtext', 'continuity_deps', 'has_overflow', 'physical_state_in',
-    'physical_state_out',
-]
 
-SECTIONS = [
-    ('Structural', 'reference/scenes.csv', STRUCTURAL_FIELDS),
-    ('Intent', 'reference/scene-intent.csv', INTENT_FIELDS),
-    ('Brief', 'reference/scene-briefs.csv', BRIEF_FIELDS),
-]
+def _read_csv_headers(csv_path):
+    """Return the column names from a pipe-delimited CSV's header row.
+
+    Returns [] if the file is missing or empty.
+    """
+    if not os.path.isfile(csv_path):
+        return []
+    with open(csv_path, encoding='utf-8') as f:
+        first = f.readline().rstrip('\r\n')
+    if not first:
+        return []
+    return [h.strip() for h in first.split('|')]
+
+
+def get_sections(project_dir):
+    """Return [(section_name, csv_rel, fields)] for the round-trip sections.
+
+    `fields` is read from each CSV's header row (excluding the 'id' key),
+    so any columns present in the CSV — including medium-specific additions —
+    are round-tripped through export/import.
+    """
+    out = []
+    for name, csv_rel in SECTION_SPECS:
+        csv_path = os.path.join(project_dir, csv_rel)
+        headers = _read_csv_headers(csv_path)
+        fields = [h for h in headers if h and h != 'id']
+        out.append((name, csv_rel, fields))
+    return out
 
 
 # ============================================================================
@@ -54,11 +75,13 @@ SECTIONS = [
 
 def export_scenes(project_dir, output_path, filter_mode='all',
                   filter_value=None, filter_value2=None):
-    """Export scene data from three CSVs to a single markdown file."""
+    """Export scene data from the three CSVs to a single markdown file."""
     meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
     all_ids = build_scene_list(meta_csv)
     scene_ids = apply_scene_filter(meta_csv, all_ids, filter_mode,
                                    filter_value, filter_value2)
+
+    sections = get_sections(project_dir)
 
     lines = []
     for i, sid in enumerate(scene_ids):
@@ -66,7 +89,7 @@ def export_scenes(project_dir, output_path, filter_mode='all',
             lines.append('')
         lines.append(f'## {sid}')
 
-        for section_name, csv_rel, fields in SECTIONS:
+        for section_name, csv_rel, fields in sections:
             csv_path = os.path.join(project_dir, csv_rel)
             lines.append('')
             lines.append(f'### {section_name}')
@@ -94,7 +117,7 @@ def parse_args(argv):
     )
     add_scene_filter_args(parser)
     parser.add_argument('--output', '-o', type=str, default=None,
-                        help='Output path (default: working/scenes-review.md)')
+                        help='Output path (default: reference/scenes-review.md)')
     return parser.parse_args(argv)
 
 
@@ -107,6 +130,6 @@ def main(argv=None):
     install_signal_handlers()
     project_dir = detect_project_root()
 
-    output = args.output or os.path.join(project_dir, 'working', 'scenes-review.md')
+    output = args.output or os.path.join(project_dir, DEFAULT_OUTPUT_PATH)
     mode, value, value2 = resolve_filter_args(args)
     export_scenes(project_dir, output, mode, value, value2)

--- a/scripts/lib/python/storyforge/cmd_scenes_export.py
+++ b/scripts/lib/python/storyforge/cmd_scenes_export.py
@@ -20,7 +20,7 @@ import os
 
 from storyforge.cli import add_scene_filter_args, resolve_filter_args
 from storyforge.common import detect_project_root, install_signal_handlers, log
-from storyforge.csv_cli import get_field
+from storyforge.csv_cli import get_field, list_ids
 from storyforge.scene_filter import apply_scene_filter, build_scene_list
 
 
@@ -75,13 +75,27 @@ def get_sections(project_dir):
 
 def export_scenes(project_dir, output_path, filter_mode='all',
                   filter_value=None, filter_value2=None):
-    """Export scene data from the three CSVs to a single markdown file."""
+    """Export scene data from the three CSVs to a single markdown file.
+
+    Sections whose CSV has no row for a given scene are omitted entirely
+    rather than rendered as a header followed by all-empty field lines.
+    At early elaboration stages most scenes only have a Structural row,
+    and dragging the reader through 25 blank lines per scene to find the
+    one populated section makes the review file unreadable.
+    """
     meta_csv = os.path.join(project_dir, 'reference', 'scenes.csv')
     all_ids = build_scene_list(meta_csv)
     scene_ids = apply_scene_filter(meta_csv, all_ids, filter_mode,
                                    filter_value, filter_value2)
 
     sections = get_sections(project_dir)
+
+    # Pre-compute which scene_ids exist in each section's CSV so we can skip
+    # rendering empty sections per scene. list_ids reads the file once each.
+    section_ids = {
+        csv_rel: set(list_ids(os.path.join(project_dir, csv_rel)))
+        for _, csv_rel, _ in sections
+    }
 
     lines = []
     for i, sid in enumerate(scene_ids):
@@ -90,6 +104,8 @@ def export_scenes(project_dir, output_path, filter_mode='all',
         lines.append(f'## {sid}')
 
         for section_name, csv_rel, fields in sections:
+            if sid not in section_ids[csv_rel]:
+                continue  # no row in this CSV — skip section entirely
             csv_path = os.path.join(project_dir, csv_rel)
             lines.append('')
             lines.append(f'### {section_name}')

--- a/scripts/lib/python/storyforge/cmd_scenes_import.py
+++ b/scripts/lib/python/storyforge/cmd_scenes_import.py
@@ -29,10 +29,16 @@ def parse_markdown(text, section_map=None):
 
     `section_map` is {section_name: (csv_rel, set(known_field_names))} — if
     provided, only those section names are recognized and only the listed
-    fields are treated as fields (other `field: value`-looking lines are
-    treated as continuations). When None, every `### Name` opens a section
-    and every `field: value` line is a field — useful as a generic parser
-    or in tests where the CSVs aren't on hand.
+    fields are treated as fields. When None, every `### Name` opens a section
+    and every `field: value` line is a field — useful as a generic parser or
+    in tests where the CSVs aren't on hand.
+
+    A line that looks like `field: value` but whose `field` isn't in the
+    section's known set is logged as a WARNING and skipped (it does NOT get
+    merged into the previous field's value — that would silently corrupt
+    CSV cells when an author types review notes into the MD). True multi-
+    line field values still work as long as the continuation line does not
+    start with `[a-z_]+:`.
 
     Returns: {scene_id: {section_name: {field: value}}}
     """
@@ -67,12 +73,19 @@ def parse_markdown(text, section_map=None):
         if current_scene and current_section:
             # Try to match "field_name: value"
             match = re.match(r'^([a-z_]+):\s?(.*)', line)
-            if match and (section_map is None
-                          or match.group(1) in section_map[current_section][1]):
+            if match:
                 field_name = match.group(1)
-                value = match.group(2)
-                scenes[current_scene][current_section][field_name] = value
-                last_field = field_name
+                if section_map is None or field_name in section_map[current_section][1]:
+                    value = match.group(2)
+                    scenes[current_scene][current_section][field_name] = value
+                    last_field = field_name
+                else:
+                    # field: value-shaped line, but the field isn't known.
+                    # Don't merge into last_field — that silently rewrites
+                    # whatever the previous real field was. Warn + skip.
+                    log(f'WARNING: {current_scene} / {current_section}: '
+                        f'unknown field "{field_name}" — line skipped')
+                    last_field = None
             elif last_field is not None:
                 # Continuation line — append to previous field
                 prev = scenes[current_scene][current_section][last_field]
@@ -89,7 +102,13 @@ def parse_markdown(text, section_map=None):
 def import_scenes(project_dir, input_path, dry_run=False):
     """Import edited markdown back into CSVs. Returns list of changes.
 
-    Each change is a tuple: (scene_id, csv_rel, field, old_value, new_value)
+    Each change is a tuple: (scene_id, csv_rel, field, old_value, new_value).
+
+    Raises RuntimeError when the markdown references a scene_id that does
+    not exist in any of the three CSVs — silently skipping such IDs would
+    let an author "rename" a scene by editing its `## heading` while leaving
+    the canonical CSV row unchanged (a phantom rename). The user must edit
+    CSVs directly to rename.
     """
     with open(input_path, encoding='utf-8') as f:
         text = f.read()
@@ -102,21 +121,36 @@ def import_scenes(project_dir, input_path, dry_run=False):
     }
 
     parsed = parse_markdown(text, section_map)
-    changes = []
 
-    # Build lookup of valid scene IDs per CSV
+    # Build lookup of valid scene IDs per CSV. Also build the union for the
+    # rename-detection check below.
     csv_ids = {}
+    all_known_ids = set()
     for section_name, (csv_rel, _fields) in section_map.items():
         csv_path = os.path.join(project_dir, csv_rel)
-        csv_ids[csv_rel] = set(list_ids(csv_path))
+        ids = set(list_ids(csv_path))
+        csv_ids[csv_rel] = ids
+        all_known_ids |= ids
 
+    unknown_ids = sorted(sid for sid in parsed if sid not in all_known_ids)
+    if unknown_ids:
+        raise RuntimeError(
+            f'Markdown references scene ID(s) not present in any CSV: '
+            f'{", ".join(unknown_ids)}. '
+            'To rename a scene, edit the CSV rows directly — renaming in '
+            'the MD alone would leave the canonical data untouched.'
+        )
+
+    changes = []
     for scene_id, sections in parsed.items():
         for section_name, fields in sections.items():
             csv_rel, _known = section_map[section_name]
             csv_path = os.path.join(project_dir, csv_rel)
 
+            # A scene may legitimately be missing from one CSV (e.g. no
+            # intent row yet) but present in another. Skip silently in that
+            # case — there's nothing to update on that side.
             if scene_id not in csv_ids.get(csv_rel, set()):
-                log(f'WARNING: Scene {scene_id} not found in {csv_rel}, skipping')
                 continue
 
             for field_name, new_value in fields.items():
@@ -161,7 +195,11 @@ def main(argv=None):
         log("Run 'storyforge scenes-export' first.")
         raise SystemExit(1)
 
-    changes = import_scenes(project_dir, input_path, dry_run=args.dry_run)
+    try:
+        changes = import_scenes(project_dir, input_path, dry_run=args.dry_run)
+    except RuntimeError as e:
+        log(f'ERROR: {e}')
+        raise SystemExit(1)
 
     if not changes:
         log('No changes detected.')

--- a/scripts/lib/python/storyforge/cmd_scenes_import.py
+++ b/scripts/lib/python/storyforge/cmd_scenes_import.py
@@ -1,7 +1,9 @@
 """storyforge scenes-import — Import edited markdown back into scene CSVs.
 
 Parses a markdown file produced by scenes-export, diffs against the current
-CSV values, and updates only fields that changed.
+CSV values, and updates only fields that changed. The field set per section
+is read from each CSV's header row at runtime, so any columns present in the
+CSVs (including graphic-novel additions) are imported.
 
 Usage:
     storyforge scenes-import                      # Import from default path
@@ -13,20 +15,24 @@ import argparse
 import os
 import re
 
-from storyforge.cmd_scenes_export import SECTIONS
+from storyforge.cmd_scenes_export import DEFAULT_OUTPUT_PATH, get_sections
 from storyforge.common import detect_project_root, install_signal_handlers, log
 from storyforge.csv_cli import get_field, list_ids, update_field
-
-# Section name -> (csv relative path, known field names)
-SECTION_MAP = {name: (csv_rel, set(fields)) for name, csv_rel, fields in SECTIONS}
 
 
 # ============================================================================
 # Markdown parser
 # ============================================================================
 
-def parse_markdown(text):
+def parse_markdown(text, section_map=None):
     """Parse scenes-review markdown into a nested dict.
+
+    `section_map` is {section_name: (csv_rel, set(known_field_names))} — if
+    provided, only those section names are recognized and only the listed
+    fields are treated as fields (other `field: value`-looking lines are
+    treated as continuations). When None, every `### Name` opens a section
+    and every `field: value` line is a field — useful as a generic parser
+    or in tests where the CSVs aren't on hand.
 
     Returns: {scene_id: {section_name: {field: value}}}
     """
@@ -47,7 +53,7 @@ def parse_markdown(text):
         # Section heading
         if line.startswith('### '):
             section_name = line[4:].strip()
-            if current_scene and section_name in SECTION_MAP:
+            if current_scene and (section_map is None or section_name in section_map):
                 current_section = section_name
                 scenes[current_scene][current_section] = {}
                 last_field = None
@@ -59,10 +65,10 @@ def parse_markdown(text):
 
         # Field line or continuation
         if current_scene and current_section:
-            known_fields = SECTION_MAP[current_section][1]
             # Try to match "field_name: value"
             match = re.match(r'^([a-z_]+):\s?(.*)', line)
-            if match and match.group(1) in known_fields:
+            if match and (section_map is None
+                          or match.group(1) in section_map[current_section][1]):
                 field_name = match.group(1)
                 value = match.group(2)
                 scenes[current_scene][current_section][field_name] = value
@@ -88,18 +94,25 @@ def import_scenes(project_dir, input_path, dry_run=False):
     with open(input_path, encoding='utf-8') as f:
         text = f.read()
 
-    parsed = parse_markdown(text)
+    # Build section_map from the project's actual CSV headers so columns added
+    # by graphic-novel mode (or future schema changes) are recognized.
+    section_map = {
+        name: (csv_rel, set(fields))
+        for name, csv_rel, fields in get_sections(project_dir)
+    }
+
+    parsed = parse_markdown(text, section_map)
     changes = []
 
     # Build lookup of valid scene IDs per CSV
     csv_ids = {}
-    for section_name, (csv_rel, _fields) in SECTION_MAP.items():
+    for section_name, (csv_rel, _fields) in section_map.items():
         csv_path = os.path.join(project_dir, csv_rel)
         csv_ids[csv_rel] = set(list_ids(csv_path))
 
     for scene_id, sections in parsed.items():
         for section_name, fields in sections.items():
-            csv_rel, _known = SECTION_MAP[section_name]
+            csv_rel, _known = section_map[section_name]
             csv_path = os.path.join(project_dir, csv_rel)
 
             if scene_id not in csv_ids.get(csv_rel, set()):
@@ -127,7 +140,7 @@ def parse_args(argv):
         description='Import edited markdown back into scene CSVs.',
     )
     parser.add_argument('--input', type=str, default=None,
-                        help='Input path (default: working/scenes-review.md)')
+                        help='Input path (default: reference/scenes-review.md)')
     parser.add_argument('--dry-run', action='store_true',
                         help='Show changes without writing')
     return parser.parse_args(argv)
@@ -142,8 +155,7 @@ def main(argv=None):
     install_signal_handlers()
     project_dir = detect_project_root()
 
-    input_path = args.input or os.path.join(project_dir, 'working',
-                                            'scenes-review.md')
+    input_path = args.input or os.path.join(project_dir, DEFAULT_OUTPUT_PATH)
     if not os.path.isfile(input_path):
         log(f'ERROR: Input file not found: {input_path}')
         log("Run 'storyforge scenes-export' first.")

--- a/scripts/lib/python/storyforge/cmd_sync.py
+++ b/scripts/lib/python/storyforge/cmd_sync.py
@@ -1,0 +1,313 @@
+"""storyforge sync — Keep scene CSVs and scenes-review.md in sync.
+
+The three scene CSVs (scenes.csv, scene-intent.csv, scene-briefs.csv) are
+the source of truth, but they're pipe-delimited and unreadable in a PR diff.
+`reference/scenes-review.md` is a regenerated mirror that makes review easy.
+
+This command compares the working tree to `git HEAD` and routes:
+
+  - both clean              → no-op (regenerate MD if missing entirely)
+  - CSVs dirty, MD clean    → export CSVs → MD
+  - MD dirty, CSVs clean    → import MD → CSVs
+  - both dirty              → conflict: write working/sync-conflict.md and
+                              exit non-zero so a pre-commit hook can refuse
+
+Also installs a pre-commit hook that runs this automatically:
+
+    storyforge sync --install-hook
+"""
+
+import argparse
+import difflib
+import os
+import subprocess
+import sys
+
+from storyforge.common import detect_project_root, install_signal_handlers, log
+from storyforge.cmd_scenes_export import (
+    DEFAULT_OUTPUT_PATH, SECTION_SPECS, export_scenes,
+)
+from storyforge.cmd_scenes_import import import_scenes
+
+
+CSV_RELS = [csv_rel for _, csv_rel in SECTION_SPECS]
+CONFLICT_REPORT_PATH = os.path.join('working', 'sync-conflict.md')
+
+
+# ============================================================================
+# Git state helpers
+# ============================================================================
+
+def _git(project_dir, *args, check=False):
+    return subprocess.run(
+        ['git', *args], cwd=project_dir,
+        capture_output=True, text=True, check=check,
+    )
+
+
+def _is_dirty(project_dir, path_rel):
+    """Return True if `path_rel` differs from HEAD (or is untracked).
+
+    Compares the working-tree state of one file to its committed version.
+    Untracked files and files absent from HEAD count as dirty.
+    """
+    abs_path = os.path.join(project_dir, path_rel)
+    # Untracked / new file → dirty if it exists on disk.
+    show = _git(project_dir, 'cat-file', '-e', f'HEAD:{path_rel}')
+    if show.returncode != 0:
+        return os.path.isfile(abs_path)
+    diff = _git(project_dir, 'diff', '--quiet', 'HEAD', '--', path_rel)
+    # `git diff --quiet` exits 1 when there's a diff, 0 when there isn't.
+    return diff.returncode != 0
+
+
+def _file_in_head(project_dir, path_rel):
+    """True if the path exists in HEAD (i.e. is tracked + committed)."""
+    return _git(project_dir, 'cat-file', '-e', f'HEAD:{path_rel}').returncode == 0
+
+
+def _head_content(project_dir, path_rel):
+    """Return the content of `path_rel` at HEAD, or '' if not in HEAD."""
+    r = _git(project_dir, 'show', f'HEAD:{path_rel}')
+    return r.stdout if r.returncode == 0 else ''
+
+
+# ============================================================================
+# Sync state machine
+# ============================================================================
+
+def detect_state(project_dir, md_rel=DEFAULT_OUTPUT_PATH):
+    """Return a dict describing what's dirty.
+
+    Keys:
+      - csv_dirty: bool — any of the three CSVs differs from HEAD
+      - md_dirty: bool  — the MD differs from HEAD (or is untracked)
+      - md_exists: bool — the MD exists on disk
+      - md_in_head: bool — the MD has ever been committed
+      - dirty_csvs: list[str] — relative paths of changed CSVs
+    """
+    dirty_csvs = [p for p in CSV_RELS if _is_dirty(project_dir, p)]
+    md_exists = os.path.isfile(os.path.join(project_dir, md_rel))
+    md_in_head = _file_in_head(project_dir, md_rel)
+    md_dirty = _is_dirty(project_dir, md_rel)
+    return {
+        'csv_dirty': bool(dirty_csvs),
+        'md_dirty': md_dirty,
+        'md_exists': md_exists,
+        'md_in_head': md_in_head,
+        'dirty_csvs': dirty_csvs,
+    }
+
+
+def _write_conflict_report(project_dir, state, md_rel):
+    """Write a structured description of the conflict and return its path."""
+    report_path = os.path.join(project_dir, CONFLICT_REPORT_PATH)
+    os.makedirs(os.path.dirname(report_path), exist_ok=True)
+
+    # Render what export would produce now (CSV-side view) for comparison.
+    tmp_md = report_path + '.csv-side.md'
+    try:
+        export_scenes(project_dir, tmp_md)
+        csv_side = open(tmp_md, encoding='utf-8').read()
+    except Exception as e:
+        csv_side = f'(could not render CSV-side preview: {e})'
+    finally:
+        if os.path.isfile(tmp_md):
+            os.remove(tmp_md)
+
+    md_path = os.path.join(project_dir, md_rel)
+    md_side = open(md_path, encoding='utf-8').read() if os.path.isfile(md_path) else ''
+
+    diff = ''.join(difflib.unified_diff(
+        md_side.splitlines(keepends=True),
+        csv_side.splitlines(keepends=True),
+        fromfile=f'{md_rel} (working tree)',
+        tofile=f'{md_rel} (would-be export from CSVs)',
+        n=3,
+    ))
+
+    body = [
+        '# Storyforge sync conflict',
+        '',
+        f'Both the scene CSVs and `{md_rel}` have uncommitted changes:',
+        '',
+        '## Changed CSVs',
+    ]
+    for csv_rel in state['dirty_csvs']:
+        body.append(f'- {csv_rel}')
+    body.extend([
+        '',
+        '## How to resolve',
+        '',
+        '1. Inspect the diff below to see how the two sides disagree.',
+        '2. Reconcile by hand: either revert one side, or edit both to match.',
+        '3. Re-run `storyforge sync` to confirm.',
+        '',
+        'For trickier merges, ask Claude in a session to walk through the',
+        'conflict and apply the right call per the brief and story intent.',
+        '',
+        '## Diff (working MD → would-be export from CSVs)',
+        '',
+        '```diff',
+        diff if diff else '(diffs are byte-equal but git sees both as dirty — '
+                          'often whitespace or line-ending drift)',
+        '```',
+        '',
+    ])
+    with open(report_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(body))
+    return report_path
+
+
+def run_sync(project_dir, md_rel=DEFAULT_OUTPUT_PATH, check_only=False):
+    """Sync CSVs and the review MD against git HEAD. Returns one of:
+
+      - 'noop'         — both sides clean and MD is present
+      - 'exported'     — CSV changes flowed to MD
+      - 'imported'     — MD changes flowed to CSVs
+      - 'conflict'     — both sides changed; conflict report written
+      - 'first-export' — MD never committed; treated as CSV → MD seed
+
+    `check_only=True` returns the same status without writing anything.
+    """
+    state = detect_state(project_dir, md_rel)
+    md_path = os.path.join(project_dir, md_rel)
+
+    # No prior committed MD: treat CSVs as canonical and seed the MD.
+    if not state['md_in_head']:
+        if check_only:
+            return 'first-export'
+        export_scenes(project_dir, md_path)
+        return 'first-export'
+
+    if state['csv_dirty'] and state['md_dirty']:
+        if check_only:
+            return 'conflict'
+        report_path = _write_conflict_report(project_dir, state, md_rel)
+        log(f'CONFLICT: both CSVs and {md_rel} have changes vs HEAD.')
+        log(f'  See {report_path} for the diff.')
+        return 'conflict'
+
+    if state['csv_dirty']:
+        if check_only:
+            return 'exported'
+        export_scenes(project_dir, md_path)
+        log(f'Exported CSV changes → {md_rel}')
+        return 'exported'
+
+    if state['md_dirty']:
+        if check_only:
+            return 'imported'
+        changes = import_scenes(project_dir, md_path, dry_run=False)
+        log(f'Imported {len(changes)} field change(s) from {md_rel} → CSVs')
+        return 'imported'
+
+    # Both clean. If the MD doesn't exist on disk somehow (e.g. wiped), regen.
+    if not state['md_exists']:
+        if check_only:
+            return 'exported'
+        export_scenes(project_dir, md_path)
+        log(f'Regenerated missing {md_rel}')
+        return 'exported'
+
+    return 'noop'
+
+
+# ============================================================================
+# Pre-commit hook installation
+# ============================================================================
+
+HOOK_FILENAME = 'pre-commit'
+
+HOOK_SCRIPT = '''#!/usr/bin/env bash
+# Installed by `storyforge sync --install-hook`. Keeps scene CSVs and
+# reference/scenes-review.md in sync before each commit.
+set -e
+
+# Only run if any tracked scene file has staged changes.
+if ! git diff --cached --name-only \\
+        | grep -E '^reference/(scenes|scene-intent|scene-briefs)\\.csv$|^reference/scenes-review\\.md$' \\
+        >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Find the storyforge runner. Prefer the one on PATH; fall back to the
+# user's plugin checkout.
+if command -v storyforge >/dev/null 2>&1; then
+    SF=storyforge
+elif [ -x "$HOME/Developer/storyforge/storyforge" ]; then
+    SF="$HOME/Developer/storyforge/storyforge"
+else
+    echo "pre-commit: 'storyforge' not on PATH; skipping sync" >&2
+    exit 0
+fi
+
+if ! "$SF" sync; then
+    echo "" >&2
+    echo "storyforge sync refused the commit." >&2
+    echo "See working/sync-conflict.md and resolve, then 'git add' and retry." >&2
+    exit 1
+fi
+
+# Restage anything sync produced (e.g. regenerated scenes-review.md or
+# updated CSV cells from an MD-side edit).
+git add reference/scenes.csv reference/scene-intent.csv \\
+        reference/scene-briefs.csv reference/scenes-review.md 2>/dev/null || true
+'''
+
+
+def install_hook(project_dir):
+    """Write the pre-commit hook into the project's .git/hooks/. Returns path."""
+    hooks_dir = os.path.join(project_dir, '.git', 'hooks')
+    if not os.path.isdir(hooks_dir):
+        log(f'ERROR: {hooks_dir} not found — is this a git repository?')
+        sys.exit(1)
+    hook_path = os.path.join(hooks_dir, HOOK_FILENAME)
+    if os.path.isfile(hook_path):
+        with open(hook_path, encoding='utf-8') as f:
+            existing = f.read()
+        if 'storyforge sync' not in existing:
+            log(f'WARNING: {hook_path} already exists and is not a storyforge hook. '
+                'Refusing to overwrite — back it up or merge by hand.')
+            sys.exit(1)
+    with open(hook_path, 'w', encoding='utf-8') as f:
+        f.write(HOOK_SCRIPT)
+    os.chmod(hook_path, 0o755)
+    log(f'Installed pre-commit hook at {hook_path}')
+    return hook_path
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='storyforge sync',
+        description='Keep scene CSVs and reference/scenes-review.md in sync.',
+    )
+    parser.add_argument('--check', action='store_true',
+                        help='Report the sync status without writing anything')
+    parser.add_argument('--install-hook', action='store_true',
+                        help='Install a git pre-commit hook that runs sync')
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    install_signal_handlers()
+    project_dir = detect_project_root()
+
+    if args.install_hook:
+        install_hook(project_dir)
+        return
+
+    status = run_sync(project_dir, check_only=args.check)
+    if args.check:
+        log(f'Sync status: {status}')
+    if status == 'conflict':
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/lib/python/storyforge/cmd_sync.py
+++ b/scripts/lib/python/storyforge/cmd_sync.py
@@ -6,15 +6,17 @@ the source of truth, but they're pipe-delimited and unreadable in a PR diff.
 
 This command compares the working tree to `git HEAD` and routes:
 
-  - both clean              → no-op (regenerate MD if missing entirely)
-  - CSVs dirty, MD clean    → export CSVs → MD
-  - MD dirty, CSVs clean    → import MD → CSVs
-  - both dirty              → conflict: write working/sync-conflict.md and
-                              exit non-zero so a pre-commit hook can refuse
+  - both clean              → 'noop' (regenerate MD if missing on disk only)
+  - CSVs dirty, MD clean    → 'exported' (CSVs → MD)
+  - MD dirty, CSVs clean    → 'imported' (MD → CSVs)
+  - both dirty              → 'conflict' — write working/sync-conflict.md
+                              and exit non-zero
+  - MD not in HEAD, absent  → 'first-export' (seed from CSVs)
+  - MD not in HEAD, present → 'untracked-md' — refuse rather than clobber
+  - CSV deleted on disk     → 'missing-csv' — refuse and instruct to restore
 
-Also installs a pre-commit hook that runs this automatically:
-
-    storyforge sync --install-hook
+`storyforge sync --install-hook` drops a pre-commit hook that runs sync,
+restages the result, and refuses commits with unresolved conflicts.
 """
 
 import argparse
@@ -22,6 +24,7 @@ import difflib
 import os
 import subprocess
 import sys
+import tempfile
 
 from storyforge.common import detect_project_root, install_signal_handlers, log
 from storyforge.cmd_scenes_export import (
@@ -32,6 +35,10 @@ from storyforge.cmd_scenes_import import import_scenes
 
 CSV_RELS = [csv_rel for _, csv_rel in SECTION_SPECS]
 CONFLICT_REPORT_PATH = os.path.join('working', 'sync-conflict.md')
+
+# git diff --quiet exit codes
+_DIFF_CLEAN = 0
+_DIFF_DIRTY = 1
 
 
 # ============================================================================
@@ -45,31 +52,37 @@ def _git(project_dir, *args, check=False):
     )
 
 
+def _is_git_repo(project_dir):
+    """Fast check that `project_dir` is inside a git working tree."""
+    return _git(project_dir, 'rev-parse', '--git-dir').returncode == 0
+
+
 def _is_dirty(project_dir, path_rel):
     """Return True if `path_rel` differs from HEAD (or is untracked).
 
-    Compares the working-tree state of one file to its committed version.
-    Untracked files and files absent from HEAD count as dirty.
+    Compares working-tree state to the committed version. Files not in HEAD
+    are treated as dirty when they exist on disk. Raises RuntimeError if
+    git itself fails for a reason other than "file isn't in HEAD" or
+    "file differs from HEAD" — masking those would let real corruption
+    look like a routine "everything is dirty" state.
     """
     abs_path = os.path.join(project_dir, path_rel)
-    # Untracked / new file → dirty if it exists on disk.
-    show = _git(project_dir, 'cat-file', '-e', f'HEAD:{path_rel}')
-    if show.returncode != 0:
+    # File absent from HEAD → dirty iff it exists on disk (new file).
+    in_head = _git(project_dir, 'cat-file', '-e', f'HEAD:{path_rel}')
+    if in_head.returncode != 0:
         return os.path.isfile(abs_path)
     diff = _git(project_dir, 'diff', '--quiet', 'HEAD', '--', path_rel)
-    # `git diff --quiet` exits 1 when there's a diff, 0 when there isn't.
-    return diff.returncode != 0
+    if diff.returncode not in (_DIFF_CLEAN, _DIFF_DIRTY):
+        raise RuntimeError(
+            f'git diff failed unexpectedly for {path_rel}: '
+            f'exit={diff.returncode} stderr={diff.stderr.strip()!r}'
+        )
+    return diff.returncode == _DIFF_DIRTY
 
 
 def _file_in_head(project_dir, path_rel):
     """True if the path exists in HEAD (i.e. is tracked + committed)."""
     return _git(project_dir, 'cat-file', '-e', f'HEAD:{path_rel}').returncode == 0
-
-
-def _head_content(project_dir, path_rel):
-    """Return the content of `path_rel` at HEAD, or '' if not in HEAD."""
-    r = _git(project_dir, 'show', f'HEAD:{path_rel}')
-    return r.stdout if r.returncode == 0 else ''
 
 
 # ============================================================================
@@ -85,8 +98,19 @@ def detect_state(project_dir, md_rel=DEFAULT_OUTPUT_PATH):
       - md_exists: bool — the MD exists on disk
       - md_in_head: bool — the MD has ever been committed
       - dirty_csvs: list[str] — relative paths of changed CSVs
+      - missing_csvs: list[str] — CSVs tracked in HEAD but absent from disk
     """
+    if not _is_git_repo(project_dir):
+        raise RuntimeError(
+            f'{project_dir} is not inside a git working tree. '
+            'storyforge sync requires git for state detection.'
+        )
     dirty_csvs = [p for p in CSV_RELS if _is_dirty(project_dir, p)]
+    missing_csvs = [
+        p for p in CSV_RELS
+        if _file_in_head(project_dir, p)
+        and not os.path.isfile(os.path.join(project_dir, p))
+    ]
     md_exists = os.path.isfile(os.path.join(project_dir, md_rel))
     md_in_head = _file_in_head(project_dir, md_rel)
     md_dirty = _is_dirty(project_dir, md_rel)
@@ -96,6 +120,7 @@ def detect_state(project_dir, md_rel=DEFAULT_OUTPUT_PATH):
         'md_exists': md_exists,
         'md_in_head': md_in_head,
         'dirty_csvs': dirty_csvs,
+        'missing_csvs': missing_csvs,
     }
 
 
@@ -105,12 +130,23 @@ def _write_conflict_report(project_dir, state, md_rel):
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
 
     # Render what export would produce now (CSV-side view) for comparison.
-    tmp_md = report_path + '.csv-side.md'
+    # Use a NamedTemporaryFile so we don't leave junk on disk if anything
+    # raises before the explicit cleanup below.
+    csv_side = ''
+    with tempfile.NamedTemporaryFile(
+        suffix='.md', mode='w', delete=False,
+        dir=os.path.dirname(report_path), encoding='utf-8',
+    ) as tmp:
+        tmp_md = tmp.name
     try:
         export_scenes(project_dir, tmp_md)
-        csv_side = open(tmp_md, encoding='utf-8').read()
-    except Exception as e:
-        csv_side = f'(could not render CSV-side preview: {e})'
+        with open(tmp_md, encoding='utf-8') as f:
+            csv_side = f.read()
+    except (OSError, UnicodeError, ValueError) as e:
+        # Narrow except: surface real bugs in export (schema drift, missing
+        # CSVs, encoding) loudly rather than burying them in the report body.
+        log(f'WARNING: could not render CSV-side preview for conflict report: {e}')
+        csv_side = f'(could not render CSV-side preview: {e}; see log above)'
     finally:
         if os.path.isfile(tmp_md):
             os.remove(tmp_md)
@@ -140,7 +176,7 @@ def _write_conflict_report(project_dir, state, md_rel):
         '## How to resolve',
         '',
         '1. Inspect the diff below to see how the two sides disagree.',
-        '2. Reconcile by hand: either revert one side, or edit both to match.',
+        '2. Reconcile by hand: revert one side, or edit both to match.',
         '3. Re-run `storyforge sync` to confirm.',
         '',
         'For trickier merges, ask Claude in a session to walk through the',
@@ -162,18 +198,43 @@ def _write_conflict_report(project_dir, state, md_rel):
 def run_sync(project_dir, md_rel=DEFAULT_OUTPUT_PATH, check_only=False):
     """Sync CSVs and the review MD against git HEAD. Returns one of:
 
-      - 'noop'         — both sides clean and MD is present
-      - 'exported'     — CSV changes flowed to MD
+      - 'noop'         — both sides clean and MD present
+      - 'exported'     — CSV changes flowed to MD (or MD regenerated because
+                         it was missing on disk)
       - 'imported'     — MD changes flowed to CSVs
       - 'conflict'     — both sides changed; conflict report written
-      - 'first-export' — MD never committed; treated as CSV → MD seed
+      - 'first-export' — MD never committed and absent on disk; seeded
+      - 'untracked-md' — MD exists on disk but not in HEAD; refused to clobber
+      - 'missing-csv'  — a CSV tracked in HEAD is missing on disk; refused
 
     `check_only=True` returns the same status without writing anything.
     """
     state = detect_state(project_dir, md_rel)
     md_path = os.path.join(project_dir, md_rel)
 
-    # No prior committed MD: treat CSVs as canonical and seed the MD.
+    # Hard refuse: a CSV is tracked but missing from disk. Sync can't proceed
+    # safely — restoring it requires the user's intent.
+    if state['missing_csvs']:
+        if check_only:
+            return 'missing-csv'
+        log(f'ERROR: CSV(s) tracked in HEAD but missing on disk: '
+            f'{", ".join(state["missing_csvs"])}')
+        log('  Restore with: git checkout HEAD -- <path>')
+        log('  Or commit the deletion explicitly before re-running sync.')
+        return 'missing-csv'
+
+    # MD never committed but already exists on disk → could be hand-edits.
+    # Refuse rather than silently overwrite.
+    if not state['md_in_head'] and state['md_exists']:
+        if check_only:
+            return 'untracked-md'
+        log(f'ERROR: {md_rel} exists on disk but is not committed.')
+        log('  If those edits are yours, `git add` and commit them, then re-run sync.')
+        log('  If you want to discard them and regenerate from the CSVs, delete '
+            'the file and re-run sync.')
+        return 'untracked-md'
+
+    # MD truly absent: seed from CSVs.
     if not state['md_in_head']:
         if check_only:
             return 'first-export'
@@ -198,11 +259,12 @@ def run_sync(project_dir, md_rel=DEFAULT_OUTPUT_PATH, check_only=False):
     if state['md_dirty']:
         if check_only:
             return 'imported'
+        # import_scenes raises RuntimeError on unknown scene IDs etc.
         changes = import_scenes(project_dir, md_path, dry_run=False)
         log(f'Imported {len(changes)} field change(s) from {md_rel} → CSVs')
         return 'imported'
 
-    # Both clean. If the MD doesn't exist on disk somehow (e.g. wiped), regen.
+    # Both clean and committed. If MD was wiped from disk somehow, regen.
     if not state['md_exists']:
         if check_only:
             return 'exported'
@@ -219,40 +281,89 @@ def run_sync(project_dir, md_rel=DEFAULT_OUTPUT_PATH, check_only=False):
 
 HOOK_FILENAME = 'pre-commit'
 
-HOOK_SCRIPT = '''#!/usr/bin/env bash
+SYNC_TRACKED_PATHS = [
+    'reference/scenes.csv',
+    'reference/scene-intent.csv',
+    'reference/scene-briefs.csv',
+    'reference/scenes-review.md',
+]
+
+# Regex the hook uses to decide whether the current commit touches any
+# sync-tracked path. Defined here so it can be unit-tested in Python.
+HOOK_PATH_FILTER = (
+    r'^reference/(scenes|scene-intent|scene-briefs)\.csv$'
+    r'|^reference/scenes-review\.md$'
+)
+
+HOOK_SCRIPT = f'''#!/usr/bin/env bash
 # Installed by `storyforge sync --install-hook`. Keeps scene CSVs and
 # reference/scenes-review.md in sync before each commit.
+#
+# Behavior:
+#   1. Skip unless the staged change touches a sync-tracked path.
+#   2. Refuse the commit if any sync-tracked file has *unstaged* changes,
+#      so sync can't accidentally bundle unrelated work into the commit.
+#   3. Run `storyforge sync`. Refuse the commit if sync writes a conflict
+#      report or otherwise exits non-zero.
+#   4. Stage the four sync-tracked files so anything sync produced lands
+#      in the commit.
+#
+# Bypass for one-off cases: STORYFORGE_SYNC_SKIP=1 git commit ...
 set -e
 
-# Only run if any tracked scene file has staged changes.
+if [ "${{STORYFORGE_SYNC_SKIP:-}}" = "1" ]; then
+    exit 0
+fi
+
+# Step 1: only run if the staged change touches a sync-tracked path.
 if ! git diff --cached --name-only \\
-        | grep -E '^reference/(scenes|scene-intent|scene-briefs)\\.csv$|^reference/scenes-review\\.md$' \\
+        | grep -E '{HOOK_PATH_FILTER}' \\
         >/dev/null 2>&1; then
     exit 0
 fi
 
-# Find the storyforge runner. Prefer the one on PATH; fall back to the
-# user's plugin checkout.
+# Step 2: refuse if any sync-tracked file has unstaged working-tree changes.
+# (Otherwise sync would mix those edits into the commit, or be blocked by
+# a spurious "both dirty" conflict.)
+UNSTAGED=$(git diff --name-only -- {' '.join(SYNC_TRACKED_PATHS)} || true)
+if [ -n "$UNSTAGED" ]; then
+    echo "" >&2
+    echo "ERROR: storyforge sync refuses to run with unstaged scene changes:" >&2
+    echo "$UNSTAGED" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "Stash, stage, or revert those changes, then commit again." >&2
+    echo "(Set STORYFORGE_SYNC_SKIP=1 to bypass.)" >&2
+    exit 1
+fi
+
+# Step 3: find the storyforge runner. Fail closed if we can't.
 if command -v storyforge >/dev/null 2>&1; then
     SF=storyforge
-elif [ -x "$HOME/Developer/storyforge/storyforge" ]; then
-    SF="$HOME/Developer/storyforge/storyforge"
+elif [ -n "${{STORYFORGE_HOME:-}}" ] && [ -x "$STORYFORGE_HOME/storyforge" ]; then
+    SF="$STORYFORGE_HOME/storyforge"
 else
-    echo "pre-commit: 'storyforge' not on PATH; skipping sync" >&2
-    exit 0
+    echo "" >&2
+    echo "ERROR: pre-commit hook needs 'storyforge' on PATH (or \\$STORYFORGE_HOME" >&2
+    echo "set to the plugin checkout) to keep scene files in sync." >&2
+    echo "Install storyforge or set STORYFORGE_SYNC_SKIP=1 to bypass." >&2
+    exit 1
 fi
 
 if ! "$SF" sync; then
     echo "" >&2
     echo "storyforge sync refused the commit." >&2
-    echo "See working/sync-conflict.md and resolve, then 'git add' and retry." >&2
+    echo "See working/sync-conflict.md (or the error above) and resolve, " >&2
+    echo "then 'git add' and retry." >&2
     exit 1
 fi
 
-# Restage anything sync produced (e.g. regenerated scenes-review.md or
-# updated CSV cells from an MD-side edit).
-git add reference/scenes.csv reference/scene-intent.csv \\
-        reference/scene-briefs.csv reference/scenes-review.md 2>/dev/null || true
+# Step 4: stage whatever sync produced. No `|| true` — a failure here means
+# the commit would land with stale files and we want to know about it.
+for f in {' '.join(SYNC_TRACKED_PATHS)}; do
+    if [ -f "$f" ]; then
+        git add "$f"
+    fi
+done
 '''
 
 
@@ -281,6 +392,10 @@ def install_hook(project_dir):
 # CLI
 # ============================================================================
 
+# Status codes that should cause the CLI / hook to exit non-zero.
+_FAILURE_STATUSES = {'conflict', 'untracked-md', 'missing-csv'}
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(
         prog='storyforge sync',
@@ -302,10 +417,15 @@ def main(argv=None):
         install_hook(project_dir)
         return
 
-    status = run_sync(project_dir, check_only=args.check)
+    try:
+        status = run_sync(project_dir, check_only=args.check)
+    except RuntimeError as e:
+        log(f'ERROR: {e}')
+        sys.exit(1)
+
     if args.check:
         log(f'Sync status: {status}')
-    if status == 'conflict':
+    if status in _FAILURE_STATUSES:
         sys.exit(1)
 
 

--- a/scripts/lib/python/storyforge/cmd_sync.py
+++ b/scripts/lib/python/storyforge/cmd_sync.py
@@ -257,6 +257,14 @@ def run_sync(project_dir, md_rel=DEFAULT_OUTPUT_PATH, check_only=False):
         return 'exported'
 
     if state['md_dirty']:
+        # MD-dirty + not on disk means the user wiped a tracked MD —
+        # there's nothing to import; regenerate it from the CSVs.
+        if not state['md_exists']:
+            if check_only:
+                return 'exported'
+            export_scenes(project_dir, md_path)
+            log(f'Regenerated wiped {md_rel} from CSVs')
+            return 'exported'
         if check_only:
             return 'imported'
         # import_scenes raises RuntimeError on unknown scene IDs etc.
@@ -336,16 +344,22 @@ if [ -n "$UNSTAGED" ]; then
     exit 1
 fi
 
-# Step 3: find the storyforge runner. Fail closed if we can't.
+# Step 3: find the storyforge runner. Tries (1) PATH, (2) $STORYFORGE_HOME
+# override, (3) the absolute path baked in at install time. Fails closed
+# if none resolve — silent exit-0 here would let desync ship.
+DEFAULT_RUNNER='__STORYFORGE_RUNNER_PATH__'
 if command -v storyforge >/dev/null 2>&1; then
     SF=storyforge
 elif [ -n "${{STORYFORGE_HOME:-}}" ] && [ -x "$STORYFORGE_HOME/storyforge" ]; then
     SF="$STORYFORGE_HOME/storyforge"
+elif [ -x "$DEFAULT_RUNNER" ]; then
+    SF="$DEFAULT_RUNNER"
 else
     echo "" >&2
-    echo "ERROR: pre-commit hook needs 'storyforge' on PATH (or \\$STORYFORGE_HOME" >&2
-    echo "set to the plugin checkout) to keep scene files in sync." >&2
-    echo "Install storyforge or set STORYFORGE_SYNC_SKIP=1 to bypass." >&2
+    echo "ERROR: pre-commit hook can't find a 'storyforge' runner." >&2
+    echo "  Tried: PATH, \\$STORYFORGE_HOME, install-time default ($DEFAULT_RUNNER)." >&2
+    echo "  Re-run \\`storyforge sync --install-hook\\` to rebake the path," >&2
+    echo "  or set STORYFORGE_SYNC_SKIP=1 to bypass." >&2
     exit 1
 fi
 
@@ -367,8 +381,28 @@ done
 '''
 
 
+def _default_runner_path():
+    """Locate the `storyforge` runner relative to this module.
+
+    `cmd_sync.py` lives at <plugin>/scripts/lib/python/storyforge/cmd_sync.py;
+    walk up four levels to <plugin>, where the runner script sits.
+    Returns an empty string if the runner isn't where we expect.
+    """
+    here = os.path.abspath(__file__)
+    plugin_root = os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(here)))
+    ))
+    candidate = os.path.join(plugin_root, 'storyforge')
+    return candidate if os.path.isfile(candidate) else ''
+
+
 def install_hook(project_dir):
-    """Write the pre-commit hook into the project's .git/hooks/. Returns path."""
+    """Write the pre-commit hook into the project's .git/hooks/. Returns path.
+
+    The current plugin's runner path is baked into the hook so that the
+    installed hook keeps working without requiring `storyforge` on PATH or
+    any env-var setup. Re-run --install-hook after moving the plugin.
+    """
     hooks_dir = os.path.join(project_dir, '.git', 'hooks')
     if not os.path.isdir(hooks_dir):
         log(f'ERROR: {hooks_dir} not found — is this a git repository?')
@@ -381,10 +415,18 @@ def install_hook(project_dir):
             log(f'WARNING: {hook_path} already exists and is not a storyforge hook. '
                 'Refusing to overwrite — back it up or merge by hand.')
             sys.exit(1)
+    runner = _default_runner_path()
+    if not runner:
+        log('WARNING: could not locate the storyforge runner relative to '
+            'this module. Hook will fall back to PATH / $STORYFORGE_HOME at '
+            'commit time.')
+    hook_content = HOOK_SCRIPT.replace('__STORYFORGE_RUNNER_PATH__', runner)
     with open(hook_path, 'w', encoding='utf-8') as f:
-        f.write(HOOK_SCRIPT)
+        f.write(hook_content)
     os.chmod(hook_path, 0o755)
     log(f'Installed pre-commit hook at {hook_path}')
+    if runner:
+        log(f'  Hook will invoke: {runner}')
     return hook_path
 
 

--- a/tests/test_cmd_sync.py
+++ b/tests/test_cmd_sync.py
@@ -1,0 +1,231 @@
+"""Tests for cmd_sync and the header-driven scenes-export round-trip."""
+
+import os
+import subprocess
+
+import pytest
+
+from storyforge.csv_cli import get_field, update_field
+
+
+def _git(project_dir, *args, check=True):
+    return subprocess.run(
+        ['git', *args], cwd=project_dir,
+        capture_output=True, text=True, check=check,
+    )
+
+
+@pytest.fixture
+def git_project(project_dir, monkeypatch):
+    """A `project_dir` fixture with an initialized git repo and an initial commit."""
+    monkeypatch.chdir(project_dir)
+    _git(project_dir, 'init', '-q')
+    _git(project_dir, 'config', 'user.email', 'test@example.com')
+    _git(project_dir, 'config', 'user.name', 'Test')
+    _git(project_dir, 'add', '-A')
+    _git(project_dir, 'commit', '-q', '-m', 'initial')
+    return project_dir
+
+
+@pytest.fixture
+def git_project_gn(project_dir_gn, monkeypatch):
+    monkeypatch.chdir(project_dir_gn)
+    _git(project_dir_gn, 'init', '-q')
+    _git(project_dir_gn, 'config', 'user.email', 'test@example.com')
+    _git(project_dir_gn, 'config', 'user.name', 'Test')
+    _git(project_dir_gn, 'add', '-A')
+    _git(project_dir_gn, 'commit', '-q', '-m', 'initial')
+    return project_dir_gn
+
+
+# ---------------------------------------------------------------------------
+# Header-driven export: round-trip GN columns
+# ---------------------------------------------------------------------------
+
+def test_export_includes_gn_specific_columns(project_dir_gn):
+    """target_pages, panel_breakdown, etc. must appear in the exported MD."""
+    from storyforge.cmd_scenes_export import export_scenes
+    out = os.path.join(project_dir_gn, 'reference', 'scenes-review.md')
+    export_scenes(project_dir_gn, out)
+    content = open(out).read()
+    assert 'target_pages: 6' in content
+    assert 'page_layout: splash p1, 4-panel grid p2' in content
+    assert 'panel_breakdown:' in content
+    assert 'visual_keywords:' in content
+    assert 'page_turn_beats:' in content
+    assert 'caption_strategy:' in content
+
+
+def test_gn_round_trip_preserves_specific_columns(project_dir_gn):
+    """Export → edit a GN column → import flows back to the right CSV cell."""
+    from storyforge.cmd_scenes_export import export_scenes
+    from storyforge.cmd_scenes_import import import_scenes
+
+    out = os.path.join(project_dir_gn, 'reference', 'scenes-review.md')
+    export_scenes(project_dir_gn, out)
+
+    content = open(out).read()
+    content = content.replace(
+        'target_pages: 6',
+        'target_pages: 8',
+    )
+    with open(out, 'w') as f:
+        f.write(content)
+
+    changes = import_scenes(project_dir_gn, out, dry_run=False)
+    assert any(c[2] == 'target_pages' for c in changes), \
+        'target_pages change should propagate to the CSV'
+
+    scenes_csv = os.path.join(project_dir_gn, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'the-blank-page', 'target_pages') == '8'
+
+
+# ---------------------------------------------------------------------------
+# Sync state machine
+# ---------------------------------------------------------------------------
+
+def test_sync_first_run_exports_when_no_md_in_head(git_project):
+    """When the MD has never been committed, sync exports it from the CSVs."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    assert not os.path.isfile(md_path)
+
+    status = run_sync(git_project)
+    assert status == 'first-export'
+    assert os.path.isfile(md_path)
+
+
+def test_sync_noop_when_both_clean(git_project):
+    """After export + commit, a fresh sync is a no-op."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    run_sync(git_project)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add scenes-review.md')
+
+    status = run_sync(git_project)
+    assert status == 'noop'
+
+
+def test_sync_exports_when_csv_dirty(git_project):
+    """CSV change with clean MD → export."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    run_sync(git_project)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add MD')
+
+    scenes_csv = os.path.join(git_project, 'reference', 'scenes.csv')
+    update_field(scenes_csv, 'act1-sc01', 'title', 'A New Title')
+
+    status = run_sync(git_project)
+    assert status == 'exported'
+    md = open(os.path.join(git_project, DEFAULT_OUTPUT_PATH)).read()
+    assert 'title: A New Title' in md
+
+
+def test_sync_imports_when_md_dirty(git_project):
+    """MD change with clean CSVs → import."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    run_sync(git_project)
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add MD')
+
+    content = open(md_path).read().replace(
+        'title: The Finest Cartographer',
+        'title: The Last Cartographer',
+    )
+    with open(md_path, 'w') as f:
+        f.write(content)
+
+    status = run_sync(git_project)
+    assert status == 'imported'
+    scenes_csv = os.path.join(git_project, 'reference', 'scenes.csv')
+    assert get_field(scenes_csv, 'act1-sc01', 'title') == 'The Last Cartographer'
+
+
+def test_sync_conflicts_when_both_dirty(git_project):
+    """Both sides changed → conflict + report file written, exit non-zero."""
+    from storyforge.cmd_sync import run_sync, CONFLICT_REPORT_PATH, DEFAULT_OUTPUT_PATH
+
+    run_sync(git_project)
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add MD')
+
+    # Edit CSV
+    scenes_csv = os.path.join(git_project, 'reference', 'scenes.csv')
+    update_field(scenes_csv, 'act1-sc01', 'pov', 'Someone Else')
+
+    # And edit MD
+    content = open(md_path).read().replace(
+        'title: The Finest Cartographer',
+        'title: A Different Title',
+    )
+    with open(md_path, 'w') as f:
+        f.write(content)
+
+    status = run_sync(git_project)
+    assert status == 'conflict'
+    report = os.path.join(git_project, CONFLICT_REPORT_PATH)
+    assert os.path.isfile(report)
+
+    report_text = open(report).read()
+    assert 'sync conflict' in report_text.lower()
+    assert 'reference/scenes.csv' in report_text
+
+    # CSV must NOT have been overwritten with MD's pov change, and MD must NOT
+    # have been overwritten with CSV-side title — both sides preserved.
+    assert get_field(scenes_csv, 'act1-sc01', 'pov') == 'Someone Else'
+    assert 'A Different Title' in open(md_path).read()
+
+
+def test_sync_check_only_does_not_write(git_project):
+    """--check returns the status without performing the sync."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    status = run_sync(git_project, check_only=True)
+    assert status == 'first-export'
+    assert not os.path.isfile(os.path.join(git_project, DEFAULT_OUTPUT_PATH))
+
+
+def test_sync_gn_first_export(git_project_gn):
+    """GN-mode project: first sync produces an MD with GN-specific fields."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    status = run_sync(git_project_gn)
+    assert status == 'first-export'
+    md = open(os.path.join(git_project_gn, DEFAULT_OUTPUT_PATH)).read()
+    assert 'target_pages: 6' in md
+    assert 'panel_breakdown:' in md
+
+
+# ---------------------------------------------------------------------------
+# Hook installation
+# ---------------------------------------------------------------------------
+
+def test_install_hook_writes_executable_script(git_project):
+    """--install-hook drops a pre-commit hook in .git/hooks/."""
+    from storyforge.cmd_sync import install_hook
+
+    hook_path = install_hook(git_project)
+    assert os.path.isfile(hook_path)
+    assert os.access(hook_path, os.X_OK), 'hook must be executable'
+    content = open(hook_path).read()
+    assert 'storyforge sync' in content
+
+
+def test_install_hook_refuses_to_overwrite_foreign_hook(git_project):
+    """If an existing hook isn't ours, we bail rather than clobber."""
+    from storyforge.cmd_sync import install_hook
+
+    hook_path = os.path.join(git_project, '.git', 'hooks', 'pre-commit')
+    with open(hook_path, 'w') as f:
+        f.write('#!/bin/sh\necho "not the storyforge hook"\n')
+
+    with pytest.raises(SystemExit) as exc_info:
+        install_hook(git_project)
+    assert exc_info.value.code != 0

--- a/tests/test_cmd_sync.py
+++ b/tests/test_cmd_sync.py
@@ -209,13 +209,19 @@ def test_sync_gn_first_export(git_project_gn):
 
 def test_install_hook_writes_executable_script(git_project):
     """--install-hook drops a pre-commit hook in .git/hooks/."""
-    from storyforge.cmd_sync import install_hook
+    from storyforge.cmd_sync import install_hook, _default_runner_path
 
     hook_path = install_hook(git_project)
     assert os.path.isfile(hook_path)
     assert os.access(hook_path, os.X_OK), 'hook must be executable'
     content = open(hook_path).read()
     assert 'storyforge sync' in content
+    # The placeholder must have been substituted with a real path
+    assert '__STORYFORGE_RUNNER_PATH__' not in content
+    runner = _default_runner_path()
+    assert runner and runner in content, (
+        'install_hook should bake the plugin runner path into the hook'
+    )
 
 
 def test_install_hook_refuses_to_overwrite_foreign_hook(git_project):
@@ -395,16 +401,14 @@ def test_hook_script_uses_staged_diff(git_project):
 
 
 def test_hook_script_fails_closed_without_storyforge():
-    """When neither $PATH nor $STORYFORGE_HOME provides the runner, the
-    hook must exit 1 — not silently exit 0 and let desync ship.
+    """When no runner is discoverable (PATH, $STORYFORGE_HOME, baked-in),
+    the hook must exit 1 — not silently exit 0 and let desync ship.
     """
     from storyforge.cmd_sync import HOOK_SCRIPT
-    # Look for the "not on PATH" branch and confirm it exits non-zero.
-    idx = HOOK_SCRIPT.find('needs \'storyforge\' on PATH')
-    assert idx != -1
-    tail = HOOK_SCRIPT[idx:idx + 400]
+    idx = HOOK_SCRIPT.find("can't find a 'storyforge' runner")
+    assert idx != -1, 'expected the runner-not-found error branch in HOOK_SCRIPT'
+    tail = HOOK_SCRIPT[idx:idx + 500]
     assert 'exit 1' in tail
-    # And there should be no `exit 0` between the warning and the exit 1.
     pre_exit = tail[:tail.index('exit 1')]
     assert 'exit 0' not in pre_exit
 
@@ -417,6 +421,24 @@ def test_sync_in_non_git_directory_errors_clearly(tmp_path):
     import pytest
     with pytest.raises(RuntimeError, match='not inside a git working tree'):
         detect_state(str(tmp_path))
+
+
+def test_sync_regenerates_wiped_md(git_project):
+    """If a tracked MD is deleted on disk, sync should re-export from the
+    CSVs rather than crashing trying to import from a missing file.
+    """
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    run_sync(git_project)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add MD')
+
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    os.remove(md_path)
+
+    status = run_sync(git_project)
+    assert status == 'exported'
+    assert os.path.isfile(md_path)
 
 
 def test_import_silently_skips_scene_with_row_only_in_one_csv(project_dir):

--- a/tests/test_cmd_sync.py
+++ b/tests/test_cmd_sync.py
@@ -229,3 +229,213 @@ def test_install_hook_refuses_to_overwrite_foreign_hook(git_project):
     with pytest.raises(SystemExit) as exc_info:
         install_hook(git_project)
     assert exc_info.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for review fixes
+# ---------------------------------------------------------------------------
+
+def test_sync_refuses_to_overwrite_untracked_md(git_project):
+    """If MD exists on disk but is not in HEAD, refuse rather than seed.
+
+    Without this guard, a hand-edited MD copied in from another branch / a
+    backup / etc. would be silently destroyed on the first sync run.
+    """
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    os.makedirs(os.path.dirname(md_path), exist_ok=True)
+    sentinel = '## from-another-project\n\n### Whatever\nfoo: bar\n'
+    with open(md_path, 'w') as f:
+        f.write(sentinel)
+
+    status = run_sync(git_project)
+    assert status == 'untracked-md'
+    # File is unchanged
+    assert open(md_path).read() == sentinel
+
+
+def test_sync_first_export_only_when_md_truly_absent(git_project):
+    """The first-export branch still works when MD doesn't exist on disk."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    md_path = os.path.join(git_project, DEFAULT_OUTPUT_PATH)
+    assert not os.path.isfile(md_path)
+    status = run_sync(git_project)
+    assert status == 'first-export'
+    assert os.path.isfile(md_path)
+
+
+def test_sync_refuses_when_csv_deleted_on_disk(git_project):
+    """Tracked CSV deleted from disk → missing-csv status, no MD writes."""
+    from storyforge.cmd_sync import run_sync, DEFAULT_OUTPUT_PATH
+
+    # Get a baseline MD in HEAD so we exercise the post-bootstrap path.
+    run_sync(git_project)
+    _git(git_project, 'add', DEFAULT_OUTPUT_PATH)
+    _git(git_project, 'commit', '-q', '-m', 'add MD')
+
+    os.remove(os.path.join(git_project, 'reference', 'scenes.csv'))
+    md_before = open(os.path.join(git_project, DEFAULT_OUTPUT_PATH)).read()
+
+    status = run_sync(git_project)
+    assert status == 'missing-csv'
+    # MD must NOT be regenerated against a half-broken project state
+    assert open(os.path.join(git_project, DEFAULT_OUTPUT_PATH)).read() == md_before
+
+
+def test_parse_markdown_unknown_field_does_not_clobber_previous(project_dir):
+    """A 'field: value'-shaped line whose field is unknown must NOT merge
+    into the prior real field's value — that's silent CSV corruption.
+    """
+    from storyforge.cmd_scenes_import import parse_markdown
+    from storyforge.cmd_scenes_export import get_sections
+
+    section_map = {
+        name: (csv_rel, set(fields))
+        for name, csv_rel, fields in get_sections(project_dir)
+    }
+    md = (
+        '## act1-sc01\n'
+        '\n'
+        '### Brief\n'
+        'goal: fill the blank page\n'
+        'note_to_author: revisit later\n'
+        'conflict: nothing comes\n'
+    )
+    parsed = parse_markdown(md, section_map)
+    assert parsed['act1-sc01']['Brief']['goal'] == 'fill the blank page'
+    assert parsed['act1-sc01']['Brief']['conflict'] == 'nothing comes'
+    assert 'note_to_author' not in parsed['act1-sc01']['Brief']
+
+
+def test_parse_markdown_continuation_still_works(project_dir):
+    """Multi-line field values (continuation without `field:` prefix) still
+    work after the unknown-field fix.
+    """
+    from storyforge.cmd_scenes_import import parse_markdown
+    from storyforge.cmd_scenes_export import get_sections
+
+    section_map = {
+        name: (csv_rel, set(fields))
+        for name, csv_rel, fields in get_sections(project_dir)
+    }
+    md = (
+        '## act1-sc01\n'
+        '\n'
+        '### Brief\n'
+        'goal: fill the blank page\n'
+        '  with steady deliberate movements\n'
+    )
+    parsed = parse_markdown(md, section_map)
+    assert parsed['act1-sc01']['Brief']['goal'] == (
+        'fill the blank page with steady deliberate movements'
+    )
+
+
+def test_export_omits_sections_for_scenes_with_no_row(project_dir):
+    """Scenes that don't have a row in scene-intent.csv or scene-briefs.csv
+    should not have those empty sections rendered at all."""
+    from storyforge.cmd_scenes_export import export_scenes
+    from storyforge.csv_cli import _read_lines, _write_lines
+
+    # Strip the brief row for act1-sc01 so it has Structural + Intent only.
+    briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+    lines = _read_lines(briefs_csv)
+    kept = [lines[0]] + [l for l in lines[1:] if not l.startswith('act1-sc01|')]
+    _write_lines(briefs_csv, kept)
+
+    out = os.path.join(project_dir, 'reference', 'scenes-review.md')
+    export_scenes(project_dir, out)
+    content = open(out).read()
+
+    # Locate the act1-sc01 block in the rendered MD
+    start = content.index('## act1-sc01')
+    end = content.index('## act1-sc02')
+    block = content[start:end]
+    assert '### Structural' in block
+    assert '### Intent' in block
+    assert '### Brief' not in block, (
+        'Brief section should be omitted when the scene has no brief row'
+    )
+
+
+def test_hook_path_filter_matches_expected_paths():
+    """Regression: the regex the hook uses to decide whether to fire must
+    match every sync-tracked path and reject lookalikes."""
+    import re
+    from storyforge.cmd_sync import HOOK_PATH_FILTER
+
+    rx = re.compile(HOOK_PATH_FILTER, re.MULTILINE)
+    for good in (
+        'reference/scenes.csv',
+        'reference/scene-intent.csv',
+        'reference/scene-briefs.csv',
+        'reference/scenes-review.md',
+    ):
+        assert rx.search(good), f'expected hook to fire for {good!r}'
+    for bad in (
+        'reference/voice-profile.csv',     # different CSV
+        'scenes-review.md',                # wrong directory
+        'reference/scenes.csv.bak',        # extension boundary
+        'reference/scene-briefs.csv.tmp',  # extension boundary
+        'docs/reference/scenes.csv',       # wrong directory prefix
+    ):
+        assert not rx.search(bad), f'hook must not fire for {bad!r}'
+
+
+def test_hook_script_uses_staged_diff(git_project):
+    """The hook reads --cached (staged) changes, not the full working tree,
+    so partial-staging commits don't trigger spurious conflict reports."""
+    from storyforge.cmd_sync import HOOK_SCRIPT
+    # The first git diff in the script must filter by --cached.
+    first_diff = HOOK_SCRIPT.find('git diff')
+    assert first_diff != -1
+    assert '--cached' in HOOK_SCRIPT[first_diff:first_diff + 100]
+
+
+def test_hook_script_fails_closed_without_storyforge():
+    """When neither $PATH nor $STORYFORGE_HOME provides the runner, the
+    hook must exit 1 — not silently exit 0 and let desync ship.
+    """
+    from storyforge.cmd_sync import HOOK_SCRIPT
+    # Look for the "not on PATH" branch and confirm it exits non-zero.
+    idx = HOOK_SCRIPT.find('needs \'storyforge\' on PATH')
+    assert idx != -1
+    tail = HOOK_SCRIPT[idx:idx + 400]
+    assert 'exit 1' in tail
+    # And there should be no `exit 0` between the warning and the exit 1.
+    pre_exit = tail[:tail.index('exit 1')]
+    assert 'exit 0' not in pre_exit
+
+
+def test_sync_in_non_git_directory_errors_clearly(tmp_path):
+    """Running sync outside a git repo must surface the missing-repo case
+    rather than mis-classifying everything as 'dirty'."""
+    from storyforge.cmd_sync import detect_state
+    # tmp_path is a non-git directory
+    import pytest
+    with pytest.raises(RuntimeError, match='not inside a git working tree'):
+        detect_state(str(tmp_path))
+
+
+def test_import_silently_skips_scene_with_row_only_in_one_csv(project_dir):
+    """A scene present in scenes.csv but missing from scene-briefs.csv must
+    not raise — only IDs missing from *all* CSVs are an error.
+    """
+    from storyforge.cmd_scenes_export import export_scenes
+    from storyforge.cmd_scenes_import import import_scenes
+    from storyforge.csv_cli import _read_lines, _write_lines
+
+    # Remove act1-sc01 from scene-briefs.csv (still in scenes + intent).
+    briefs_csv = os.path.join(project_dir, 'reference', 'scene-briefs.csv')
+    lines = _read_lines(briefs_csv)
+    kept = [lines[0]] + [l for l in lines[1:] if not l.startswith('act1-sc01|')]
+    _write_lines(briefs_csv, kept)
+
+    out = os.path.join(project_dir, 'reference', 'scenes-review.md')
+    export_scenes(project_dir, out)
+
+    # The MD references act1-sc01 (it's in scenes.csv). Import must succeed.
+    changes = import_scenes(project_dir, out, dry_run=True)
+    assert changes == [], 'expected no diff round-trip immediately after export'

--- a/tests/test_scenes_review.py
+++ b/tests/test_scenes_review.py
@@ -256,7 +256,11 @@ class TestImport:
         assert get_field(csv_path, 'act1-sc02', 'pov') == 'Elara Voss'
         assert get_field(csv_path, 'act2-sc03', 'pov') == 'Elara Voss'
 
-    def test_import_unknown_scene_skipped(self, project_dir):
+    def test_import_unknown_scene_raises(self, project_dir):
+        """An MD referencing a scene_id not in any CSV must raise — silent
+        skip would let a "rename in MD" go undetected (phantom rename).
+        """
+        import pytest
         from storyforge.cmd_scenes_import import import_scenes
 
         md_path = os.path.join(project_dir, 'working', 'scenes-review.md')
@@ -264,5 +268,5 @@ class TestImport:
         with open(md_path, 'w') as f:
             f.write('## nonexistent-scene\n\n### Structural\nseq: 99\n')
 
-        changes = import_scenes(project_dir, md_path, dry_run=False)
-        assert changes == []
+        with pytest.raises(RuntimeError, match='nonexistent-scene'):
+            import_scenes(project_dir, md_path, dry_run=False)


### PR DESCRIPTION
## Summary
- **New `storyforge sync` command**: detects which side is dirty vs `git HEAD` and routes — CSV-dirty/MD-clean → export; MD-dirty/CSV-clean → import; both dirty → write `working/sync-conflict.md` and exit 1. First run (MD never committed) seeds the MD from the CSVs.
- **Pre-commit hook**: `storyforge sync --install-hook` drops a hook into `.git/hooks/pre-commit` that runs sync and restages the result, refusing the commit on unresolved conflicts. Hook is filtered to only fire when the staged change touches scene CSVs or `scenes-review.md`.
- **Header-driven export/import**: `cmd_scenes_export.py` no longer hardcodes novel-mode columns. Both export and import now read each CSV's header row at runtime, so `target_pages`, `panel_breakdown`, `visual_keywords`, `page_turn_beats`, `caption_strategy`, and any future schema additions round-trip without code changes.
- **Default output moved** from `working/scenes-review.md` to `reference/scenes-review.md` so the file is naturally committable and shows up in PR diffs.

## Why
Reviewing changes to scene metadata in pipe-delimited CSV diffs is painful. The exported MD is much more readable but only useful in PR review if it's actually in git. This wires both sides up: the MD is committed, sync keeps it fresh automatically, and conflicts surface as a structured report rather than silent overwrites.

## Test plan
- [x] `python3 -m pytest tests/test_cmd_sync.py tests/test_scenes_review.py` (31 passed)
- [x] Full suite: `python3 -m pytest tests/` (3625 passed, 10 skipped)
- [x] Live test on Ashes: first sync produced 1271-line MD with all GN-specific columns present; hook installed; CSV-edit-then-commit cycle automatically regenerated MD and included both files in one commit; revert cycle re-synced correctly
- [x] Conflict path verified by unit test (`test_sync_conflicts_when_both_dirty`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)