### PR TITLE
Research design docs: bidirectional, scored elaboration hierarchy (#224)

### DIFF
--- a/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
+++ b/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
@@ -2,9 +2,14 @@
 
 Research design doc for issue [#226](https://github.com/benjaminsnorris/storyforge/issues/226), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
 
-Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md) — read that first. Refers to its level numbering throughout.
+Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md) and the [review synthesis](2026-05-24-elaboration-review-synthesis.md) — read those first. Refers to the levels doc's numbering throughout. The synthesis supersedes this doc where they disagree (it folded in author + reviewer feedback after this was written).
 
-Status: **draft**, expects iteration. Implementation out of scope.
+Status: **draft + revisions noted inline**. Implementation out of scope.
+
+> **Post-review revisions** that affect this doc:
+> - The structural tier is split into discrete artifacts (spine.csv, architecture.csv, scenes.csv) rather than `status` flags on a single CSV. This makes the 3→4 and 4→5 boundary detection trivially deterministic (set membership on `spine_event` and `architecture_scene` columns).
+> - The diff+verdict mechanism (used at LLM-judged boundaries) has a coaching-level-aware actor: in `full`, the LLM proposes the verdict and the author can override; in `coach`, the LLM proposes and the author confirms; in `strict`, only the author records verdicts. See the synthesis for details.
+> - `mtime`-only drift detection is replaced by `mtime + content_hash` so typo commits don't trigger false drift.
 
 ---
 
@@ -63,12 +68,13 @@ Several drift cases can be flagged without an LLM:
 
 | Detection | Where | How |
 |---|---|---|
-| A spine event has no descendant scenes | Spine → Architecture/Map | No `scenes.csv` row maps to spine event N |
-| An architecture scene has no entry in scene-intent.csv | Architecture → Map | Row missing |
+| A spine event has no descendant architecture rows | Spine → Architecture (3→4) | `spine.csv.id` not referenced by any `architecture.csv.spine_event` — set difference |
+| An architecture anchor has no descendant map scenes | Architecture → Map (4→5) | `architecture.csv.id` not referenced by any `scenes.csv.architecture_scene` — set difference |
+| A theme has no scene engagements | Theme → Manuscript | `themes.csv.id` not present in any `scene-intent.csv.theme_threads` — set difference |
 | A brief references a `value_at_stake` not in `values.csv` | Briefs ↔ Registries | Set difference |
 | A scene's `pov` character is not in `characters.csv` | Map ↔ Registries | Set difference |
 | A draft scene's word count is 0 (untouched) | Briefs → Draft | `word_count` column check |
-| A prose-tier section's `_updated` timestamp is older than a downstream level's | Logline → Synopsis, etc. | Frontmatter date compare |
+| A prose-tier section's `_updated` timestamp is older than a downstream level's | Logline → Synopsis, etc. | Frontmatter date compare + content-hash delta |
 | The MD file for a scene exists on disk but `status` is `briefed` | Status drift | File presence vs. status |
 
 These are coverage and freshness checks. They produce hard "X is missing / out of date / inconsistent" signals.

--- a/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
+++ b/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
@@ -1,0 +1,327 @@
+# Cascade mechanics between elaboration levels
+
+Research design doc for issue [#226](https://github.com/benjaminsnorris/storyforge/issues/226), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
+
+Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md) — read that first. Refers to its level numbering throughout.
+
+Status: **draft**, expects iteration. Implementation out of scope.
+
+---
+
+## TL;DR
+
+Three motions, not one.
+
+- **Forward** — the default: elaborate a level into the next level down. Today's pipeline.
+- **Upward** — a late-stage discovery propagates up: a brief reveals the protagonist actually wants X, the synopsis is no longer accurate.
+- **Lateral** — re-propagate a change down only into affected branches, not the whole tree.
+
+A new `storyforge cascade` command handles all three. It is **detection-deterministic, resolution-creative**: the system identifies what's out of sync and what's affected; the author (often via Claude in a session) decides what to do about it. Conflict surface aligns with `sync`'s existing conflict report format.
+
+The most important design choice in this doc is **cost visibility**: before any cascade fires, the system surfaces the *blast radius* (how many lower-level units could be affected) so the author can decide whether to take the change at all.
+
+---
+
+## Why three motions
+
+The existing `elaborate` pipeline is forward-only. You can rerun any stage, but the system has no idea which downstream artifacts are now stale. The author either manually re-elaborates everything below the change (expensive) or accepts silent drift (eventually fatal).
+
+The three motions correspond to three real authoring situations:
+
+1. **Forward (default).** The author has finished iterating at level N and is ready to elaborate into N+1. The cascade has nothing to do here — it's just the existing elaborate flow. Forward is the only motion that *generates new content*; the other two propagate or surface drift on content that exists.
+
+2. **Upward.** The author makes a change at some level N (often from a discovery while working at a lower level). Higher levels may now be wrong. Example: while writing the briefs for Act 2, the author realizes the protagonist's want is actually about belonging, not achievement. The synopsis and logline no longer fit. The act-shape's middle paragraph is wrong. The system should *flag* these as affected and the author should resolve.
+
+3. **Lateral.** The author makes a change at level N and the change needs to flow down — but only into the branches that touched the changed content. Example: the inciting incident moves from "the wife dies" to "the wife leaves." Spine event 2 changes; architecture scenes 4–7 (which dealt with the consequence) need re-examination; scenes 12–14 (which deal with later consequences) may also need updates; everything else is untouched.
+
+Forward and lateral can blur — both move downward. The distinction is that *forward* generates new content where none existed, while *lateral* updates existing content whose upstream input has shifted. Treat them separately in the design because the author's intent differs (creating vs. reconciling).
+
+---
+
+## The cascade as graph traversal
+
+Think of the project as a graph:
+
+- **Nodes** are level artifacts (logline, synopsis, act-shape, each spine event, each scene at architecture/map/briefs/draft level).
+- **Vertical edges** connect each node to its parent(s) at the level above and its children at the level below.
+- **Horizontal edges** are derivation relationships among nodes at the same level (e.g., a scene at brief level depends on continuity_deps from prior scenes — already tracked in scene-briefs.csv).
+- **Cross-cutting edges** connect every node to the bibles and registries it references.
+
+A cascade is a graph walk: starting from a changed node, identify the neighborhood that may be affected, surface it.
+
+**Vertical edges are the load-bearing ones for cascade.** Horizontal edges are already handled by `hone` and the brief continuity_deps machinery. Cross-cutting edges are mostly scoring concerns (#227), not cascade.
+
+---
+
+## Detection: how the system finds drift
+
+Drift detection is deterministic where possible, LLM-driven where necessary.
+
+### Deterministic detection
+
+Several drift cases can be flagged without an LLM:
+
+| Detection | Where | How |
+|---|---|---|
+| A spine event has no descendant scenes | Spine → Architecture/Map | No `scenes.csv` row maps to spine event N |
+| An architecture scene has no entry in scene-intent.csv | Architecture → Map | Row missing |
+| A brief references a `value_at_stake` not in `values.csv` | Briefs ↔ Registries | Set difference |
+| A scene's `pov` character is not in `characters.csv` | Map ↔ Registries | Set difference |
+| A draft scene's word count is 0 (untouched) | Briefs → Draft | `word_count` column check |
+| A prose-tier section's `_updated` timestamp is older than a downstream level's | Logline → Synopsis, etc. | Frontmatter date compare |
+| The MD file for a scene exists on disk but `status` is `briefed` | Status drift | File presence vs. status |
+
+These are coverage and freshness checks. They produce hard "X is missing / out of date / inconsistent" signals.
+
+### LLM-driven detection
+
+Some drift can only be detected by reading both sides:
+
+- "Does this synopsis still describe what the spine says happens?" — semantic comparison.
+- "Does scene 14's brief honor the emotional arc that scene-intent says it has?" — semantic comparison.
+- "Does the logline still fit the story?" — broad semantic comparison.
+
+These are expensive and noisy. They should run **on demand** (when the author asks "is this still aligned?") rather than continuously. The cascade command can offer them as a flag (`--semantic`) but the default should be the cheap deterministic pass.
+
+### A drift report
+
+The output of detection is a structured drift report, written to `working/cascade-drift.md` (analogous to `working/sync-conflict.md`). Shape:
+
+```markdown
+# Cascade drift report
+
+Generated at 2026-05-24T10:00:00Z against HEAD.
+
+## Stale upward (downstream level changed, upstream may be wrong)
+
+- **Synopsis** was last updated 2026-05-10. Spine events 3 and 7 were
+  modified at 2026-05-23. Possible drift: synopsis may no longer reflect
+  the current spine.
+  - Affected unit: `reference/story-summary.md § Synopsis`
+  - Suggested motion: upward refactor
+
+## Stale downward (upstream changed, downstream may be wrong)
+
+- **Spine event 4** ("inciting incident: the wife leaves") was updated
+  at 2026-05-20. Architecture scenes 5–8 reference this event but were
+  last updated 2026-05-12. Possible drift.
+  - Affected units: scenes act1-sc05 through act1-sc08
+  - Suggested motion: lateral re-propagation
+  - Blast radius: 4 architecture scenes, 4 map scenes, 4 briefs, 4 drafts (if drafted)
+
+## Coverage gaps (deterministic)
+
+- Spine event 7 ("midpoint reversal") has no descendant scenes in
+  architecture. Forward elaboration needed.
+
+## Registry consistency (deterministic)
+
+- Scene act2-sc12 references value_at_stake "honor" but `values.csv`
+  has no such entry. Either add to registry or change the scene-intent value.
+
+## Suggested next actions
+
+- Upward: review the synopsis against the current spine.
+- Lateral: reconcile architecture scenes 5–8 against the updated spine event 4.
+- Forward: extend spine event 7 into architecture scenes.
+- Hygiene: resolve the values.csv registry mismatch.
+```
+
+The report is human-readable and machine-parseable (one section per drift category, one bullet per affected unit).
+
+---
+
+## Resolution: how the system applies changes
+
+The system **does not author content**. It identifies what needs work and what depends on what. The author does the creative work — either directly (editing files) or via Claude in a session ("here's the drift report, walk me through each item").
+
+### The three motion patterns
+
+#### Forward
+
+Already exists as today's pipeline. Cascade adds nothing new for the forward motion except surfacing it as the natural next step in the drift report ("spine event 7 has no children — forward elaborate?").
+
+#### Upward refactor
+
+Triggered when a lower-level change implies an upper level is now stale. The cascade:
+
+1. Identifies the affected upstream nodes from the drift report.
+2. Renders side-by-side: current upstream content vs. a summary of what the lower-level changes are saying.
+3. Prompts the author (or Claude-in-session) to update the upstream.
+4. After update, the new upstream may itself imply *further* upstream changes — the cascade recurses upward through the drift report.
+
+Upward never updates content automatically. It always asks.
+
+#### Lateral re-propagation
+
+Triggered when an upstream node has been edited and downstream branches need to be reconciled. The cascade:
+
+1. Identifies the affected downstream nodes (the *branches* under the changed node).
+2. For each affected branch:
+   - If the branch is at a level the author hasn't iterated yet, re-elaborate forward from the changed upstream (regenerate the brief, draft, etc.).
+   - If the branch has author work in it, *do not* regenerate — surface a conflict and ask the author to reconcile.
+3. Tracks which branches have been reconciled and which still need attention.
+
+The key constraint: **lateral re-propagation never silently overwrites author work**. If a brief exists, the cascade asks; if no brief exists, it re-elaborates.
+
+### Conflict format
+
+When resolution requires the author's call, the cascade writes a conflict to `working/cascade-conflict.md` with the same shape as `sync-conflict.md`: the two sides shown explicitly, with notes on how to resolve, plus a structured machine-readable section for tools (e.g., a future `cascade resolve` command).
+
+Same conventions as `sync`:
+- Author commits the resolution; the cascade re-runs and verifies.
+- The hook (or `cascade --check`) refuses commits that leave drift unresolved (configurable per project).
+
+---
+
+## Triggers: when does cascade run
+
+Three places:
+
+1. **On demand: `storyforge cascade`** — primary path. The author runs it when they want to check or apply cascade.
+2. **As part of `sync`** — `storyforge sync` already runs on every commit (via the pre-commit hook). Cascade detection can be wired in as a lightweight check that surfaces drift without blocking commits unless explicitly configured.
+3. **Score-triggered** — when scoring (#227) detects a level's fidelity score has dropped, the score report can suggest running cascade. Not automatic.
+
+The default cadence is: deterministic detection runs cheap and often (in the hook); LLM-driven detection runs rarely and on author command (`storyforge cascade --semantic`).
+
+---
+
+## CLI surface
+
+A single command with subcommands and flags:
+
+```
+storyforge cascade [--check] [--semantic] [--from LEVEL] [--to LEVEL] [--scenes IDS]
+
+storyforge cascade
+  → Run deterministic detection, write drift report, exit 0 (no work performed)
+
+storyforge cascade --check
+  → Same as above but exit 1 if drift is present (for hooks/CI)
+
+storyforge cascade --semantic
+  → Run deterministic + LLM detection. Slow, costs money, more thorough.
+
+storyforge cascade --from spine --to architecture
+  → Focus detection on a specific boundary
+
+storyforge cascade --scenes act1-sc05,act1-sc06
+  → Focus detection on specific scenes' branches
+
+storyforge cascade apply --to-branch act1-sc05
+  → (Future) Apply a lateral re-propagation to a specific branch (regenerate
+    its brief and draft from the current upstream, if no author work is present)
+```
+
+The `apply` subcommand is future work; v1 is detection only.
+
+---
+
+## Relationship to existing commands
+
+| Command | Scope | New role |
+|---|---|---|
+| `storyforge sync` | Horizontal: CSVs ↔ MD | Unchanged. May invoke cascade detection as a lightweight check. |
+| `storyforge revise` | Per-scene prose revision | Unchanged. Cascade doesn't touch prose-level revision. |
+| `storyforge elaborate` | Forward elaboration | Becomes one of three cascade motions (the forward one). |
+| `storyforge hone` | Registry consistency, brief quality | Already implements registry consistency at brief level. Cascade extends this pattern across levels. |
+| `storyforge cascade` | Vertical: drift across levels | New. Detects + reports; doesn't author. |
+
+The relationship between `sync` and `cascade` worth special note: they share the **conflict report format**, the **fail-closed hook integration**, and the **detection-deterministic, resolution-creative** philosophy. But sync resolves at the same level (CSV ↔ MD are different views of the same data); cascade resolves across levels (different content at different altitudes).
+
+---
+
+## Cost visibility
+
+The single most important design constraint, and the one that makes cascade tractable instead of overwhelming.
+
+Every drift item in the report carries a **blast radius**: the number of downstream units that *could* be affected. The author sees the cost before taking the change.
+
+Example display:
+
+```
+- **Spine event 4** modified at 2026-05-20. Reconciliation cost:
+    4 architecture scenes
+    4 map scenes
+    4 briefs (3 drafted)
+    estimated tokens for full semantic re-check: ~12,000 input / ~3,000 output
+    estimated wall time: ~5 min
+```
+
+This lets the author make the call: "yes, the change is worth the reconciliation cost" or "no, defer this and live with the drift until a polish pass."
+
+Cost visibility also informs the system's behavior:
+
+- Low blast radius (1–3 units) → cascade can suggest "I'll auto-apply this, ok?" with high default trust.
+- Medium (4–15 units) → cascade surfaces, author reviews, applies one at a time.
+- High (>15 units) → cascade refuses to auto-apply; author must work through each branch deliberately.
+
+The thresholds are heuristics, configurable per project (in `storyforge.yaml`).
+
+---
+
+## Edge cases
+
+### Conflict between upward and lateral
+
+The author makes a change at the briefs level. Cascade detects:
+- Upward drift: the synopsis no longer reflects this brief change.
+- Lateral drift: the draft for this scene is now stale.
+
+Which goes first?
+
+**Upward first.** If the synopsis is wrong, *every* downstream level is potentially wrong, including the draft we were about to re-propagate. Resolve up first, then re-propagate.
+
+Encode this in the cascade ordering: upward motions before lateral motions in the report.
+
+### A change at multiple levels simultaneously
+
+The author edits the synopsis AND a brief in the same session. Both upward and lateral cascades are now potentially relevant. What's the model?
+
+The simplest model: **cascade processes one motion type at a time** in the order above (upward → lateral → forward). The drift report after the synopsis edit shows the lateral consequences; after those are reconciled, the next cascade run shows the new state.
+
+This is slow but legible. Future optimization: a `cascade --plan` that shows the full multi-step reconciliation graph before any work.
+
+### What if the author wants to *abandon* a level
+
+E.g., the author decides the act-shape is wrong and wants to delete it (revert to having only the logline and synopsis). The cascade should detect: every downstream level depended on the act-shape, but the act-shape is gone. Treat it as a special case of upward drift — the upstream node was deleted, downstream nodes are orphaned.
+
+Implementation note: don't delete the file; mark the section empty. Detection then triggers naturally.
+
+---
+
+## What's deliberately not in this doc
+
+- **Scoring** — every drift detection here uses thresholds, but the *quality scores* underneath those thresholds belong in [#227](https://github.com/benjaminsnorris/storyforge/issues/227).
+- **The exact LLM prompts** for semantic detection. Implementation, after scoring lands.
+- **A formal proof that the graph is acyclic.** It is (levels go strictly downward, registries are leaves), but the doc doesn't prove it formally.
+- **Performance optimizations.** First version runs everything every time; iteration on caching/incremental detection comes after real usage.
+
+---
+
+## Open questions
+
+1. **Should the pre-commit hook block on cascade drift by default?** The argument for: drift is bad, surface it now. The argument against: drift is sometimes intentional (the author knows the synopsis is stale and will fix it after a few more scenes). My instinct: surface as warning by default, configurable to block per project.
+
+2. **Should cascade `--apply` ever auto-apply changes without asking?** I lean no, even for trivial cases. The whole point of the cascade is that the author owns the creative resolution. Auto-apply could be useful for "the registry says X but the brief says Y, X is the registry source of truth, normalize Y" cases — but those should probably stay in `hone`, not bleed into cascade.
+
+3. **How does cascade interact with the GN-mode revise pass?** GN revise rewrites a draft based on score findings. If revise changes the draft, that's downstream content changing — cascade should detect that the draft's brief may no longer match. But the right policy may be "drafts can drift from briefs" because the draft is the final artifact. Open.
+
+4. **Multi-branch projects (a `revise` branch + an `elaborate` branch concurrently).** Cascade is currently scoped to a single working tree. Cross-branch reconciliation is out of scope but worth flagging.
+
+5. **Does cascade emit machine-readable artifacts that future tools (e.g., a dashboard) can consume?** Probably yes — same shape as the scoring summary CSVs. Don't design this until the dashboard story is clearer.
+
+---
+
+## Acceptance criteria for the design
+
+This doc is "done" when:
+
+- The three motions are unambiguous and the boundary between forward and lateral is clear.
+- The drift report format is concrete enough that a future implementer can build the detection code.
+- The CLI surface answers "what command do I run when X happens?" for every X.
+- Cost visibility is a first-class concept, not an afterthought.
+- The relationship with `sync`, `revise`, `elaborate`, and `hone` is unambiguous.
+- Open questions are listed; nothing is silently undecided.
+
+(Self-assessment: all six pass at the draft level. Items 2 and 4 in "Open questions" want author input before implementation.)

--- a/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
+++ b/docs/superpowers/specs/2026-05-24-cascade-mechanics-design.md
@@ -89,6 +89,8 @@ Some drift can only be detected by reading both sides:
 
 These are expensive and noisy. They should run **on demand** (when the author asks "is this still aligned?") rather than continuously. The cascade command can offer them as a flag (`--semantic`) but the default should be the cheap deterministic pass.
 
+**Floor vs ceiling in cascade.** Drift fires only on *floor* failures — completeness, coverage, registry conformance, timestamp/hash deltas. The ceiling axes from the scoring doc (specificity, irony, causation, voice consistency, etc.) inform the LLM faithfulness diffs that get rendered for the author *after* drift is detected, but they don't themselves trigger drift. This keeps cascade signal-driven (something is broken or stale) rather than verdict-driven (something could be better).
+
 ### A drift report
 
 The output of detection is a structured drift report, written to `working/cascade-drift.md` (analogous to `working/sync-conflict.md`). Shape:
@@ -146,6 +148,8 @@ The system **does not author content**. It identifies what needs work and what d
 #### Forward
 
 Already exists as today's pipeline. Cascade adds nothing new for the forward motion except surfacing it as the natural next step in the drift report ("spine event 7 has no children — forward elaborate?").
+
+When the author produces multiple candidate elaborations (e.g., three drafts of a logline, two competing synopses, or alternative spines), use `storyforge score --compare` from the scoring doc rather than running the cascade on each one separately. The comparison primitive produces a multi-axis report that surfaces what each candidate does best without declaring a winner — the author decides; the cascade resumes once the chosen candidate is in place.
 
 #### Upward refactor
 

--- a/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
@@ -1,0 +1,229 @@
+# Elaboration levels and artifact shapes
+
+Research design doc for issue [#225](https://github.com/benjaminsnorris/storyforge/issues/225), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
+
+Status: **draft**, expects iteration. Implementation out of scope.
+
+---
+
+## TL;DR
+
+The proposal is **eight levels in two tiers**, with two new artifacts at the top and the existing pipeline carrying the rest.
+
+**Prose tier (free-form, LLM-scored):**
+- 0. Logline (1 sentence)
+- 1. Synopsis (1 paragraph)
+- 2. Act-shape (3 paragraphs)
+
+**Structural tier (CSV-backed, mostly deterministic):**
+- 3. Spine (5–10 events)
+- 4. Architecture (15–25 scenes)
+- 5. Scene map (40–60 scenes with operational metadata)
+- 6. Briefs (drafting contracts)
+- 7. Draft (prose)
+
+Levels 0–2 are new and live in a new file `reference/story-summary.md`. Levels 3–7 already exist; this design reframes them but adds no new schema.
+
+The bibles, registries, and voice profile sit **alongside** the hierarchy as cross-cutting reference data, not above or within it.
+
+---
+
+## Why eight levels and not four, or twelve
+
+A boundary is worth a level only if it has a real semantic discontinuity — a question that the level below can answer and the level above cannot. The eight proposed boundaries each pass that test; collapsing any of them would either hide a real gap (e.g., merging spine into architecture loses the irreducible-events question) or paper over a quality leap that needs its own scoring rubric.
+
+The boundary I considered hardest is **1 → 2 (synopsis → act-shape)**. They're both prose summaries. The argument for keeping them separate: a one-paragraph synopsis answers "what kind of story is this?" while a three-paragraph act-shape answers "where are the turning points and how does each act bear its load?" The act-shape names the load-bearing structure that the synopsis only gestures at. Two different questions, two different levels.
+
+A boundary I considered adding but rejected: between architecture and scene-map at "draft scene order." The current architecture stage already produces ordered scenes, so there's no real semantic gap there — the scene-map stage adds *operational* metadata (location, timeline, cast), not new structural decisions.
+
+---
+
+## The level taxonomy
+
+### Prose tier
+
+| Level | Name | Scope | Question it answers | What it can't answer |
+|---|---|---|---|---|
+| 0 | Logline | 1 sentence | Who is this about and what's the central tension? | Act-shape, character arcs, world specifics |
+| 1 | Synopsis | 1 paragraph (~5–7 sentences) | How does the story open, escalate, and resolve thematically? | Where the turning points land; the dramatic shape |
+| 2 | Act-shape | 3 paragraphs (one per act) | What's the load-bearing structure of each act? Where are the major turns? | The specific events; who is on stage |
+
+### Structural tier
+
+| Level | Name | Scope | Question it answers | What it can't answer |
+|---|---|---|---|---|
+| 3 | Spine | 5–10 irreducible events | What are the load-bearing events of the story? | Action/sequel rhythm; subplot weave |
+| 4 | Architecture | 15–25 scenes | What's the dramatic rhythm — value shifts, action/sequel, character POV? | Where each scene happens, who's there, MICE thread weave |
+| 5 | Scene map | 40–60 scenes | What's the full plot inventory with operational metadata (location, timeline, cast)? | Specific goals, conflicts, key dialogue, motifs |
+| 6 | Briefs | All scenes | What is the drafting contract for each scene? | How the prose actually reads |
+| 7 | Draft | All scenes | How does the prose actually read? | (terminal) |
+
+### What changes vs. today
+
+- Levels 0–2 are **new** as first-class artifacts. `project.logline` exists in `storyforge.yaml` today but isn't elaborated/scored as a level. No synopsis or act-shape artifact exists.
+- Levels 3–7 already exist exactly as documented above. The existing `scene.status` column already tracks per-scene level: `spine | architecture | mapped | briefed | drafted | polished`.
+
+---
+
+## Artifact shapes and storage
+
+### Prose tier — single file with three sections
+
+The three prose-tier levels live together in `reference/story-summary.md`. One file rather than three because:
+
+- They're conceptually one thinking unit (story-as-prose at varying granularity).
+- Reviewing them side-by-side is more useful than reviewing them apart.
+- A single file is a single git diff target, simpler to sync, simpler to score.
+- Each section can still be queried/scored independently — the boundary between levels is the `##` heading, not the file boundary.
+
+Proposed format:
+
+```markdown
+# Story summary
+
+<!--
+Edit this file freely. `storyforge sync` keeps the structural tier
+aligned. Each section corresponds to an elaboration level (#225).
+-->
+
+## Logline
+
+One sentence: protagonist + want + obstacle + stakes.
+
+## Synopsis
+
+One paragraph, ~5–7 sentences. Opens, escalates, resolves.
+
+## Act-shape
+
+### Act 1
+What this act bears. Where the inciting incident lands.
+
+### Act 2
+What this act bears. Where the midpoint shifts.
+
+### Act 3
+What this act bears. The climax demand and the resolution.
+```
+
+The `## Logline`, `## Synopsis`, `## Act-shape` headers are load-bearing for parsing. Within each section, prose is free-form (no required sub-structure for logline and synopsis; act-shape gets `### Act N` sub-sections).
+
+### Structural tier — already in CSVs
+
+No new artifacts. The structural levels reuse the existing three-file CSV model:
+
+| Level | Files | Columns added at this level |
+|---|---|---|
+| 3 Spine | `reference/scenes.csv`, `reference/scene-intent.csv`, `reference/story-architecture.md` | `id, seq, title` (scenes); `function` (intent); narrative framing (architecture md) |
+| 4 Architecture | same | `part, pov` (scenes); `action_sequel, emotional_arc, value_at_stake, value_shift, turning_point` (intent) |
+| 5 Scene map | same | `location, timeline_day, time_of_day, duration` (scenes); `characters, on_stage, mice_threads` (intent) |
+| 6 Briefs | + `reference/scene-briefs.csv` | full brief schema (goal, conflict, outcome, etc.); GN columns when applicable |
+| 7 Draft | + `scenes/{id}.md` | `word_count` (scenes); prose in scene files |
+
+The `scenes.csv:status` column already records which level each scene has reached; no new tracking is needed.
+
+### Relationship of `project.logline` (yaml) to `## Logline` (md)
+
+Today the logline lives in `storyforge.yaml`. Proposal: **`reference/story-summary.md § Logline` becomes canonical**; `project.logline` is deprecated as an input. A one-time migration on first run copies the yaml value into the new md if the md is absent. Code that currently reads `project.logline` can be updated incrementally to read from the md, or a small helper in `common.py` can resolve from whichever is present.
+
+This is a backward-compat concern but a small one — `project.logline` is used in only a few places (init, prompt building for elaboration). It's a clean migration.
+
+### Relationship to `reference/story-architecture.md`
+
+This file already exists and contains premise + theme + three-level conflict + ending. It's populated at the spine stage. Two options:
+
+- **A. Keep as-is.** story-summary.md and story-architecture.md coexist. Some overlap in content (the architecture file's premise paragraph is essentially the synopsis), but each has a primary purpose.
+- **B. Merge.** Restructure story-architecture.md to include the logline/synopsis/act-shape sections at the top, with premise/theme/conflict/ending at the bottom. One file.
+
+**Recommendation: A.** Less migration risk, preserves existing code paths, and the conceptual split (summary vs. structural framing) is real — the synopsis tells you what kind of story this is; the architecture tells you how it works thematically. They can both exist.
+
+If overlap becomes a problem in practice, B is straightforward to do later.
+
+---
+
+## Cross-cutting reference artifacts
+
+Bibles, registries, and the voice profile are **not** levels. They are reference data that every level should be consistent with. They live alongside the hierarchy as a separate graph dimension.
+
+The cross-cutting set, as it stands today:
+
+| Artifact | Format | Role |
+|---|---|---|
+| `reference/character-bible.md` | free-form md | Full character documentation |
+| `reference/world-bible.md` | free-form md | Setting + systems |
+| `reference/voice-guide.md` | free-form md | Authorial voice and tone fingerprint |
+| `reference/voice-profile.csv` | pipe-csv | Structured voice constraints (banned words, preferred patterns) |
+| `reference/characters.csv` | pipe-csv | Character registry |
+| `reference/locations.csv` | pipe-csv | Location registry |
+| `reference/mice-threads.csv` | pipe-csv | MICE thread registry |
+| `reference/motif-taxonomy.csv` | pipe-csv | Motif registry |
+| `reference/knowledge.csv` | pipe-csv | Story-fact registry |
+| `reference/values.csv` | pipe-csv | Value registry (for value_at_stake) |
+| `reference/physical-states.csv` | pipe-csv | Per-character physical state |
+| `reference/timeline.md` | free-form md | Chronological reference |
+| `reference/key-decisions.md` | free-form md | Author constraints |
+
+**Relationship to levels (for the future scoring design, #227):**
+
+- **Registries** (the `.csv` files) become the deterministic check against any level's structural data: every `value_at_stake` in scene-intent must be in `values.csv`; every `characters` entry in scene-intent must be in `characters.csv`; every motif in scene-briefs must be in `motif-taxonomy.csv`.
+- **Bibles** (the `.md` files) feed the LLM faithfulness checks: does this scene's brief honor the character voice and constraints in the bible?
+- These checks apply at *every level*, not just one. The logline should respect the character bible's notion of the protagonist; the briefs should respect the voice guide; the draft should respect both.
+
+The bibles and registries themselves can become richer / drift over time — they're living documents. The scoring design (#227) needs to be honest about that: the bibles are reference data *now*, but a discovery at level 7 (draft) might reasonably propagate back to the bible. That's a cascade case (#226), and it crosses the prose/reference boundary in addition to the level boundaries.
+
+---
+
+## Common metadata
+
+The prose tier benefits from a small amount of explicit metadata so the cascade machinery can detect what's derived from what. I propose YAML frontmatter on `story-summary.md`:
+
+```yaml
+---
+logline_updated: 2026-05-24
+synopsis_updated: 2026-05-24
+act_shape_updated: 2026-05-24
+---
+```
+
+A timestamp per section, not per-file. That gives the cascade enough signal to ask "the logline changed after the synopsis — does the synopsis still hold?" without having to compute content hashes.
+
+The structural tier doesn't need explicit metadata — `scenes.csv:status` plus git timestamps on the CSV files give the cascade enough to work with.
+
+(Content hashes per section, derivation graphs, etc. were considered and rejected as over-engineering. The cascade design (#226) can revisit if needed.)
+
+---
+
+## What's deliberately not in this doc
+
+- **Cascade mechanics** — how a change at one level propagates to others. That's #226.
+- **Scoring** — per-level quality rubrics and cross-level fidelity. That's #227.
+- **Prompts** — how each level is generated or expanded. Implementation, after all three research issues land.
+- **CLI surface** — whether `storyforge elaborate logline` becomes a thing, or whether the prose tier is author-only. Cascade design (#226) will surface this.
+
+---
+
+## Open questions / things to push back on
+
+1. **Is the prose tier really three levels, or one?** The proposal treats logline / synopsis / act-shape as three separate scored levels but one artifact. If in practice they always move together (you can't change one without re-doing the others), they might be one level with three views. Test this assumption with real iterations on Ashes once implemented.
+
+2. **Should `story-architecture.md` be absorbed into `story-summary.md`?** Currently kept separate (Option A above). If the duplication between "synopsis" and "premise paragraph" becomes painful, merge.
+
+3. **What about projects that start with a beat sheet, treatment, or outline instead of a logline?** Real-world authoring rarely starts at level 0. The system needs to be hospitable to entering at any level. Implementation concern, not a taxonomy concern — flag and revisit.
+
+4. **Is the spine really a separate level from architecture, or just architecture with fewer scenes?** Today's pipeline treats them distinctly (`status=spine` vs `status=architecture`), and the survey confirmed they answer different questions (irreducible events vs. dramatic rhythm). Keep as separate levels.
+
+5. **GN mode and the prose tier.** The prose tier as proposed makes no medium distinction — a logline is a logline whether the medium is novel or graphic novel. GN-specific structure (page-turn beats, panel rhythm) starts at the structural tier. Confirm with a GN project iteration.
+
+---
+
+## Implementation sketch (informational only)
+
+For when the three research docs converge and we move to building:
+
+- New file template at `templates/reference/story-summary.md`.
+- `storyforge init` writes the file with the project's seed logline.
+- A small `parse_story_summary(project_dir)` helper parses the three sections via `## Logline`, `## Synopsis`, `## Act-shape` headers, returns a dict.
+- `storyforge sync` extended to include `story-summary.md` in its watched paths (though the prose tier doesn't round-trip through CSVs — it's the source of truth for its three levels).
+- Migration: on first run after the change, if `story-summary.md` is absent and `storyforge.yaml:project.logline` is present, scaffold the file with the logline filled in and synopsis/act-shape empty.
+
+Nothing here is committed; this section is just to confirm the taxonomy maps cleanly to an implementation plan when it's time.

--- a/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
@@ -2,45 +2,58 @@
 
 Research design doc for issue [#225](https://github.com/benjaminsnorris/storyforge/issues/225), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
 
-Status: **draft**, expects iteration. Implementation out of scope.
+Status: **revised after review pass** (2026-05-24). The big revisions: the structural tier is now *three* sub-tiers (spine / anchors / manuscript) with discrete artifacts at each, not one CSV with status flags; story-summary.md gains a Theme section and a themes registry; story-architecture.md now points to story-summary.md rather than duplicating content. See the synthesis doc for full context.
 
 ---
 
 ## TL;DR
 
-The proposal is **eight levels in two tiers**, with two new artifacts at the top and the existing pipeline carrying the rest.
+The proposal is **eight levels in three tiers**, with each tier holding its own discrete artifacts so a reader can point at "the spine" or "the architecture" as a single thing.
 
-**Prose tier (free-form, LLM-scored):**
+**Prose tier (free-form, LLM-scored):** all in one file
 - 0. Logline (1 sentence)
 - 1. Synopsis (1 paragraph)
 - 2. Act-shape (3 paragraphs)
+- *Theme* (2–4 sentences) — what the story argues, paired with a themes registry
 
-**Structural tier (CSV-backed, mostly deterministic):**
-- 3. Spine (5–10 events)
-- 4. Architecture (15–25 scenes)
-- 5. Scene map (40–60 scenes with operational metadata)
-- 6. Briefs (drafting contracts)
-- 7. Draft (prose)
+**Structural-anchor tier (discrete CSVs, each a thing you can read):**
+- 3. Spine — `reference/spine.csv` (5–10 irreducible events)
+- 4. Architecture — `reference/architecture.csv` (15–25 anchor scenes with dramatic-skeleton metadata)
 
-Levels 0–2 are new and live in a new file `reference/story-summary.md`. Levels 3–7 already exist; this design reframes them but adds no new schema.
+**Manuscript tier (existing pipeline, scene rows + companions):**
+- 5. Scene map — `reference/scenes.csv` (40–60 scenes — anchors plus interstitial scenes)
+- 6. Briefs — `reference/scene-briefs.csv` (same scene IDs, status `briefed`)
+- 7. Draft — `scenes/{id}.md` files (same scene IDs, prose)
 
-The bibles, registries, and voice profile sit **alongside** the hierarchy as cross-cutting reference data, not above or within it.
+Two new reference columns make the level boundaries explicit:
+- `spine_event` on `architecture.csv` — each architecture scene names its parent spine event.
+- `architecture_scene` on `scenes.csv` (optional) — each manuscript scene either is, or sits adjacent to, an architecture anchor; or it's purely interstitial.
+
+The bibles, registries, and voice profile sit **alongside** the hierarchy as cross-cutting reference data. The themes registry joins them.
 
 ---
 
-## Why eight levels and not four, or twelve
+## Why eight levels in three tiers
 
-A boundary is worth a level only if it has a real semantic discontinuity — a question that the level below can answer and the level above cannot. The eight proposed boundaries each pass that test; collapsing any of them would either hide a real gap (e.g., merging spine into architecture loses the irreducible-events question) or paper over a quality leap that needs its own scoring rubric.
+A boundary is worth a level only if it has a real semantic discontinuity — a question that the level below can answer and the level above cannot. The eight boundaries each pass that test.
 
-The boundary I considered hardest is **1 → 2 (synopsis → act-shape)**. They're both prose summaries. The argument for keeping them separate: a one-paragraph synopsis answers "what kind of story is this?" while a three-paragraph act-shape answers "where are the turning points and how does each act bear its load?" The act-shape names the load-bearing structure that the synopsis only gestures at. Two different questions, two different levels.
+The **three tiers** come from a different observation: levels within a tier share artifact identity, but levels across tiers expand the row count.
 
-A boundary I considered adding but rejected: between architecture and scene-map at "draft scene order." The current architecture stage already produces ordered scenes, so there's no real semantic gap there — the scene-map stage adds *operational* metadata (location, timeline, cast), not new structural decisions.
+- Prose tier: three levels, one file, three sections. No row expansion (it's prose).
+- Structural-anchor tier: two levels, two CSVs. Spine has 5–10 events; architecture has 15–25 anchor scenes. Each architecture row names its parent spine event.
+- Manuscript tier: three levels, shared row identity. The scene map has 40–60 rows; briefs and drafts attach more data to the same rows. No further row expansion within the tier.
+
+The tier boundaries are where new artifacts get created and rows multiply. Within a tier, rows can be enriched without being duplicated.
+
+The boundary I considered hardest is still **1 → 2 (synopsis → act-shape)**. They're both prose summaries. The argument for keeping them separate: a one-paragraph synopsis answers "what kind of story is this?" while a three-paragraph act-shape answers "where are the turning points and how does each act bear its load?" Two different questions, two different levels — but they live in the same artifact.
+
+The boundary I had wrong in the original draft was **4 → 5 (architecture → scene map)**. The original said scene-map "adds operational metadata, not new structural decisions." That was incomplete. The scene map *expands* the scene count — it adds interstitial scenes (transitions, breathers, B-story, character moments) that aren't on the architectural skeleton. Architecture is the dramatic skeleton; scene map is the full manuscript inventory. They belong to different tiers because the row counts differ.
 
 ---
 
 ## The level taxonomy
 
-### Prose tier
+### Prose tier (all in `reference/story-summary.md`)
 
 | Level | Name | Scope | Question it answers | What it can't answer |
 |---|---|---|---|---|
@@ -48,20 +61,34 @@ A boundary I considered adding but rejected: between architecture and scene-map 
 | 1 | Synopsis | 1 paragraph (~5–7 sentences) | How does the story open, escalate, and resolve thematically? | Where the turning points land; the dramatic shape |
 | 2 | Act-shape | 3 paragraphs (one per act) | What's the load-bearing structure of each act? Where are the major turns? | The specific events; who is on stage |
 
-### Structural tier
+A fourth section, **Theme** (2–4 sentences), names what the story argues. It's not a numbered level (it doesn't elaborate downward in the same way), but it sits in the same file alongside the prose-tier sections and is queryable for scoring.
 
-| Level | Name | Scope | Question it answers | What it can't answer |
+### Structural-anchor tier (each its own CSV)
+
+| Level | Name | Artifact | Scope | Question it answers |
 |---|---|---|---|---|
-| 3 | Spine | 5–10 irreducible events | What are the load-bearing events of the story? | Action/sequel rhythm; subplot weave |
-| 4 | Architecture | 15–25 scenes | What's the dramatic rhythm — value shifts, action/sequel, character POV? | Where each scene happens, who's there, MICE thread weave |
-| 5 | Scene map | 40–60 scenes | What's the full plot inventory with operational metadata (location, timeline, cast)? | Specific goals, conflicts, key dialogue, motifs |
-| 6 | Briefs | All scenes | What is the drafting contract for each scene? | How the prose actually reads |
-| 7 | Draft | All scenes | How does the prose actually read? | (terminal) |
+| 3 | Spine | `reference/spine.csv` | 5–10 rows | What are the load-bearing events of the story? |
+| 4 | Architecture | `reference/architecture.csv` | 15–25 rows, each with `spine_event` → spine.csv | What's the dramatic skeleton — value shifts, action/sequel, POV at each anchor? |
+
+The architecture scenes are *not* a subset of manuscript scenes — they're a separate artifact representing the dramatic skeleton. When the author advances to scene map, the architecture rows seed scenes.csv (each architecture scene becomes a manuscript scene with an `architecture_scene` self-reference) and the author elaborates from there.
+
+### Manuscript tier (shared scene-row identity)
+
+| Level | Name | Artifact | Scope | Question it answers |
+|---|---|---|---|---|
+| 5 | Scene map | `reference/scenes.csv` + `reference/scene-intent.csv` | 40–60 rows, each with optional `architecture_scene` → architecture.csv | What's the full plot inventory with operational metadata? |
+| 6 | Briefs | `reference/scene-briefs.csv` | Same row IDs as scenes.csv, status `briefed` | What is the drafting contract for each scene? |
+| 7 | Draft | `scenes/{id}.md` | Same row IDs, prose | How does it actually read? |
+
+The status column on scenes.csv (`mapped | briefed | drafted | polished`) tracks per-scene level within this tier. No row expansion within the manuscript tier.
 
 ### What changes vs. today
 
-- Levels 0–2 are **new** as first-class artifacts. `project.logline` exists in `storyforge.yaml` today but isn't elaborated/scored as a level. No synopsis or act-shape artifact exists.
-- Levels 3–7 already exist exactly as documented above. The existing `scene.status` column already tracks per-scene level: `spine | architecture | mapped | briefed | drafted | polished`.
+- **Prose tier**: entirely new as first-class artifacts. `project.logline` exists in `storyforge.yaml` today but isn't elaborated/scored as a level; no synopsis, act-shape, or theme artifact exists.
+- **Structural-anchor tier**: spine and architecture get their own CSVs. Today both are tracked as `status` flags on `scenes.csv`, which conflates "5-10 spine events" and "15-25 architecture beats" into the same row set. This change separates them into discrete artifacts.
+- **Manuscript tier**: existing pipeline, no structural change. The `architecture_scene` column on scenes.csv is new; it's optional (purely interstitial map scenes leave it empty).
+
+Migration for existing projects: a one-time `cmd_migrate` step extracts spine events from the current `status=spine` rows into `spine.csv`, copies architecture-status rows into `architecture.csv` (and removes them from scenes.csv if they aren't yet at map stage), and rewrites `spine_event` / `architecture_scene` references where derivable. For Ashes specifically, this is mechanical because the project has 24 architecture-status scenes — the author or migrate identifies the 5–10 that should be the spine and the rest become architecture rows.
 
 ---
 
@@ -104,23 +131,36 @@ What this act bears. Where the midpoint shifts.
 
 ### Act 3
 What this act bears. The climax demand and the resolution.
+
+## Theme
+
+Two to four sentences naming what the story is arguing — its
+central question or claim. Internal use, not pitch material.
+Themes that recur as concrete imagery should be registered in
+`reference/themes.csv` and tagged per-scene via the `theme_threads`
+column on `scene-intent.csv`.
 ```
 
-The `## Logline`, `## Synopsis`, `## Act-shape` headers are load-bearing for parsing. Within each section, prose is free-form (no required sub-structure for logline and synopsis; act-shape gets `### Act N` sub-sections).
+The `## Logline`, `## Synopsis`, `## Act-shape`, `## Theme` headers are load-bearing for parsing. Within each section, prose is free-form (no required sub-structure for logline / synopsis / theme; act-shape gets `### Act N` sub-sections).
 
-### Structural tier — already in CSVs
+### Structural-anchor tier — two new CSVs
 
-No new artifacts. The structural levels reuse the existing three-file CSV model:
+| Level | Artifact | Columns | Notes |
+|---|---|---|---|
+| 3 Spine | `reference/spine.csv` | `id, seq, title, function, part` | 5–10 rows. Each row is an irreducible story event. `part` partitions events into acts so the architecture tier can spread anchors proportionally. |
+| 4 Architecture | `reference/architecture.csv` | `id, seq, title, part, pov, spine_event, action_sequel, emotional_arc, value_at_stake, value_shift, turning_point` | 15–25 rows. `spine_event` references `spine.csv.id` (every architecture row names its parent spine event). Carries the dramatic-skeleton metadata that today lives on scenes.csv at status `architecture`. |
+
+A derived human-readable view is rendered as `reference/spine.md` and `reference/architecture.md` by `scenes-export`, just as `scenes-review.md` is rendered today. The CSV is the substrate; the .md is the pointable artifact.
+
+### Manuscript tier — existing files, one new column
 
 | Level | Files | Columns added at this level |
 |---|---|---|
-| 3 Spine | `reference/scenes.csv`, `reference/scene-intent.csv`, `reference/story-architecture.md` | `id, seq, title` (scenes); `function` (intent); narrative framing (architecture md) |
-| 4 Architecture | same | `part, pov` (scenes); `action_sequel, emotional_arc, value_at_stake, value_shift, turning_point` (intent) |
-| 5 Scene map | same | `location, timeline_day, time_of_day, duration` (scenes); `characters, on_stage, mice_threads` (intent) |
-| 6 Briefs | + `reference/scene-briefs.csv` | full brief schema (goal, conflict, outcome, etc.); GN columns when applicable |
-| 7 Draft | + `scenes/{id}.md` | `word_count` (scenes); prose in scene files |
+| 5 Scene map | `reference/scenes.csv` + `reference/scene-intent.csv` | All non-anchor columns on scenes.csv (`location, timeline_day, time_of_day, duration`, etc.); MICE / characters / on_stage on intent; new column `architecture_scene` on scenes.csv references `architecture.csv.id` (optional — interstitial scenes leave it empty) |
+| 6 Briefs | + `reference/scene-briefs.csv` | Full brief schema (goal, conflict, outcome, etc.); GN columns when applicable. Same row IDs as scenes.csv. |
+| 7 Draft | + `scenes/{id}.md` | `word_count` on scenes.csv; prose in scene files. Same row IDs. |
 
-The `scenes.csv:status` column already records which level each scene has reached; no new tracking is needed.
+The status column on scenes.csv tracks per-scene progress within the manuscript tier: `mapped | briefed | drafted | polished`. The earlier statuses (`spine`, `architecture`) are no longer used — those rows live in their own CSVs now.
 
 ### Relationship of `project.logline` (yaml) to `## Logline` (md)
 
@@ -130,14 +170,15 @@ This is a backward-compat concern but a small one — `project.logline` is used 
 
 ### Relationship to `reference/story-architecture.md`
 
-This file already exists and contains premise + theme + three-level conflict + ending. It's populated at the spine stage. Two options:
+This file already exists and contains premise + theme + three-level conflict + ending. Most of that content overlaps with what now belongs in `story-summary.md` (premise ≈ synopsis; theme moves into the Theme section). The bits unique to story-architecture.md are the three-level conflict framing and the ending.
 
-- **A. Keep as-is.** story-summary.md and story-architecture.md coexist. Some overlap in content (the architecture file's premise paragraph is essentially the synopsis), but each has a primary purpose.
-- **B. Merge.** Restructure story-architecture.md to include the logline/synopsis/act-shape sections at the top, with premise/theme/conflict/ending at the bottom. One file.
+**Revision: story-architecture.md becomes a thin pointer + the unique content.** Specifically:
 
-**Recommendation: A.** Less migration risk, preserves existing code paths, and the conceptual split (summary vs. structural framing) is real — the synopsis tells you what kind of story this is; the architecture tells you how it works thematically. They can both exist.
+- At the top, link to `story-summary.md` as the canonical source for logline / synopsis / act-shape / theme.
+- Keep only the content that doesn't live anywhere else: the three-level conflict structure and the ending.
+- Do not duplicate content. When the synopsis changes, the architecture file is unaffected (because the architecture file doesn't carry the synopsis anymore).
 
-If overlap becomes a problem in practice, B is straightforward to do later.
+This drops the "two files describe the same content" maintenance burden and makes each file's role clear.
 
 ---
 
@@ -156,7 +197,8 @@ The cross-cutting set, as it stands today:
 | `reference/characters.csv` | pipe-csv | Character registry |
 | `reference/locations.csv` | pipe-csv | Location registry |
 | `reference/mice-threads.csv` | pipe-csv | MICE thread registry |
-| `reference/motif-taxonomy.csv` | pipe-csv | Motif registry |
+| `reference/motif-taxonomy.csv` | pipe-csv | Motif registry — concrete recurring elements (images, objects, sounds, phrases) that carry thematic weight |
+| `reference/themes.csv` | pipe-csv (new) | Theme registry — abstract questions/arguments the story makes. Referenced by `theme_threads` on scene-intent.csv. See note below on themes vs motifs. |
 | `reference/knowledge.csv` | pipe-csv | Story-fact registry |
 | `reference/values.csv` | pipe-csv | Value registry (for value_at_stake) |
 | `reference/physical-states.csv` | pipe-csv | Per-character physical state |
@@ -171,6 +213,8 @@ The cross-cutting set, as it stands today:
 
 The bibles and registries themselves can become richer / drift over time — they're living documents. The scoring design (#227) needs to be honest about that: the bibles are reference data *now*, but a discovery at level 7 (draft) might reasonably propagate back to the bible. That's a cascade case (#226), and it crosses the prose/reference boundary in addition to the level boundaries.
 
+**Themes vs motifs** — a note since this is a new registry. Themes are *abstract* questions or claims the story is making ("what does it mean to remember?", "power corrupts"). Motifs are *concrete* recurring elements that carry thematic weight (a specific image, object, phrase, sound). The relationship is many-to-many: one theme can be carried by several motifs; one motif can serve several themes. They're kept as separate registries because conflating them loses information — `legibility` is a theme but not a motif; `wire spectacles` is a motif that might serve `legibility` as one of its themes. Per-scene tracking lives in two columns: `theme_threads` on scene-intent.csv (which abstract concerns this scene engages) and `motifs` on scene-briefs.csv (which concrete recurring elements appear in this scene).
+
 ---
 
 ## Common metadata
@@ -182,14 +226,13 @@ The prose tier benefits from a small amount of explicit metadata so the cascade 
 logline_updated: 2026-05-24
 synopsis_updated: 2026-05-24
 act_shape_updated: 2026-05-24
+theme_updated: 2026-05-24
 ---
 ```
 
-A timestamp per section, not per-file. That gives the cascade enough signal to ask "the logline changed after the synopsis — does the synopsis still hold?" without having to compute content hashes.
+A timestamp per section, not per-file. That gives the cascade enough signal to ask "the logline changed after the synopsis — does the synopsis still hold?"
 
-The structural tier doesn't need explicit metadata — `scenes.csv:status` plus git timestamps on the CSV files give the cascade enough to work with.
-
-(Content hashes per section, derivation graphs, etc. were considered and rejected as over-engineering. The cascade design (#226) can revisit if needed.)
+For the structural tiers, the discrete artifacts (`spine.csv`, `architecture.csv`, `scenes.csv` + companions) carry their own git timestamps. The cascade combines mtime with a content-hash cache (see the cascade synthesis) to distinguish typo fixes from semantic edits.
 
 ---
 
@@ -206,11 +249,11 @@ The structural tier doesn't need explicit metadata — `scenes.csv:status` plus 
 
 1. **Is the prose tier really three levels, or one?** The proposal treats logline / synopsis / act-shape as three separate scored levels but one artifact. If in practice they always move together (you can't change one without re-doing the others), they might be one level with three views. Test this assumption with real iterations on Ashes once implemented.
 
-2. **Should `story-architecture.md` be absorbed into `story-summary.md`?** Currently kept separate (Option A above). If the duplication between "synopsis" and "premise paragraph" becomes painful, merge.
+2. **~~Should story-architecture.md be absorbed into story-summary.md?~~** *Resolved: architecture file becomes a thin pointer to summary + only the unique content (three-level conflict, ending). No duplication.*
 
 3. **What about projects that start with a beat sheet, treatment, or outline instead of a logline?** Real-world authoring rarely starts at level 0. The system needs to be hospitable to entering at any level. Implementation concern, not a taxonomy concern — flag and revisit.
 
-4. **Is the spine really a separate level from architecture, or just architecture with fewer scenes?** Today's pipeline treats them distinctly (`status=spine` vs `status=architecture`), and the survey confirmed they answer different questions (irreducible events vs. dramatic rhythm). Keep as separate levels.
+4. **~~Is the spine really a separate level from architecture, or just architecture with fewer scenes?~~** *Resolved: separate. They live in different artifacts (`spine.csv` and `architecture.csv`) and the architecture rows explicitly reference their parent spine event.*
 
 5. **GN mode and the prose tier.** The prose tier as proposed makes no medium distinction — a logline is a logline whether the medium is novel or graphic novel. GN-specific structure (page-turn beats, panel rhythm) starts at the structural tier. Confirm with a GN project iteration.
 
@@ -220,10 +263,12 @@ The structural tier doesn't need explicit metadata — `scenes.csv:status` plus 
 
 For when the three research docs converge and we move to building:
 
-- New file template at `templates/reference/story-summary.md`.
-- `storyforge init` writes the file with the project's seed logline.
-- A small `parse_story_summary(project_dir)` helper parses the three sections via `## Logline`, `## Synopsis`, `## Act-shape` headers, returns a dict.
-- `storyforge sync` extended to include `story-summary.md` in its watched paths (though the prose tier doesn't round-trip through CSVs — it's the source of truth for its three levels).
-- Migration: on first run after the change, if `story-summary.md` is absent and `storyforge.yaml:project.logline` is present, scaffold the file with the logline filled in and synopsis/act-shape empty.
+- New file templates: `templates/reference/story-summary.md`, `templates/reference/themes.csv`, `templates/reference/spine.csv`, `templates/reference/architecture.csv`.
+- `storyforge init` writes story-summary.md with the project's seed logline, and creates empty spine.csv / architecture.csv / themes.csv with their headers.
+- A small `parse_story_summary(project_dir)` helper parses the four sections (Logline / Synopsis / Act-shape / Theme) via `## ` headers, returns a dict.
+- `storyforge sync` extended to render derived markdown for the new structural-anchor artifacts: `reference/spine.md` and `reference/architecture.md` (sibling of the existing `scenes-review.md`).
+- Migrations:
+  - On first run, if story-summary.md is absent and `storyforge.yaml:project.logline` is present, scaffold the file with the logline filled in and synopsis/act-shape/theme empty.
+  - For existing projects whose spine and architecture rows currently live as `status=spine` / `status=architecture` on scenes.csv: `cmd_migrate` extracts spine rows into spine.csv (preserving IDs), copies architecture rows into architecture.csv, and rewrites references where derivable. The author confirms or adjusts the spine event count.
 
 Nothing here is committed; this section is just to confirm the taxonomy maps cleanly to an implementation plan when it's time.

--- a/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-levels-design.md
@@ -259,6 +259,20 @@ For the structural tiers, the discrete artifacts (`spine.csv`, `architecture.csv
 
 ---
 
+## How each level supports iteration
+
+Defining the levels alone doesn't make the system useful for iteration — the author also needs ways to (a) tell whether *this version* of a level is any good and (b) decide between *multiple candidates* at the same level. The scoring doc handles both, but worth noting the contract here so the levels make sense:
+
+- **Per-level scoring is split into floor and ceiling.** Floor checks ask "is this level complete and consistent?" — they're mostly deterministic and they're what `storyforge score --level N` reports. Ceiling sketches name what separates passable from excellent at the level; they inform LLM prompts and give the author shared language for what iteration is reaching for. The floor catches broken; the ceiling targets great. Full per-level rubrics live in the [scoring doc](2026-05-24-elaboration-scoring-design.md).
+
+- **`storyforge score --compare` lets the author iterate across alternatives.** When the author drafts three loglines, two competing synopses, or alternative spines, the comparison primitive renders a multi-axis report showing what each candidate does best — without declaring a winner. The author decides; the system surfaces. Most useful at the prose tier and at the spine level; less common at the manuscript-tier levels where full-artifact alternatives are rare.
+
+- **Boundaries between levels use diff + verdict, not score.** Per the synthesis: when an upper level changes and the lower level may be out of date, the LLM produces a structured diff, and the verdict is recorded (proposed by the LLM in `full` coaching, by the author in `strict`). The verdict persists; the boundary isn't re-flagged unless content changes materially.
+
+These three mechanisms together — floor/ceiling at each level, comparison across alternatives, diff+verdict across boundaries — are what the level taxonomy is in service of. The taxonomy without those scoring mechanisms is just an organizational chart.
+
+---
+
 ## Implementation sketch (informational only)
 
 For when the three research docs converge and we move to building:

--- a/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
@@ -174,6 +174,40 @@ The originals encoded three-act, Swain action/sequel, McKee value shifts, and We
 
 **Revision:** drop the `custom` option for v1. Author judgment (PR review): too much work for too little value at this stage. v1 assumes three-act throughout. Non-three-act stories can use whatever scoring axes apply to them and ignore the rest via the score-overrides mechanism. If specific bundled checks (kishōtenketsu, mosaic) emerge as a real need, they're added in a follow-up.
 
+### Floor vs ceiling: making the rubric useful for iteration
+
+A self-critique of the original scoring design (after the four-agent review): the proposed rubrics tested *completeness* at each level, not *quality*. A complete logline with all four elements present could still be flat; the rubric would call it passing. The scoring would catch broken states but not push toward excellent ones.
+
+**Revision: each level now has two rubrics.**
+
+- **Floor checks** — does this level exist, complete, and consistent? Mostly deterministic. Failure means the level is missing pieces or broken. This is the original rubric, with the noise culled (see below).
+- **Ceiling sketch** — what separates *passable* from *excellent* at this level? Descriptive guidance, not gates. Examples: "uses specific nouns rather than generic ones," "shows causation between events not just sequence," "ends most scenes with a question the next one answers." The ceiling sketches inform LLM prompts (v2+) and give the author language for what iteration is reaching for.
+
+The full per-level ceilings live in the scoring doc. They're not separate scored axes in v1 — they're how the existing axes get framed and what the LLM judges should be reaching for.
+
+### Comparison primitive: helping iterate across alternatives
+
+Another gap the original scoring design left: the rubrics grade one artifact at a time. Real iteration is usually "I have three candidate loglines, which fits this story best?" Grading each independently can't answer that — and a fix-the-low-axes loop biases toward axis-satisficing prose.
+
+**Revision: add a comparison primitive.**
+
+`storyforge score --compare candidate1 candidate2 [candidate3] [candidate4]` produces a multi-axis comparison report showing what each candidate does best, **without declaring a winner**. The author decides. The "no winner" rule is intentional: an LLM-declared best candidate would re-create the gradient-toward-LLM-taste problem the diff+verdict already solved.
+
+Most useful at the prose tier (logline / synopsis / theme statement) where authors iterate on alternative drafts. Also useful for candidate spines. Less common at deeper structural levels.
+
+Ships in v1 with deterministic floor axes filled in; LLM ceiling axes ship in v2.
+
+### Cull the extraneous
+
+The original per-level rubrics included four checks that the scoring-design review identified as noise:
+
+- **"Genre/tone legible" at logline** — most great loglines convey genre through specific imagery, not tagging. The LLM check is fuzzy and produces noise.
+- **"Stays at story abstraction" at synopsis** — punishes good writing; a synopsis with one vivid scene-level detail is often better than fully abstract.
+- **"Theme is implicit in the shape" at act-shape** — too vague to operationalize; the themes dimension is now first-class, so we don't need a fuzzy theme check here.
+- **"Action/sequel alternates" at architecture (strict)** — strict alternation produces mechanical pacing. Softened to "both action and sequel scenes present (at least 25% of each)" — confirms presence without dictating rhythm.
+
+Also dropped: "Events spread roughly evenly across acts" at spine (genre-bound) and "Scene types are diverse" at scene map (genre-bound per existing choosiness pass).
+
 ### Demote the causal-chain LLM check
 
 The original scoring doc listed "Causal chain holds (event N enables event N+1)" as a level-3 LLM check. The craft skeptic was right: postmodern, magic-realist, mosaic, and theme-driven structures intentionally violate causal chains. An LLM saying "event 3 doesn't lead to event 4" might be confused or might be right — but the cost of false positives here is high.
@@ -232,7 +266,8 @@ The engineering review's "v1 cut" landed on roughly what I'd commit to:
 - Migration of existing `status=spine` and `status=architecture` rows from scenes.csv into their new discrete CSVs (`cmd_migrate`).
 - A parser in `common.py` that reads story-summary.md's four sections (Logline / Synopsis / Act-shape / Theme).
 - New columns: `spine_event` (on architecture.csv, required), `architecture_scene` (on scenes.csv, optional), `theme_threads` (on scene-intent.csv, optional).
-- `storyforge score --level N` extension that emits deterministic quality + registry checks for levels 3–6 (generalizing existing `hone.py` + `structural.py` logic).
+- `storyforge score --level N` extension that emits deterministic *floor checks* per level (length, presence, registry conformance, coverage). Per-level *ceiling sketches* are encoded as guidance for LLM prompts and ship empty in v1.
+- `storyforge score --compare candidate1 candidate2 [candidate3] [candidate4]` — new comparison primitive that produces a multi-axis comparison report (deterministic axes in v1; LLM ceiling axes filled in at v2). Never declares an overall winner — the author decides.
 - The orphan-registry check generalized across all structural levels, including the new themes registry.
 - `working/scoring-overrides.csv` and the parser for it.
 - `working/scoring-verdicts.csv` and its parser (the diff+verdict persistence file).

--- a/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
@@ -1,0 +1,258 @@
+# Review synthesis and design revisions
+
+Final design doc for umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224). Companion to the three research docs already on this branch — this one rolls in the cross-cutting feedback from a four-agent review pass and supersedes the originals where they disagree.
+
+The originals remain useful as the *pre-review* artifact (and as detailed argument for the parts that survived); this doc is the *post-review* proposal and should drive implementation when the time comes.
+
+Status: **proposal**, ready for author sign-off.
+
+---
+
+## The review, in one paragraph
+
+Four agents read the three originals from different angles: implementation cost / feasibility, author workflow / friction, story-craft skepticism, and voice / authorial distinctiveness. They converged surprisingly hard. The praise was unanimous on a small set of design principles (blast radius / cost visibility, detection-deterministic-resolution-creative, don't-compose, choosiness). The critique was also unanimous on a different small set — each angle vocalized it differently, but every reviewer pointed at: *the design pressures the author toward compliance with a rubric the author can't override*. Multiple specific mechanisms drive that pressure, listed below.
+
+The revisions in this doc address the consensus critique without touching the praise list.
+
+---
+
+## What carried through unchanged
+
+The originals' load-bearing decisions all survive review:
+
+- **Eight levels in two tiers** (3 prose-tier, 5 structural-tier). The closest-call boundary (synopsis ↔ act-shape) earns its keep.
+- **Three motions** — forward, upward refactor, lateral re-propagation.
+- **Three score families** — per-level quality, cross-level fidelity, cross-cutting consistency.
+- **Don't compose scores. Show every axis.**
+- **Detection-deterministic, resolution-creative.**
+- **Be choosy** — explicit keep / on-demand / skip pass on every score.
+- **Blast radius / cost visibility before any cascade fires.**
+- **Lateral re-propagation never silently overwrites author work.**
+- **LLM checks confined to on-demand, never in the commit hook.**
+
+Don't relitigate these. They held.
+
+---
+
+## The big move: faithfulness as diff, not score
+
+This is the most important change. It addresses voice, craft-skeptic concerns, and the author-override gap in a single restructure.
+
+**The problem.** The originals proposed an "upward faithfulness" score (0.0–1.0) at each level boundary, LLM-judged. The voice reviewer named the failure mode precisely: an LLM can't tell *drift* (the lower level departed in error) from *discovery* (the lower level found something the upper level didn't know yet). A number that conflates the two will be acted on — and the action will be reconciliation toward the LLM's idea of "faithful," which is consensus prose at the level above. The system will systematically push authorial discovery back into convention.
+
+**The change.** Replace the upward-faithfulness *score* with an upward-faithfulness *diff*. At each boundary, when triggered:
+
+1. The system surfaces the two sides as a structured comparison — what the upstream level says about this story unit, what the downstream level is doing.
+2. The author records a verdict: `correct=upstream`, `correct=downstream`, `both are right`, or `needs work`. A one-line rationale is optional but encouraged.
+3. The verdict persists across runs in `working/scoring-verdicts.csv` (scene/unit + boundary + verdict + rationale + timestamp).
+4. The system does not re-flag a boundary where a verdict is recorded unless one side has materially changed since the verdict.
+
+**What this preserves.** The LLM is still doing semantic comparison — the same prompt, the same cost. We just stop emitting a number for the comparison's result.
+
+**What this changes.** The author's judgment is a first-class output, not a workaround. The path of least resistance is to read the comparison and decide, not to make the LLM happier. Story discovery is protected from being talked back into consensus.
+
+**Where scores still apply.**
+- *Deterministic* coverage checks at structural boundaries still emit scores (these are objective: does every spine event have descendants, do all values resolve to the registry). They're cheap, the failure mode is unambiguous, and the fix is concrete.
+- *Per-level quality* still emits scores for deterministic axes (length, presence of required fields, registry conformance). For LLM-judged quality axes (the prose-tier ones at levels 0–2), use the diff-and-verdict mechanism too.
+- *Bible consistency* uses the diff-and-verdict mechanism. Two sources disagree — which is correct?
+
+The two-table reporting view changes accordingly: deterministic axes get a number; LLM-judged axes get a "verdict pending / accepted / disagreed" status.
+
+---
+
+## Author affordances (three new mechanisms)
+
+### 1. Score overrides
+
+A `working/scoring-overrides.csv` file (pipe-delimited, sibling of `score-history.csv`) where the author marks any score finding as `considered_accepted` with a one-line rationale and a timestamp. The score continues to surface, but with the marker — and the cascade / quality-gate logic ignores it for refusal purposes.
+
+```
+scope|axis|finding_id|verdict|rationale|recorded_at
+the-blank-page|economy_clarity|low-density|accepted|sparse is intentional here|2026-05-24
+act1-sc12|brief_fidelity|missing-key-dialogue|accepted|the dialogue moved offstage on purpose|2026-05-24
+```
+
+Verdicts are scoped tightly: a verdict on `act1-sc12 / brief_fidelity / missing-key-dialogue` only suppresses that specific finding. If a different brief-fidelity finding appears for the same scene, it surfaces normally.
+
+### 2. Drafting mode
+
+A project-level mode that suspends cascade and pre-commit quality checks during active drafting. Two surfaces:
+
+- `STORYFORGE_DRAFTING=1 git commit ...` for one-off bypass.
+- `project.cascade_mode: live | drafting | paused` in `storyforge.yaml`. `drafting` suspends cascade in the hook; `paused` suspends both cascade and sync's quality gates entirely.
+
+When in drafting mode, the hook still runs sync (CSV↔MD) — that's the bare-minimum integrity check — but cascade detection is silent. The author resumes by changing the mode back to `live` and running `storyforge cascade --check` explicitly.
+
+This is the "I just want to write" override. Without it, the system trains authors to commit less often, which breaks everything else.
+
+### 3. Acceptance thresholds with persistence
+
+Each axis has a project-configurable acceptance threshold (defaulted loosely). An `accepted_at` field on `score-history.csv` lets the author declare "this level is done" at any score. The system stops nagging about that axis until either (a) the underlying content materially changes, or (b) the author explicitly re-opens it.
+
+```yaml
+# storyforge.yaml
+scoring:
+  acceptance_thresholds:
+    economy_clarity: 0.7   # below this it's surfaced, above it it's just shown
+    brief_fidelity: 0.6
+    # ... per-axis defaults; project can override
+  acceptance_strategy: loose  # loose | strict | manual
+```
+
+`loose` defaults applied automatically when scores cross threshold; `strict` requires explicit author confirmation; `manual` never auto-accepts (author marks everything individually).
+
+---
+
+## Cascade revisions
+
+### Neutralize the language
+
+"Stale upward" → "no longer in agreement." "Synopsis may no longer reflect the current spine" → "synopsis and spine are no longer aligned; reconcile direction TBD." "Drift" stays as the technical term (it's precise) but the *suggested action* phrasing becomes symmetric: not "review the synopsis against the current spine" but "reconcile synopsis with spine (either direction)."
+
+The cascade doc's existing "Suggested next actions" framing gets removed. The drift report enumerates *what is out of alignment*, not *what should be done about it*. The author (or Claude in session) decides direction.
+
+### Cap upward recursion
+
+The original cascade doc had a quietly dangerous line: "the new upstream may itself imply further upstream changes — the cascade recurses upward through the drift report." A single creative insight at the brief level could drag the author through logline → synopsis → act-shape → spine reconciliation in one session.
+
+**Revision: cascade goes up at most one level per `cascade --semantic` invocation.** If the author updates the spine after reconciling it with architecture, *then* the next cascade run can surface synopsis-spine drift. Recursive upward propagation requires an explicit `--recurse` flag or repeated runs.
+
+This keeps the author in control of how deep a refactor goes.
+
+### Defer the `storyforge cascade` command
+
+The cascade command as designed is ~5 subcommands and a CLI taxonomy. Ship it incrementally:
+
+- **v1: `storyforge score --drift`** — read-only drift report from the existing scoring machinery. No new command. Output is the structured report at `working/cascade-drift.md`.
+- **v2: `storyforge cascade --semantic`** — adds LLM-driven semantic detection on top of the deterministic skeleton.
+- **v3: `storyforge cascade apply ...`** — anything that *modifies* content. Out of scope until v1/v2 have been in author hands long enough to validate the surface.
+
+### Drift detection: mtime AND content hash
+
+The originals proposed mtime-only drift detection. The workflow reviewer caught the problem: a typo in a brief updates the mtime, the cascade flags downstream drift, the author commits a one-character fix and the hook refuses.
+
+**Revision:** drift signal is `mtime_changed AND content_hash_differs`. Store last-seen content hashes per file in `working/.cascade-state` (gitignored). A typo touches mtime but not the hash — no drift. A meaningful edit touches both. The over-engineering objection from the original cascade doc was wrong; this is a one-file state cache, not a graph of derivations.
+
+---
+
+## Scoring revisions
+
+### Add an explicit thematic axis
+
+The story-craft reviewer was right: no rubric across eight levels asks "is this story about something?" Motif registries are vehicles for theme, not theme itself.
+
+**Revision: add `## Theme` as a fourth section in `reference/story-summary.md`** — alongside Logline, Synopsis, Act-shape. Two-to-four sentences naming what the story argues. The argument is internal-use only (it's not pitch material) and explicit.
+
+Scoring axes on the theme section:
+- *Presence* — deterministic. Empty section → finding.
+- *Engagement at lower levels* — LLM, on-demand. Do the briefs and drafts engage with this theme, or does it disappear after level 0?
+
+This is the smallest possible addition that gives the system a place to ask the most important story question.
+
+### Genre / structure escape hatch
+
+The originals encoded three-act, Swain action/sequel, McKee value shifts, and Weiland brief contracts as universal rules. They're one tradition (commercial American screenwriting + popular novel craft). They don't fit kishōtenketsu, mosaic, fragmented narrative, plotless literary, picaresque, or vignette-driven work.
+
+**Revision:** add `project.structure` field to `storyforge.yaml`:
+
+```yaml
+project:
+  structure: three-act        # three-act | four-act | kishōtenketsu | mosaic | episodic | custom
+```
+
+When `structure: custom`, the structure-specific scoring checks (action/sequel alternation, three-act value-shift distribution, "events spread evenly across acts") are *disabled*. The author opts in to whatever subset they want via a `scoring.enabled_checks` list. Default for novel mode is `three-act`; default for graphic-novel is `three-act` too unless author specifies.
+
+Other structures get bundled checks (e.g., `kishōtenketsu` enables a four-act value-shift check with a specific pattern). Bundled checks are out of scope for v1; the escape hatch (`custom`) is what ships.
+
+### Demote the causal-chain LLM check
+
+The original scoring doc listed "Causal chain holds (event N enables event N+1)" as a level-3 LLM check. The craft skeptic was right: postmodern, magic-realist, mosaic, and theme-driven structures intentionally violate causal chains. An LLM saying "event 3 doesn't lead to event 4" might be confused or might be right — but the cost of false positives here is high.
+
+**Revision:** move causal-chain to an *advisory* tier in the level-3 quality report. It still runs (on demand, with `--advisory`), but its findings are labeled `advisory` and excluded from acceptance thresholds and quality gates. The author can choose to look at them.
+
+### Bible / voice consistency: neutral framing
+
+Originals framed bible checks as "does the prose honor the bible?" — putting the bible in the authority position. For character development this is backwards: the character *is being discovered* through writing. The check should be neutral.
+
+**Revision:** all bible-consistency findings use the form *"Bible and prose disagree: bible says X, scene N says Y. Verdict?"* with the diff+verdict mechanism. The author records which is correct — sometimes it's the bible (update the scene), sometimes the scene (update the bible), sometimes both are right (the character has multiple facets).
+
+### Prompt caching for bibles is mandatory, not optional
+
+The engineering review caught the cost: a full bible-consistency pass on a 50-scene novel is ~$20-25 with prompt caching and ~$80 without. **The design now mandates `cache_control` on bible content** — bibles are stable across a scoring run, and the caching infrastructure already exists in `api.py`. The doc states the cached cost ($20-25) explicitly and recommends running this pass at most once per major milestone (pre-revise, pre-publish).
+
+---
+
+## Schema and engineering decisions
+
+### Defer the `spine_event` column
+
+The original scoring doc proposed adding a `spine_event` column to `scene-intent.csv` to make 3→4 downward coverage trivially deterministic. The engineering review showed this is ~400-600 LOC across 8 files plus a schema migration plus per-architecture-scene population logic.
+
+**Revision: defer.** v1 uses LLM-driven mapping for 3→4 downward coverage (one call per cascade run that asks "which spine event does this architecture scene serve?"). This is cheap (~$0.05/run with caching) and good-enough at the scale a single project operates at. If v1 in author hands proves the mapping is slow or lossy, add the column in v2 with a proper migration.
+
+### Hook performance budget
+
+The pre-commit hook gets a hard limit: **<500ms on a 100-scene project**. A test enforces it. Any deterministic check that can't meet the budget is downgraded to on-demand. Without this discipline the hook gets slow, authors set `STORYFORGE_SYNC_SKIP=1`, and the data-integrity guarantee evaporates.
+
+### What ships in v1 (the shippable cut)
+
+The engineering review's "v1 cut" landed on roughly what I'd commit to:
+
+**v1 includes:**
+- New file `reference/story-summary.md` with sections: Logline, Synopsis, Act-shape, Theme. Template at `templates/reference/`.
+- `storyforge init` writes the file pre-seeded with the project's logline.
+- One-time migration of `storyforge.yaml:project.logline` into the new file (loud, atomic, single command).
+- A parser in `common.py` that reads the four sections.
+- `storyforge score --level N` extension that emits deterministic quality + registry checks for levels 3–6 (generalizing existing `hone.py` + `structural.py` logic).
+- The orphan-registry check generalized across all structural levels.
+- `working/scoring-overrides.csv` and the parser for it.
+- `STORYFORGE_DRAFTING=1` env-var bypass.
+- `storyforge score --drift` — read-only drift report combining deterministic coverage + timestamps + content-hash deltas.
+- `project.structure` field with `custom` as the escape hatch.
+
+**v1 does NOT include:**
+- The `spine_event` column (deferred).
+- The `storyforge cascade` command (ships as `score --drift` first).
+- LLM-driven semantic boundary checks (the diff+verdict mechanism is designed but the v1 doesn't run the LLM calls — runs deterministic only).
+- Bible-consistency pass (the most expensive feature; designed but deferred).
+- Pre-commit hook integration of new quality gates (hook stays as-is; quality gates are opt-in).
+
+Rough effort: ~600 LOC of Python, one template file, one new module, modest extensions to `cmd_score.py` and `schema.py`, plus tests. Two weeks of focused work, no schema migration, no new hook surface, no LLM cost story to explain at v1.
+
+### Effort beyond v1
+
+v2 adds: LLM-driven semantic comparison at the prose-tier boundaries; bible-consistency with caching; the diff+verdict mechanism running over LLM checks; one round of acceptance-threshold tuning based on v1 usage.
+
+v3 adds: the proper `storyforge cascade` command surface (after `score --drift` has been used long enough to inform the design); the `spine_event` column if mapping perf is insufficient; bundled checks for non-three-act structures.
+
+---
+
+## Open questions remaining after review
+
+1. **Where does the scoring-verdicts file live?** Proposed `working/scoring-verdicts.csv` for now. Alternative: `reference/scoring-verdicts.csv` (canonical, committed). Argument for `reference/`: verdicts are author-authored content, not ephemeral state. Argument for `working/`: they're tied to current content and shouldn't bloat the canonical reference set. Lean `reference/` if pressed; flag for resolution.
+
+2. **Theme axis: how deep does it go?** v1 has Theme as a section in story-summary.md with deterministic presence + LLM engagement checks. Should there also be a `theme_engaged` boolean column on `scene-intent.csv`? Probably not in v1 — too much schema commitment for a feature that should prove itself first.
+
+3. **`project.structure: custom` semantics.** When `custom`, which checks are disabled by default? Strict interpretation: all structure-specific checks (action/sequel, value-shift distribution, three-act partitioning) are off. Loose: only the ones the author explicitly opts out of. Lean strict — opt-in is safer than opt-out for the escape hatch.
+
+4. **Cascade UI for the diff+verdict flow.** When a comparison is surfaced, what does the author actually see? A markdown file with the two sides + a verdict line they fill in? A slash-command in a Claude session? Both? Defer to implementation; flagged here so it doesn't get forgotten.
+
+5. **What happens to existing scoring (the 25-principle novel scorer) under the new framing?** It's level 7 quality; surfaces unchanged. The boundary scoring for 6→7 (does draft honor brief) reuses the existing `brief_fidelity` deterministic check + the existing `revise --findings` LLM loop. No restructure needed. But: when a scene scores 0.42 on `economy_clarity`, does the diff+verdict mechanism apply, or is that a "real" deterministic score the author should just fix? The distinction matters. Lean: deterministic scores stay as numbers; LLM-judged comparisons become diff+verdict.
+
+---
+
+## Self-assessment
+
+This synthesis is "done" enough to act on when:
+
+- The five consensus critiques from review (override, drafting bypass, faithfulness-as-score, cascade-as-drift-problem, structure assumptions) all have concrete revisions. ✓
+- The biggest individual critique (no thematic axis) is addressed. ✓
+- The most expensive engineering surprise (`spine_event` column) is acknowledged and deferred. ✓
+- The v1 cut is shippable in ~2 weeks of focused work. ✓ (per engineering review)
+- The originals remain accurate as the *pre-review* design state; this doc is the *post-review* proposal. ✓
+
+Remaining work before implementation:
+- Author sign-off on the revisions (especially the faithfulness-as-diff change, the v1 cut, and the deferred `cascade` command).
+- One more pass through the design specifically to check: are there any places the originals' rubrics still encode "compliance = good" by accident? The choosiness pass was good; a second pass with the explicit framing of "this measures structural integrity, not life" may catch axes that still sneak through.
+
+(Self-assessment: comfortable with this proposal as the next step. The reviews caught real weaknesses, the revisions address them without unraveling the core design, and the v1 cut is honest about what we'd actually build first.)

--- a/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-review-synthesis.md
@@ -43,9 +43,12 @@ This is the most important change. It addresses voice, craft-skeptic concerns, a
 **The change.** Replace the upward-faithfulness *score* with an upward-faithfulness *diff*. At each boundary, when triggered:
 
 1. The system surfaces the two sides as a structured comparison — what the upstream level says about this story unit, what the downstream level is doing.
-2. The author records a verdict: `correct=upstream`, `correct=downstream`, `both are right`, or `needs work`. A one-line rationale is optional but encouraged.
-3. The verdict persists across runs in `working/scoring-verdicts.csv` (scene/unit + boundary + verdict + rationale + timestamp).
-4. The system does not re-flag a boundary where a verdict is recorded unless one side has materially changed since the verdict.
+2. **Who records the verdict depends on coaching level:**
+   - **full** (default): the LLM looks at the content history on both sides, proposes a verdict (`correct=upstream` / `correct=downstream` / `both are right` / `needs work`) with a one-line rationale, and the proposal is always called out in the cascade review so the author can override.
+   - **coach**: the LLM proposes; the author confirms or overrides before the verdict is recorded.
+   - **strict**: only the author records verdicts. The LLM still produces the diff but never the verdict.
+3. The verdict persists across runs in `working/scoring-verdicts.csv` (scene/unit + boundary + verdict + rationale + actor + timestamp). `actor` records whether the LLM proposed or the author authored.
+4. The system does not re-flag a boundary where a verdict is recorded unless one side has materially changed since the verdict (content-hash delta, not just mtime).
 
 **What this preserves.** The LLM is still doing semantic comparison — the same prompt, the same cost. We just stop emitting a number for the comparison's result.
 
@@ -137,32 +140,39 @@ The originals proposed mtime-only drift detection. The workflow reviewer caught 
 
 ## Scoring revisions
 
-### Add an explicit thematic axis
+### Add an explicit thematic axis — with per-scene tracking
 
-The story-craft reviewer was right: no rubric across eight levels asks "is this story about something?" Motif registries are vehicles for theme, not theme itself.
+The story-craft reviewer was right: no rubric across eight levels asks "is this story about something?" Motifs in the existing registry are concrete *vehicles* for theme, not theme itself.
 
-**Revision: add `## Theme` as a fourth section in `reference/story-summary.md`** — alongside Logline, Synopsis, Act-shape. Two-to-four sentences naming what the story argues. The argument is internal-use only (it's not pitch material) and explicit.
+**Revision: two additions.**
 
-Scoring axes on the theme section:
-- *Presence* — deterministic. Empty section → finding.
-- *Engagement at lower levels* — LLM, on-demand. Do the briefs and drafts engage with this theme, or does it disappear after level 0?
+1. **Add `## Theme` as a fourth section in `reference/story-summary.md`** — alongside Logline, Synopsis, Act-shape. Two-to-four sentences naming what the story argues. The argument is internal-use only (not pitch material) and explicit.
 
-This is the smallest possible addition that gives the system a place to ask the most important story question.
+2. **Add `reference/themes.csv` registry** — abstract concerns the story is about. Same pattern as `mice-threads.csv` / `values.csv`:
 
-### Genre / structure escape hatch
-
-The originals encoded three-act, Swain action/sequel, McKee value shifts, and Weiland brief contracts as universal rules. They're one tradition (commercial American screenwriting + popular novel craft). They don't fit kishōtenketsu, mosaic, fragmented narrative, plotless literary, picaresque, or vignette-driven work.
-
-**Revision:** add `project.structure` field to `storyforge.yaml`:
-
-```yaml
-project:
-  structure: three-act        # three-act | four-act | kishōtenketsu | mosaic | episodic | custom
+```
+id|name|tier|description
+legibility|Legibility|primary|What is and isn't legible, to whom.
+recovery|Recovery|primary|What can be brought back from loss.
+erasure|Erasure|secondary|What gets erased and what survives.
 ```
 
-When `structure: custom`, the structure-specific scoring checks (action/sequel alternation, three-act value-shift distribution, "events spread evenly across acts") are *disabled*. The author opts in to whatever subset they want via a `scoring.enabled_checks` list. Default for novel mode is `three-act`; default for graphic-novel is `three-act` too unless author specifies.
+And **add a `theme_threads` column to `scene-intent.csv`** — semicolon-delimited list of theme IDs that each scene engages. Mirrors `mice_threads`.
 
-Other structures get bundled checks (e.g., `kishōtenketsu` enables a four-act value-shift check with a specific pattern). Bundled checks are out of scope for v1; the escape hatch (`custom`) is what ships.
+Scoring axes on the theme dimension:
+- *Theme section presence* — deterministic. Empty `## Theme` → finding.
+- *Themes registry presence* — deterministic. Empty themes.csv → finding (after Theme section is written).
+- *Per-theme coverage* — deterministic. For each registered theme, what fraction of scenes engage it? Flags themes with too few scene engagements (decorative themes that never land) or too many (one theme drowning out the others).
+- *Theme distribution* — deterministic. Where in the story does each theme light up? Flags themes that vanish for entire acts.
+- *Per-scene engagement validity* — LLM, on-demand. Does this scene actually engage the themes its `theme_threads` claims, or is it tagged-but-not-engaged?
+
+**Themes vs motifs.** They stay as separate registries. Themes are abstract concerns ("what does it mean to remember?"); motifs are concrete recurring elements ("the wire spectacles," "the lamp glow on paper"). The relationship is many-to-many: a theme can be carried by several motifs; a motif can serve several themes. Conflating them would lose information — `legibility` is a theme but not a motif; `wire spectacles` is a motif that might serve `legibility` as one of its themes. Per-scene tracking lives in two columns: `theme_threads` on scene-intent.csv (which abstract concerns this scene engages) and `motifs` on scene-briefs.csv (which concrete recurring elements appear in this scene). The motif registry stays as-is.
+
+### Genre / structure assumptions
+
+The originals encoded three-act, Swain action/sequel, McKee value shifts, and Weiland brief contracts as universal rules. The reviews proposed a `project.structure: custom` escape hatch for non-three-act stories.
+
+**Revision:** drop the `custom` option for v1. Author judgment (PR review): too much work for too little value at this stage. v1 assumes three-act throughout. Non-three-act stories can use whatever scoring axes apply to them and ignore the rest via the score-overrides mechanism. If specific bundled checks (kishōtenketsu, mosaic) emerge as a real need, they're added in a follow-up.
 
 ### Demote the causal-chain LLM check
 
@@ -184,11 +194,28 @@ The engineering review caught the cost: a full bible-consistency pass on a 50-sc
 
 ## Schema and engineering decisions
 
-### Defer the `spine_event` column
+### Structural-anchor tier: discrete artifacts, two new columns
 
-The original scoring doc proposed adding a `spine_event` column to `scene-intent.csv` to make 3→4 downward coverage trivially deterministic. The engineering review showed this is ~400-600 LOC across 8 files plus a schema migration plus per-architecture-scene population logic.
+The original docs treated the spine and architecture levels as `status` flags on the shared `scenes.csv`. Author pushback (PR review): the levels aren't just "same rows with more columns" — they have **different row counts**. The spine is 5–10 events; architecture is 15–25 anchor scenes; the scene map is 40–60 scenes. Each tier transition expands the row count by elaborating each upstream unit into multiple downstream units.
 
-**Revision: defer.** v1 uses LLM-driven mapping for 3→4 downward coverage (one call per cascade run that asks "which spine event does this architecture scene serve?"). This is cheap (~$0.05/run with caching) and good-enough at the scale a single project operates at. If v1 in author hands proves the mapping is slow or lossy, add the column in v2 with a proper migration.
+**Revision: the structural tier splits into discrete artifacts.**
+
+| Tier | Artifact(s) | Row count |
+|---|---|---|
+| Structural anchors | `reference/spine.csv` | 5–10 |
+| Structural anchors | `reference/architecture.csv` | 15–25, each with `spine_event` → spine.csv |
+| Manuscript | `reference/scenes.csv` + companions | 40–60, each with optional `architecture_scene` → architecture.csv |
+
+Two new reference columns make the level boundaries explicit:
+
+- `spine_event` on `architecture.csv` — every architecture row names its parent spine event. Required.
+- `architecture_scene` on `scenes.csv` — every map scene either *is* an architecture anchor (`architecture_scene = own_id`) or sits adjacent to one (`architecture_scene = nearest_anchor_id`) or is purely interstitial (`architecture_scene = ''`). Optional.
+
+The deterministic downward-coverage checks fall out of this for free: "every spine event has at least one architecture row referencing it"; "every architecture anchor has at least one map scene linked to it." Both are set-membership operations, both ship in v1.
+
+Why this is in v1 rather than deferred: the original engineering review estimated ~400–600 LOC across 8 files because it imagined the column added on top of the existing single-CSV-with-status pattern. Splitting into discrete artifacts is a different (and cleaner) refactor — and the user wants it from the start because the artifact split is what makes "the spine" something you can refer to as a thing.
+
+Migration for existing projects (Ashes, Meridian) is mechanical: `cmd_migrate` extracts `status=spine` rows from scenes.csv into spine.csv, copies `status=architecture` rows into architecture.csv, and populates `spine_event` references where derivable. Author confirms the spine event count.
 
 ### Hook performance budget
 
@@ -200,40 +227,43 @@ The engineering review's "v1 cut" landed on roughly what I'd commit to:
 
 **v1 includes:**
 - New file `reference/story-summary.md` with sections: Logline, Synopsis, Act-shape, Theme. Template at `templates/reference/`.
-- `storyforge init` writes the file pre-seeded with the project's logline.
+- `storyforge init` writes story-summary.md pre-seeded with the project's logline, plus empty `themes.csv`, `spine.csv`, `architecture.csv` with their headers.
 - One-time migration of `storyforge.yaml:project.logline` into the new file (loud, atomic, single command).
-- A parser in `common.py` that reads the four sections.
+- Migration of existing `status=spine` and `status=architecture` rows from scenes.csv into their new discrete CSVs (`cmd_migrate`).
+- A parser in `common.py` that reads story-summary.md's four sections (Logline / Synopsis / Act-shape / Theme).
+- New columns: `spine_event` (on architecture.csv, required), `architecture_scene` (on scenes.csv, optional), `theme_threads` (on scene-intent.csv, optional).
 - `storyforge score --level N` extension that emits deterministic quality + registry checks for levels 3–6 (generalizing existing `hone.py` + `structural.py` logic).
-- The orphan-registry check generalized across all structural levels.
+- The orphan-registry check generalized across all structural levels, including the new themes registry.
 - `working/scoring-overrides.csv` and the parser for it.
-- `STORYFORGE_DRAFTING=1` env-var bypass.
+- `working/scoring-verdicts.csv` and its parser (the diff+verdict persistence file).
+- `STORYFORGE_DRAFTING=1` env-var bypass and `project.cascade_mode` in storyforge.yaml.
 - `storyforge score --drift` — read-only drift report combining deterministic coverage + timestamps + content-hash deltas.
-- `project.structure` field with `custom` as the escape hatch.
+- Derived markdown renderings: `reference/spine.md`, `reference/architecture.md` (siblings of the existing `scenes-review.md`).
 
 **v1 does NOT include:**
-- The `spine_event` column (deferred).
-- The `storyforge cascade` command (ships as `score --drift` first).
+- The `storyforge cascade` command as its own surface (ships as `score --drift` first; cascade as a top-level command lands in v2/v3).
 - LLM-driven semantic boundary checks (the diff+verdict mechanism is designed but the v1 doesn't run the LLM calls — runs deterministic only).
 - Bible-consistency pass (the most expensive feature; designed but deferred).
+- `project.structure: custom` or any non-three-act bundled checks (deferred per author decision).
 - Pre-commit hook integration of new quality gates (hook stays as-is; quality gates are opt-in).
 
-Rough effort: ~600 LOC of Python, one template file, one new module, modest extensions to `cmd_score.py` and `schema.py`, plus tests. Two weeks of focused work, no schema migration, no new hook surface, no LLM cost story to explain at v1.
+Rough effort: ~800–1000 LOC of Python (up from the original ~600 because of the structural-anchor artifact split + the migration step), one template directory addition, two new modules, modest extensions to `cmd_score.py` and `schema.py`, plus tests. Maybe three weeks of focused work given the migration. No LLM cost story to explain at v1.
 
 ### Effort beyond v1
 
-v2 adds: LLM-driven semantic comparison at the prose-tier boundaries; bible-consistency with caching; the diff+verdict mechanism running over LLM checks; one round of acceptance-threshold tuning based on v1 usage.
+v2 adds: LLM-driven semantic comparison at the prose-tier and structural-tier boundaries; the diff+verdict mechanism running over LLM checks (coaching-level-driven actor); bible-consistency with caching; one round of acceptance-threshold tuning based on v1 usage.
 
-v3 adds: the proper `storyforge cascade` command surface (after `score --drift` has been used long enough to inform the design); the `spine_event` column if mapping perf is insufficient; bundled checks for non-three-act structures.
+v3 adds: the proper `storyforge cascade` command surface (after `score --drift` has been used long enough to inform the design); bundled checks for non-three-act structures if a real need emerges.
 
 ---
 
 ## Open questions remaining after review
 
-1. **Where does the scoring-verdicts file live?** Proposed `working/scoring-verdicts.csv` for now. Alternative: `reference/scoring-verdicts.csv` (canonical, committed). Argument for `reference/`: verdicts are author-authored content, not ephemeral state. Argument for `working/`: they're tied to current content and shouldn't bloat the canonical reference set. Lean `reference/` if pressed; flag for resolution.
+1. **~~Where does the scoring-verdicts file live?~~** *Resolved: `working/scoring-verdicts.csv`. The verdicts are part of the process, not canonical reference material.*
 
-2. **Theme axis: how deep does it go?** v1 has Theme as a section in story-summary.md with deterministic presence + LLM engagement checks. Should there also be a `theme_engaged` boolean column on `scene-intent.csv`? Probably not in v1 — too much schema commitment for a feature that should prove itself first.
+2. **~~Theme axis: how deep does it go?~~** *Resolved: separate themes.csv registry + `theme_threads` column on scene-intent.csv (mirrors the mice_threads pattern). Themes stay distinct from motifs.*
 
-3. **`project.structure: custom` semantics.** When `custom`, which checks are disabled by default? Strict interpretation: all structure-specific checks (action/sequel, value-shift distribution, three-act partitioning) are off. Loose: only the ones the author explicitly opts out of. Lean strict — opt-in is safer than opt-out for the escape hatch.
+3. **~~`project.structure: custom` semantics.~~** *Resolved: dropped for v1. Too much work for the value; non-three-act stories use the score-overrides mechanism. Bundled checks for other structures are follow-up work if needed.*
 
 4. **Cascade UI for the diff+verdict flow.** When a comparison is surfaced, what does the author actually see? A markdown file with the two sides + a verdict line they fill in? A slash-command in a Claude session? Both? Defer to implementation; flagged here so it doesn't get forgotten.
 

--- a/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
@@ -452,17 +452,20 @@ What carries over from existing scoring, what's new:
 | Structural scoring (brief-level) | `structural.py` | Reuse for level 6 |
 | Findings → revision feedback loop | `cmd_revise.py`, `cmd_revise_gn.py` | Reuse for 6→7 upward fidelity |
 | Score history tracking | `history.py`, `score-history.csv` | Reuse, extend schema to include level + boundary scores |
-| Per-level quality rubrics for levels 0–5 | — | New |
-| LLM faithfulness scoring at boundaries | — | New (small wrapper per boundary; reuses API/cost infra) |
+| Per-level floor checks (levels 0–6) | — | New |
+| Per-level ceiling sketches (levels 0–7) | — | New (descriptive guidance for LLM prompts, not separately scored) |
+| LLM faithfulness scoring at boundaries (diff+verdict per synthesis) | — | New (small wrapper per boundary; reuses API/cost infra) |
 | Cross-cutting bible-consistency scoring | — | New |
 | Score reporting at non-scene levels (logline, synopsis, etc.) | — | New |
+| **Comparison primitive** (`score --compare`) | — | New (deterministic axes v1, LLM axes v2) |
 
 **Where this lands in code (rough):**
 
-- `scoring_levels.py` — new module: per-level quality rubrics for levels 0–6, dispatching to existing scorers where they exist.
-- `scoring_boundary.py` — new module: cross-level fidelity checks, both directions.
+- `scoring_levels.py` — new module: per-level floor checks for levels 0–6, dispatching to existing scorers where they exist. Ceiling sketches inform LLM prompts but don't need their own module.
+- `scoring_boundary.py` — new module: cross-level fidelity (downward coverage + upward diff+verdict).
 - `scoring_consistency.py` — new module: registry + bible conformance, applied per level.
-- `cmd_score.py` (and `cmd_score_gn.py`) — extended to accept `--level N`, `--boundary N-M`, or `--all`.
+- `scoring_comparison.py` — new module: multi-candidate comparison (reuses floor + ceiling axes; emits the no-winner comparison report).
+- `cmd_score.py` (and `cmd_score_gn.py`) — extended to accept `--level N`, `--boundary N-M`, `--compare a b [c] [d]`, or `--all`.
 
 This is implementation detail and out of scope for the design doc, but flagged so future implementers know the existing scoring code doesn't need to be refactored from the ground up.
 

--- a/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
@@ -45,9 +45,16 @@ The two "expensive + on-demand" lines are the ones we have to be most careful ab
 
 ## Per-level quality rubrics
 
-For each level, what does "good" look like? Some criteria are deterministic; some need an LLM. Some reuse existing scoring; some are new.
+For each level, what does "good" look like? Each level gets two rubrics:
+
+- **Floor checks** — does this level even exist, complete, and consistent? Mostly deterministic. A failure here means the level is broken or missing pieces. This is what most existing scoring does today.
+- **Ceiling sketch** — what separates *passable* from *excellent* at this level? Mostly LLM-judged, often subjective, never a number. This gives the LLM a target richer than "complete," and gives the author language for what the iteration is trying to reach.
+
+The floor checks ship in v1 as deterministic + cheap LLM. The ceiling sketches inform LLM prompts at v2 and beyond; they're descriptive guidance, not gates.
 
 ### Level 0 — Logline
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
@@ -56,11 +63,21 @@ For each level, what does "good" look like? Some criteria are deterministic; som
 | Names a want/goal | LLM | new |
 | Names an obstacle | LLM | new |
 | Names stakes | LLM | new |
-| Genre/tone legible | LLM | new |
 
-All four LLM checks fit in one prompt → one API call. Cheap-enough on-demand.
+All four LLM checks fit in one prompt → one API call. Cheap-enough on-demand. The "genre/tone legible" check from the original draft is dropped — most great loglines convey genre through specific imagery rather than tagging, and the check would produce noise.
+
+**Ceiling sketch — what separates passable from excellent**
+
+A passable logline names protagonist + want + obstacle + stakes. An excellent logline additionally:
+
+- Uses *specific* nouns and verbs rather than generic ones (the difference between "a man wants to find his daughter" and "a cartographer wants to find his daughter, who exists only in maps no one else can read").
+- Creates *irony* between elements — the want is also the flaw, or the obstacle is internal not just external.
+- Contains a hook word or phrase that makes it memorable.
+- Suggests genre and tone through imagery, not tagging.
 
 ### Level 1 — Synopsis
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
@@ -68,48 +85,108 @@ All four LLM checks fit in one prompt → one API call. Cheap-enough on-demand.
 | Opens with a hook (inciting incident or premise) | LLM | new |
 | Names the protagonist + central conflict | LLM (logline alignment) | new |
 | Reveals the ending or resolution (this is internal, not a pitch) | LLM | new |
-| Stays at "story" abstraction (no scene-level specifics) | LLM | new |
+
+The "stays at story abstraction" check from the original is dropped — a synopsis with one vivid scene-level detail is often better than fully abstract prose. Risks punishing good writing.
+
+**Ceiling sketch**
+
+A passable synopsis names protagonist + conflict + ending. An excellent synopsis additionally:
+
+- Shows *causation* between events (X *because of* Y, not X *and then* Y).
+- Traces an *internal arc* alongside the plot — the protagonist's relationship to their want changes through the story.
+- Makes the stakes *escalate* in visible steps, not in one jump at the end.
+- Lands the ending as inevitable-in-retrospect, not tacked-on.
 
 ### Level 2 — Act-shape
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
 | Exactly 3 paragraphs | deterministic | new |
 | Each paragraph names a turn (inciting / midpoint / climax) | LLM | new |
 | Escalation is visible (act stakes grow) | LLM | new |
-| Theme is implicit in the shape | LLM | new |
+
+The "theme is implicit in the shape" check from the original is dropped — too vague to operationalize consistently. The themes dimension is now first-class (see the themes-registry section); we don't need a fuzzy theme check at the act-shape level.
+
+**Ceiling sketch**
+
+A passable act-shape has three paragraphs each naming a turn. An excellent act-shape additionally:
+
+- Shows Act 2 as having *its own internal arc*, not as a long middle.
+- Makes Act 3's climax fall out of Act 2's setup (the climax is prepared, not introduced).
+- Shows *opposition pressure* scaling alongside the protagonist's progression.
+- Gives each act a different *kind* of pressure (e.g., external in Act 1, internal in Act 2, ethical in Act 3 — or some other meaningful variation).
 
 ### Level 3 — Spine
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
 | 5–10 events for novel / 4–8 for GN | deterministic | new |
-| Events spread roughly evenly across acts | deterministic | new |
-| Each event has a non-empty `function` in scene-intent | deterministic | reuse (already validated) |
+| Each event has a non-empty `function` in scene-intent | deterministic | reuse |
 | Each event is irreducible (cutting it breaks causation) | LLM | new |
-| Causal chain holds (event N enables event N+1) | LLM | new |
+
+The "events spread roughly evenly across acts" check is dropped — genre-bound. Thrillers cluster in Act 3, literary in Act 2. The author can use score-overrides if a spread check matters for their specific project. The "causal chain holds" LLM check stays in the advisory tier per the synthesis (not a floor gate).
+
+**Ceiling sketch**
+
+A passable spine has 5–10 irreducible events. An excellent spine additionally:
+
+- Makes each event *cause* the next, not just precede it.
+- Shows the protagonist's relationship to the central question *change across events* — the question they ask themselves at event 5 is different in kind from event 1, not just in intensity.
+- Contains at least one event that *can't be predicted* from earlier ones — a real turn, not just escalation.
+- Ends on a state that's different *in kind* from where it started.
 
 ### Level 4 — Architecture
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
 | 15–25 scenes total (novel) / 10–18 (GN) | deterministic | new |
-| Every scene has `part`, `pov`, `action_sequel`, `emotional_arc`, `value_at_stake`, `value_shift`, `turning_point` | deterministic | reuse (structural validation) |
-| Action/sequel alternates | deterministic | new (count check on `action_sequel`) |
-| Value shifts present and varied | deterministic | reuse (existing flat-shift check) |
-| POV distribution matches story design | deterministic + LLM | new |
+| Every scene has `part`, `pov`, `action_sequel`, `emotional_arc`, `value_at_stake`, `value_shift`, `turning_point` | deterministic | reuse |
+| Both action and sequel scenes present (at least 25% of each) | deterministic | new — softened from "alternates" |
+| Value shifts present and varied | deterministic | reuse |
+| POV distribution matches story design | LLM | new |
+
+The original "action/sequel alternates" check is softened — strict alternation produces mechanical pacing. Many great novels have multiple action scenes in a row (thriller climax) or multiple sequels (literary). The new check confirms both modes are present without enforcing rhythm.
+
+**Ceiling sketch**
+
+A passable architecture has all columns populated and uses both action and sequel scenes. An excellent architecture additionally:
+
+- Ends most scenes with a *question* the next scene answers or complicates (forward pull).
+- Shows *stakes escalating across the sequence*, not just within each scene.
+- Gives the antagonist force its *own visible arc* across the architecture — the opposition has a story too.
+- Varies *value at stake* across the sequence rather than hammering one value.
 
 ### Level 5 — Scene map
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
 | Every scene has `location`, `timeline_day`, `time_of_day`, `duration` | deterministic | reuse |
-| Timeline is causally consistent | deterministic + LLM | reuse partial (timeline construction) |
-| POV is on-stage where they're POV | deterministic | reuse (`hone`) |
-| MICE threads opened are closed | deterministic | new (set walk on `mice_threads`) |
-| Scene types are diverse | deterministic | new (count check) |
+| Timeline is causally consistent (ordering) | deterministic | reuse |
+| POV is on-stage where they're POV | deterministic | reuse |
+| MICE threads opened are closed by story end | deterministic | new (set walk) |
+
+The "scene types are diverse" check is dropped per the choosiness pass (genre-bound, not universal).
+
+**Ceiling sketch**
+
+A passable scene map has full operational metadata and MICE threads that resolve. An excellent scene map additionally:
+
+- Uses *spatial economy* — few locations recurring with meaning, rather than many scattered ones.
+- Inserts *breathing scenes* between high-pressure ones so the reader doesn't burn out.
+- Uses *time-of-day variation* with intention, not randomness.
+- Plants *setup details* that pay off later (foreshadowing through specifics, not just plot).
 
 ### Level 6 — Briefs
+
+**Floor checks**
 
 | Check | Mechanism | Source |
 |---|---|---|
@@ -119,11 +196,89 @@ All four LLM checks fit in one prompt → one API call. Cheap-enough on-demand.
 | GN: panel_breakdown / page_layout / visual_keywords present | deterministic | reuse |
 | Brief honors scene-intent's value_at_stake | LLM | new (this is a 5→6 fidelity check too) |
 
+**Ceiling sketch**
+
+A passable brief has goal/conflict/outcome with non-abstract language. An excellent brief additionally:
+
+- Names *subtext* explicitly in the `subtext` field — what's beneath the surface dialogue and action.
+- Aligns the *emotional_arc* with the *key_actions* — not plot-level specifics with vague emotional notes, or vice versa.
+- Makes the *key_dialogue* carry the scene's argument, not just exposition.
+- Names what the *POV character notices* in a way that reveals their state without telling.
+
 ### Level 7 — Draft
 
 **Use existing scoring.** Novel mode: the 25-principle rubric in `scoring.py`. GN mode: the 6-principle deterministic rubric in `scoring_gn.py` plus the 3-persona evaluation panel.
 
 No new per-level rubric needed at level 7. The existing scoring is the rubric.
+
+**Ceiling sketch**
+
+A passable draft hits the principle rubric. An excellent draft additionally:
+
+- Shows *consistent voice* across the scene — not just hitting craft-rule averages.
+- Makes the scene's *subtext* live in concrete imagery and behavior, not in stated emotion.
+- Uses *specifics that earn their place* — every concrete detail does work for character, mood, or plot.
+- Leaves the reader with a *question* that pulls them into the next scene.
+
+These ceiling axes inform the LLM persona evaluation panel's prompts but aren't separate scored axes — they describe what the existing evaluators should be reaching for.
+
+---
+
+## Comparison scoring — for iteration across alternatives
+
+The per-level rubrics above grade *one* artifact at a time. Most real iteration involves several candidates: three logline drafts, two competing synopses, alternative spines. The grade-each-independently model can't say *which is best for this story* — and an axis-by-axis improvement loop biases toward axis-satisficing prose. The comparison primitive fixes that.
+
+**`storyforge score --compare <artifact1> <artifact2> [<artifact3>] [<artifact4>]`**
+
+Produces a multi-axis comparison report — explicitly *not* a winner. The author uses the report to decide; the system never declares an overall best.
+
+Inputs: 2–4 candidate artifacts at the same level. Most common: prose-tier (logline / synopsis / theme statement). Useful at level 3 (alternative spines). Rarely needed at deeper levels — at the scene map and below, you don't usually have full-artifact alternatives.
+
+Output: `working/comparison-<level>-<timestamp>.md` shaped like this:
+
+```markdown
+# Comparison: logline candidates (3)
+
+## Candidates
+- **A**: A cartographer who maps places no one else can find loses the daughter he never recorded.
+- **B**: When an imperial archivist discovers his mentor's secret atlas, he must choose between burning it and being burned with it.
+- **C**: A man fights to find his daughter using only the maps in his head.
+
+## Floor checks (deterministic)
+
+| Axis | A | B | C |
+|---|---|---|---|
+| Length (words) | 21 | 28 | 17 |
+| Names protagonist | ✓ | ✓ | partial (generic "a man") |
+| Names want | ✓ | ✓ | ✓ |
+| Names obstacle | implicit | ✓ | partial |
+| Names stakes | ✓ | ✓ | weak |
+
+## Ceiling axes (LLM, on demand)
+
+| Axis | A | B | C |
+|---|---|---|---|
+| Specific vs generic nouns | medium | high | low |
+| Irony between elements | want = flaw | duty vs preservation | absent |
+| Memorable hook word | "never recorded" | "burning / burned" | none |
+| Genre/tone via imagery | literary | thriller-tinged | generic |
+
+## What each does best
+- **A**: most distinctive *want+flaw* irony; the "never recorded" hook lands.
+- **B**: strongest stakes and most active phrasing; longest.
+- **C**: tightest length but weakest specificity and stakes.
+
+## Author task
+Pick the axes that matter most for THIS story and decide. The system does
+not recommend a winner — it surfaces what each candidate does best so you
+can either pick one or synthesize.
+```
+
+**Why no overall winner.** Same reason the upward-faithfulness score became a diff: an overall "best candidate" score would re-create the gradient-toward-LLM-taste problem. The candidates may differ in ways the rubric can't weigh against each other (irony vs. tightness vs. genre fit) and the choice depends on what *this story* needs — which the system doesn't know. The author decides; the system surfaces.
+
+**v1 vs v2.** The deterministic axes ship in v1 — they're set-membership and counts, cheap. The "ceiling axes" (LLM-judged comparative qualities) ship in v2 with the rest of the LLM scoring infrastructure. In v1 the ceiling-axes table is present but populated with "—" placeholders; running with `--semantic` flag in v2 fills them in.
+
+**Where this lives.** New module `scoring_comparison.py`. Reuses the per-level floor and ceiling definitions; no new rubrics. The CLI surface adds one flag.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
@@ -2,9 +2,15 @@
 
 Research design doc for issue [#227](https://github.com/benjaminsnorris/storyforge/issues/227), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
 
-Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md) and [the cascade-mechanics doc](2026-05-24-cascade-mechanics-design.md) — read those first; this one refers to the level numbering they establish.
+Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md), [the cascade-mechanics doc](2026-05-24-cascade-mechanics-design.md), and the [review synthesis](2026-05-24-elaboration-review-synthesis.md) — read those first; this one refers to the level numbering they establish. The synthesis supersedes this doc where they disagree.
 
-Status: **draft**, expects iteration. Implementation out of scope.
+Status: **draft + revisions noted inline**. Implementation out of scope.
+
+> **Post-review revisions** that affect this doc:
+> - The structural tier is split into discrete artifacts (`spine.csv`, `architecture.csv`, `scenes.csv` + companions). Downward coverage at 3→4 and 4→5 becomes a trivial set-membership check against the new `spine_event` and `architecture_scene` reference columns.
+> - **Upward faithfulness scores are replaced by diffs + author verdicts** at the prose-tier and structural-tier boundaries. Numbers go away; the LLM still runs the comparison but the output is a structured diff with a coaching-level-aware verdict actor. See the synthesis.
+> - A new theme dimension: `reference/themes.csv` registry and `theme_threads` column on scene-intent.csv. Themes and motifs stay as separate registries.
+> - `project.structure: custom` is dropped for v1.
 
 ---
 
@@ -132,33 +138,35 @@ These are different questions and need different checks.
 
 ### The cross-level scoring matrix
 
-| Boundary | Downward (deterministic where possible) | Upward (LLM) |
+| Boundary | Downward (deterministic where possible) | Upward (diff+verdict per synthesis) |
 |---|---|---|
-| 0 → 1 Logline → Synopsis | None deterministic — both are prose | "Does the synopsis still describe the logline's story?" |
-| 1 → 2 Synopsis → Act-shape | None deterministic | "Does the act-shape match the synopsis's outline?" |
-| 2 → 3 Act-shape → Spine | Each spine event maps to one of the three acts (per `part` column) | "Does the spine embody the act-shape's turns?" |
-| 3 → 4 Spine → Architecture | Every spine event has descendant scenes in `scenes.csv` (need a `spine_event` reference column — see "Schema additions" below) | "Do the architecture scenes serve the spine?" |
-| 4 → 5 Architecture → Map | Every architecture scene has full map columns populated | "Does the map's operational metadata honor architecture's structural intent?" |
-| 5 → 6 Map → Briefs | Every map scene has a brief row | "Does the brief honor the scene-intent?" |
-| 6 → 7 Briefs → Draft | Every brief has a draft file with word_count > 0 | "Does the draft honor the brief?" (reuse: this is exactly `brief_fidelity` in scoring_gn.py and the upward signal of `revise --findings`) |
+| 0 → 1 Logline → Synopsis | None deterministic — both are prose | LLM diff: "what does the synopsis say vs. what the logline implies?" |
+| 1 → 2 Synopsis → Act-shape | None deterministic | LLM diff |
+| 2 → 3 Act-shape → Spine | Each spine event's `part` field maps to one of the three acts | LLM diff |
+| 3 → 4 Spine → Architecture | Every `spine.csv.id` is referenced by at least one `architecture.csv.spine_event` — set membership | LLM diff |
+| 4 → 5 Architecture → Map | Every `architecture.csv.id` is referenced by at least one `scenes.csv.architecture_scene` — set membership | LLM diff |
+| 5 → 6 Map → Briefs | Every scene with `status >= briefed` has a row in `scene-briefs.csv` — set membership | LLM diff |
+| 6 → 7 Briefs → Draft | Every brief has a draft file with word_count > 0 | Reuse: `brief_fidelity` in scoring_gn.py + the upward signal of `revise --findings` |
 
 ### Where the prose tier is special
 
 The 0↔1, 1↔2 boundaries (and partly 2↔3) have no clean deterministic downward checks — both sides are prose. **All scoring at these boundaries is LLM-driven.** That's expensive and noisy, so we should:
 
-- Run these scores only on demand (not in the hook).
-- Trigger them from the cascade: if the drift detector sees mismatched `_updated` timestamps between, say, logline and synopsis, *then* run the LLM check.
+- Run these checks only on demand (not in the hook).
+- Trigger them from the cascade: if the drift detector sees mismatched `_updated` timestamps + content-hash deltas, *then* run the LLM check.
 - Cache results between runs; only re-check if either side has been touched.
+- Per the synthesis, the LLM output is a structured diff with a coaching-level-aware verdict actor, not a 0.0–1.0 score.
 
-### Schema additions to make downward coverage cheap
+### Schema that makes downward coverage cheap
 
-The deterministic downward check at 3 → 4 (Spine → Architecture) needs a way to map architecture scenes to their parent spine event. Today nothing tracks this — architecture scenes are just rows with `status=architecture`; their relationship to spine events is implicit in the title/sequence.
+The level-and-shapes doc and synthesis introduce two reference columns that make the structural-tier downward checks trivial:
 
-**Proposed addition: `spine_event` column in `scene-intent.csv`.** When the architecture stage elaborates the spine, each new scene gets the `id` of its parent spine event recorded. Downward coverage becomes a trivial set check.
+- **`spine_event`** on `architecture.csv` (required) — every architecture row names its parent spine event. 3→4 downward becomes "every spine.csv.id appears in some architecture.csv.spine_event."
+- **`architecture_scene`** on `scenes.csv` (optional) — every map scene either is an architecture anchor (`architecture_scene = own_id`), sits adjacent to one (`architecture_scene = anchor_id`), or is purely interstitial (`architecture_scene = ''`). 4→5 downward becomes "every architecture.csv.id appears in some scenes.csv.architecture_scene."
 
-For 2 → 3 (Act-shape → Spine), the existing `part` column on scenes.csv already partitions spine events into acts; no new column needed. The downward check is "each act has at least one spine event," "each act has events proportional to its length."
+For 2 → 3 (Act-shape → Spine), the existing `part` column on spine.csv partitions events into acts; no new column needed. The downward check is "each act has at least one spine event."
 
-For higher levels, the CSV row identity *is* the parent-child relationship (every architecture scene IS a map scene IS a brief IS a draft — same `id`, more columns populated). No new columns needed.
+For 6 → 7 (Briefs → Draft), the row identity is preserved (same scene id in scene-briefs.csv and scenes/{id}.md) — set membership over file existence + word_count.
 
 ---
 
@@ -176,12 +184,30 @@ For every level that has structural data (3–7), check that all references poin
 | `location` | `locations.csv` | 5, 6, 7 |
 | `value_at_stake` | `values.csv` | 4, 5, 6, 7 |
 | `motifs` | `motif-taxonomy.csv` | 6, 7 |
+| `theme_threads` | `themes.csv` *(new)* | 5, 6, 7 |
 | `mice_threads` | `mice-threads.csv` | 5, 6, 7 |
 | `physical_state_in` / `physical_state_out` | `physical-states.csv` | 6, 7 |
+| `spine_event` | `spine.csv` | 4 (required) |
+| `architecture_scene` | `architecture.csv` | 5 (optional) |
 
 These are pure set comparisons — each one is one CSV read + one set difference. Cheap. Already partly implemented in `hone`. The reorganization here is making the pattern explicit per level instead of hone-specific.
 
 **Score:** for each (level, registry) pair, `coverage = 1.0 - (orphan_count / total_refs)`. A score of 1.0 means every reference resolves; less than 1.0 means orphans exist. Findings are the orphan list with their containing scene IDs.
+
+### Per-theme coverage (deterministic, new)
+
+The themes registry adds a second dimension to the registry-conformance pattern: not just "are references valid" but "is each registry entry actually used."
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Every theme in `themes.csv` is engaged by at least one scene | deterministic | new |
+| Each theme's per-scene engagement count crosses a minimum threshold (default: 3) | deterministic | new |
+| No single theme dominates more than X% of scenes (default: 70%) | deterministic | new |
+| Each theme has scene engagements spread across all acts (no theme drops out for a full act) | deterministic | new |
+
+These add per-theme findings of the form *"theme `erasure` is registered but engages only 1 scene — decorative, not load-bearing"* or *"theme `legibility` engages 38 of 50 scenes — drowning out other themes"* or *"theme `recovery` engages 12 scenes in Acts 1–2 but vanishes in Act 3."*
+
+These are the highest-leverage axes for the theme dimension: they catch the "theme is named at the top but never actually carried" failure mode that the story-craft reviewer flagged.
 
 ### Bible consistency (LLM, on demand)
 

--- a/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
+++ b/docs/superpowers/specs/2026-05-24-elaboration-scoring-design.md
@@ -1,0 +1,346 @@
+# Per-level rubrics and cross-level fidelity scoring
+
+Research design doc for issue [#227](https://github.com/benjaminsnorris/storyforge/issues/227), under the umbrella [#224](https://github.com/benjaminsnorris/storyforge/issues/224).
+
+Companion to [the levels-and-shapes doc](2026-05-24-elaboration-levels-design.md) and [the cascade-mechanics doc](2026-05-24-cascade-mechanics-design.md) — read those first; this one refers to the level numbering they establish.
+
+Status: **draft**, expects iteration. Implementation out of scope.
+
+---
+
+## TL;DR
+
+Three score families. Most are cheap; a few are expensive; the expensive ones run on demand.
+
+- **Per-level quality.** Eight rubrics, one per level. Some reuse existing scoring (level 7 already has the 25-principle novel-mode rubric and the 6-principle GN-mode rubric); some are new (logline, synopsis).
+- **Cross-level fidelity.** Two scores at each of the seven boundaries: *downward coverage* (deterministic where possible) and *upward faithfulness* (LLM-driven). The prose-tier boundaries (0↔1, 1↔2, 2↔3) get LLM-only scoring; the structural-tier boundaries get deterministic coverage plus optional LLM faithfulness.
+- **Cross-cutting consistency.** Registry conformance (deterministic, already partly in `hone`) plus bible consistency (LLM-driven, on-demand).
+
+Two design principles run through the whole proposal:
+
+1. **Don't compose.** Show each axis to the author separately. A single composite number hides which axis is broken and what to fix.
+2. **Be choosy.** Add a score only if a bad value means something is broken AND the fix is concrete AND ideally the computation is cheap. Cull aggressively.
+
+---
+
+## Three families of score, side by side
+
+| Family | What it measures | Cost profile | Cadence |
+|---|---|---|---|
+| Per-level quality | Is this level any good on its own terms? | Mix: cheap for structural (count-based, registry-based); expensive for prose (LLM) | On demand |
+| Cross-level fidelity, downward | Does the lower level realize the upper? | Cheap (mostly set coverage) | Always-on (cheap enough to run in `sync` hook) |
+| Cross-level fidelity, upward | Does the lower level honor what's above? | Expensive (LLM, semantic) | On demand only |
+| Registry consistency | Do structural fields reference real registry entries? | Cheap (set comparison) | Always-on |
+| Bible consistency | Does this artifact honor the character/world/voice bibles? | Expensive (LLM) | On demand only |
+
+The two "expensive + on-demand" lines are the ones we have to be most careful about. They want clear, actionable findings or they become noise the author learns to ignore.
+
+---
+
+## Per-level quality rubrics
+
+For each level, what does "good" look like? Some criteria are deterministic; some need an LLM. Some reuse existing scoring; some are new.
+
+### Level 0 — Logline
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Length ≤ 35 words | deterministic | new |
+| Names a protagonist | LLM | new |
+| Names a want/goal | LLM | new |
+| Names an obstacle | LLM | new |
+| Names stakes | LLM | new |
+| Genre/tone legible | LLM | new |
+
+All four LLM checks fit in one prompt → one API call. Cheap-enough on-demand.
+
+### Level 1 — Synopsis
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Length 4–8 sentences | deterministic | new |
+| Opens with a hook (inciting incident or premise) | LLM | new |
+| Names the protagonist + central conflict | LLM (logline alignment) | new |
+| Reveals the ending or resolution (this is internal, not a pitch) | LLM | new |
+| Stays at "story" abstraction (no scene-level specifics) | LLM | new |
+
+### Level 2 — Act-shape
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Exactly 3 paragraphs | deterministic | new |
+| Each paragraph names a turn (inciting / midpoint / climax) | LLM | new |
+| Escalation is visible (act stakes grow) | LLM | new |
+| Theme is implicit in the shape | LLM | new |
+
+### Level 3 — Spine
+
+| Check | Mechanism | Source |
+|---|---|---|
+| 5–10 events for novel / 4–8 for GN | deterministic | new |
+| Events spread roughly evenly across acts | deterministic | new |
+| Each event has a non-empty `function` in scene-intent | deterministic | reuse (already validated) |
+| Each event is irreducible (cutting it breaks causation) | LLM | new |
+| Causal chain holds (event N enables event N+1) | LLM | new |
+
+### Level 4 — Architecture
+
+| Check | Mechanism | Source |
+|---|---|---|
+| 15–25 scenes total (novel) / 10–18 (GN) | deterministic | new |
+| Every scene has `part`, `pov`, `action_sequel`, `emotional_arc`, `value_at_stake`, `value_shift`, `turning_point` | deterministic | reuse (structural validation) |
+| Action/sequel alternates | deterministic | new (count check on `action_sequel`) |
+| Value shifts present and varied | deterministic | reuse (existing flat-shift check) |
+| POV distribution matches story design | deterministic + LLM | new |
+
+### Level 5 — Scene map
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Every scene has `location`, `timeline_day`, `time_of_day`, `duration` | deterministic | reuse |
+| Timeline is causally consistent | deterministic + LLM | reuse partial (timeline construction) |
+| POV is on-stage where they're POV | deterministic | reuse (`hone`) |
+| MICE threads opened are closed | deterministic | new (set walk on `mice_threads`) |
+| Scene types are diverse | deterministic | new (count check) |
+
+### Level 6 — Briefs
+
+| Check | Mechanism | Source |
+|---|---|---|
+| Goal / conflict / outcome / crisis / decision present | deterministic | reuse (structural scoring) |
+| knowledge_in / knowledge_out flow correctly | deterministic | reuse |
+| key_dialogue / key_actions specific (not abstract) | LLM | reuse (`hone` abstract detection) |
+| GN: panel_breakdown / page_layout / visual_keywords present | deterministic | reuse |
+| Brief honors scene-intent's value_at_stake | LLM | new (this is a 5→6 fidelity check too) |
+
+### Level 7 — Draft
+
+**Use existing scoring.** Novel mode: the 25-principle rubric in `scoring.py`. GN mode: the 6-principle deterministic rubric in `scoring_gn.py` plus the 3-persona evaluation panel.
+
+No new per-level rubric needed at level 7. The existing scoring is the rubric.
+
+---
+
+## Cross-level fidelity scoring
+
+At each of the seven level boundaries (0↔1, 1↔2, ..., 6↔7), two scores:
+
+- **Downward coverage** — does the lower level realize the upper?
+- **Upward faithfulness** — does the lower level honor what's above?
+
+These are different questions and need different checks.
+
+### The cross-level scoring matrix
+
+| Boundary | Downward (deterministic where possible) | Upward (LLM) |
+|---|---|---|
+| 0 → 1 Logline → Synopsis | None deterministic — both are prose | "Does the synopsis still describe the logline's story?" |
+| 1 → 2 Synopsis → Act-shape | None deterministic | "Does the act-shape match the synopsis's outline?" |
+| 2 → 3 Act-shape → Spine | Each spine event maps to one of the three acts (per `part` column) | "Does the spine embody the act-shape's turns?" |
+| 3 → 4 Spine → Architecture | Every spine event has descendant scenes in `scenes.csv` (need a `spine_event` reference column — see "Schema additions" below) | "Do the architecture scenes serve the spine?" |
+| 4 → 5 Architecture → Map | Every architecture scene has full map columns populated | "Does the map's operational metadata honor architecture's structural intent?" |
+| 5 → 6 Map → Briefs | Every map scene has a brief row | "Does the brief honor the scene-intent?" |
+| 6 → 7 Briefs → Draft | Every brief has a draft file with word_count > 0 | "Does the draft honor the brief?" (reuse: this is exactly `brief_fidelity` in scoring_gn.py and the upward signal of `revise --findings`) |
+
+### Where the prose tier is special
+
+The 0↔1, 1↔2 boundaries (and partly 2↔3) have no clean deterministic downward checks — both sides are prose. **All scoring at these boundaries is LLM-driven.** That's expensive and noisy, so we should:
+
+- Run these scores only on demand (not in the hook).
+- Trigger them from the cascade: if the drift detector sees mismatched `_updated` timestamps between, say, logline and synopsis, *then* run the LLM check.
+- Cache results between runs; only re-check if either side has been touched.
+
+### Schema additions to make downward coverage cheap
+
+The deterministic downward check at 3 → 4 (Spine → Architecture) needs a way to map architecture scenes to their parent spine event. Today nothing tracks this — architecture scenes are just rows with `status=architecture`; their relationship to spine events is implicit in the title/sequence.
+
+**Proposed addition: `spine_event` column in `scene-intent.csv`.** When the architecture stage elaborates the spine, each new scene gets the `id` of its parent spine event recorded. Downward coverage becomes a trivial set check.
+
+For 2 → 3 (Act-shape → Spine), the existing `part` column on scenes.csv already partitions spine events into acts; no new column needed. The downward check is "each act has at least one spine event," "each act has events proportional to its length."
+
+For higher levels, the CSV row identity *is* the parent-child relationship (every architecture scene IS a map scene IS a brief IS a draft — same `id`, more columns populated). No new columns needed.
+
+---
+
+## Cross-cutting consistency
+
+### Registry conformance (deterministic)
+
+For every level that has structural data (3–7), check that all references point to real registry entries:
+
+| Reference | Registry | Levels where applicable |
+|---|---|---|
+| `pov` | `characters.csv` | 4, 5, 6, 7 |
+| `characters` | `characters.csv` | 5, 6, 7 |
+| `on_stage` | `characters.csv` | 5, 6, 7 |
+| `location` | `locations.csv` | 5, 6, 7 |
+| `value_at_stake` | `values.csv` | 4, 5, 6, 7 |
+| `motifs` | `motif-taxonomy.csv` | 6, 7 |
+| `mice_threads` | `mice-threads.csv` | 5, 6, 7 |
+| `physical_state_in` / `physical_state_out` | `physical-states.csv` | 6, 7 |
+
+These are pure set comparisons — each one is one CSV read + one set difference. Cheap. Already partly implemented in `hone`. The reorganization here is making the pattern explicit per level instead of hone-specific.
+
+**Score:** for each (level, registry) pair, `coverage = 1.0 - (orphan_count / total_refs)`. A score of 1.0 means every reference resolves; less than 1.0 means orphans exist. Findings are the orphan list with their containing scene IDs.
+
+### Bible consistency (LLM, on demand)
+
+The bibles are richer than the registries — they contain prose descriptions of characters, world systems, voice. Their consistency check is necessarily semantic:
+
+| Check | Levels |
+|---|---|
+| Does the logline reflect the character bible's protagonist? | 0 |
+| Does the synopsis honor the world bible's setting/rules? | 1, 2 |
+| Do the briefs honor the voice guide's tone fingerprint? | 6 |
+| Do the drafts honor the character/world/voice bibles? | 7 (already partially scored) |
+
+These run on demand only (`storyforge score --against-bibles` or similar). They're slow and noisy enough that they should not be wired into the hook.
+
+---
+
+## Composition (or: deliberately don't)
+
+A scene at level 5 has multiple scores against it:
+
+- Map-level quality score
+- Map-level registry consistency
+- Architecture → Map downward coverage (was this scene properly elaborated?)
+- Architecture → Map upward faithfulness (does the map honor architecture?)
+- Map → Briefs downward coverage (does the brief exist?)
+
+Tempting to compose these into one "scene 5 health" number. Don't. The whole point of multi-axis scoring is that different axes mean different things; collapsing them hides which axis is broken.
+
+**Reporting format proposal:** for any level, the author can run `storyforge score --level 5` and get a table:
+
+```
+SCENE         Map-quality  Reg-consist  ↓Coverage  ↑Faithful  ↓Briefs
+act1-sc01        0.92         1.00       1.00       0.85       1.00
+act1-sc02        0.88         1.00       1.00       0.90       0.00*
+act1-sc03        0.95         0.83**     1.00       0.88       1.00
+
+*  no brief row yet (forward elaboration needed)
+** 1 orphan reference: value_at_stake="grace" not in values.csv
+```
+
+One row per scene, one column per axis. Lowest-scoring scenes float to the top via existing sort logic. The asterisks reference notes; the author sees not just a number but the specific finding.
+
+This is exactly how the existing scene-prose scoring already reports. Reuse the table format.
+
+---
+
+## Choosiness pass
+
+Now the uncomfortable part: which of the scores I just proposed actually earn their keep?
+
+### Definitely keep
+
+- **All deterministic checks.** Registry conformance, structural-tier downward coverage, presence/count rubrics. Cheap, signal-rich, fix-actionable.
+- **Existing scene-prose scoring** (level 7). Not changing it.
+- **Brief-fidelity in `revise`'s `--findings` loop.** Already exists; reuse for 6 → 7 upward.
+- **`hone` brief-quality checks.** Already exist; reuse for level 6 quality.
+
+### Probably keep, but on-demand only
+
+- **LLM upward faithfulness at structural boundaries.** Useful when the cascade flags drift. Don't run continuously.
+- **Bible consistency.** Useful pre-publish or pre-major-revision. Don't run continuously.
+- **Prose-tier LLM quality checks** (logline craft, synopsis structure, etc.). Useful when iterating at the top. Don't run continuously.
+
+### Worth thinking about whether to keep at all
+
+- **MICE threads opened are closed** (level 5 quality). Could be a deterministic walk, but the failure case ("a thread is open at the end") is sometimes intentional. Risk: noise.
+- **Causal chain at spine level.** This is a strong claim and probably needs human judgment — an LLM saying "event N doesn't enable event N+1" might be wrong. Might be worth flagging as advisory only.
+- **Scene types are diverse.** A genre constraint, not a universal one. Maybe per-genre rubrics. Skip in v1.
+
+### Skip
+
+- **Composite scores.** Explicit non-feature.
+- **Time-series scoring** (scene quality improving over revisions). Already exists in `score-history.csv`; not redoing it.
+- **Inter-scene narrative-arc scoring.** Tempting but out of scope — the existing architecture-level value-shift checks are the closest we go.
+
+---
+
+## Reuse vs. new code
+
+What carries over from existing scoring, what's new:
+
+| Component | Source | Status |
+|---|---|---|
+| Deterministic scene-prose scoring (novel + GN) | `scoring.py`, `scoring_gn.py`, etc. | Reuse as-is for level 7 |
+| Persona evaluation panel | `cmd_evaluate.py`, `cmd_evaluate_gn.py` | Reuse for level 7 |
+| Registry validation logic | `hone.py` | Generalize — apply the pattern at every level, not just briefs |
+| Structural scoring (brief-level) | `structural.py` | Reuse for level 6 |
+| Findings → revision feedback loop | `cmd_revise.py`, `cmd_revise_gn.py` | Reuse for 6→7 upward fidelity |
+| Score history tracking | `history.py`, `score-history.csv` | Reuse, extend schema to include level + boundary scores |
+| Per-level quality rubrics for levels 0–5 | — | New |
+| LLM faithfulness scoring at boundaries | — | New (small wrapper per boundary; reuses API/cost infra) |
+| Cross-cutting bible-consistency scoring | — | New |
+| Score reporting at non-scene levels (logline, synopsis, etc.) | — | New |
+
+**Where this lands in code (rough):**
+
+- `scoring_levels.py` — new module: per-level quality rubrics for levels 0–6, dispatching to existing scorers where they exist.
+- `scoring_boundary.py` — new module: cross-level fidelity checks, both directions.
+- `scoring_consistency.py` — new module: registry + bible conformance, applied per level.
+- `cmd_score.py` (and `cmd_score_gn.py`) — extended to accept `--level N`, `--boundary N-M`, or `--all`.
+
+This is implementation detail and out of scope for the design doc, but flagged so future implementers know the existing scoring code doesn't need to be refactored from the ground up.
+
+---
+
+## How the scores feed cascade
+
+This is where #226 and #227 stitch together.
+
+The cascade's deterministic drift detection asks one question: "is something out of date or missing?" That's coverage and freshness, not quality. The scoring family that powers cascade is **downward coverage** + **timestamps**.
+
+The cascade's semantic drift detection asks: "are these two levels still saying the same story?" That's **upward faithfulness** scoring. Cascade triggers these LLM checks on demand when the deterministic signals suggest something may be wrong.
+
+The other score families (per-level quality, bible consistency) are NOT for cascade. They're for the author iterating on a level deciding whether it's good enough to advance from.
+
+So the dependency reads:
+
+- Cascade detection → uses downward coverage + timestamps (cheap)
+- Cascade `--semantic` → uses upward faithfulness (expensive)
+- Author quality check at any level → uses per-level quality + registry + bible consistency
+
+Three different reasons to score, with three different cost/cadence profiles.
+
+---
+
+## What's deliberately not in this doc
+
+- **Exact LLM prompts** for the new scoring checks. Implementation.
+- **Score thresholds** (what counts as "passing" at each level). These should emerge from iteration on real projects, not be locked in at design time.
+- **Per-genre rubric variants** (literary vs. thriller vs. romance). Future extension; level rubrics are genre-agnostic for v1.
+- **Visualization / dashboard.** Out of scope; the table view above is the v1 surface.
+- **Scoring of the bibles themselves.** Are the bibles internally consistent? Are they complete? Open question; flagged as future work.
+
+---
+
+## Open questions
+
+1. **Schema addition for spine_event reference.** Adding `spine_event` to `scene-intent.csv` is the cleanest way to get cheap 3→4 downward coverage. The cost is one new column. Worth it. (Implementation note, but flagged here because the design depends on it.)
+
+2. **Composite "level health" view.** I argued against composition in the report. But for cascade UI ("is level 5 in good shape overall?"), some reduction may be necessary. Probably a *traffic-light* view (green/yellow/red per axis) rather than a single number. Decide during implementation.
+
+3. **What if the existing scene-prose scoring's 25 principles overlap with the brief-level quality rubric?** Some principles (e.g., dialogue compression) are level-7 concerns. Some (economy_clarity) might apply to the synopsis too. Decide per-principle whether it generalizes upward.
+
+4. **Threshold-triggered automatic LLM checks.** If a deterministic check finds a coverage gap, should the system automatically run the LLM faithfulness check for the affected branch? Tempting (it's more thorough) but expensive (could run dozens of LLM calls without asking). Default: no auto-trigger; cascade surfaces the issue and the author decides.
+
+5. **Scoring as part of `sync`.** The deterministic cheap scores (registry, coverage, presence) could run in the pre-commit hook alongside sync. The hook would refuse commits with new orphan registry references, new coverage gaps, etc. This is a *quality gate* that the existing sync hook doesn't have. Author preference — some authors will want it, some will find it noisy. Make it opt-in.
+
+---
+
+## Acceptance criteria for the design
+
+This doc is "done" when:
+
+- Each of the eight levels has a quality rubric, even if it's "reuse existing."
+- Each of the seven boundaries has both downward and upward scoring proposals, with explicit "this is LLM-only" or "this has a deterministic check."
+- Registry consistency is generalized from `hone` to every level.
+- Bible consistency is enumerated and explicitly cost-flagged.
+- The choosiness pass has been done — every proposed score has an explicit "keep / on-demand / skip" judgment.
+- The relationship to cascade is unambiguous (which scores power cascade, which don't).
+- Open questions are listed.
+
+(Self-assessment: all pass at the draft level. Open question 1 — schema addition — and open question 5 — quality gates in sync — want explicit author input before implementation.)


### PR DESCRIPTION
Design-doc PR — no code. Closes part of [#224](https://github.com/benjaminsnorris/storyforge/issues/224) (the umbrella) and answers the three research issues underneath it: [#225](https://github.com/benjaminsnorris/storyforge/issues/225), [#226](https://github.com/benjaminsnorris/storyforge/issues/226), [#227](https://github.com/benjaminsnorris/storyforge/issues/227).

## What's on the branch

Four design docs in `docs/superpowers/specs/`:

| File | Purpose |
|------|---------|
| `2026-05-24-elaboration-levels-design.md` | Answers #225 — the 8-level taxonomy in 2 tiers (prose + structural), artifact shapes, storage layout, relationship to bibles |
| `2026-05-24-cascade-mechanics-design.md` | Answers #226 — three motions (forward / upward / lateral), drift detection, conflict format, blast-radius visibility |
| `2026-05-24-elaboration-scoring-design.md` | Answers #227 — three score families (per-level quality, cross-level fidelity, cross-cutting consistency), per-level rubrics, choosiness pass |
| `2026-05-24-elaboration-review-synthesis.md` | **Read this one**. Post-review consolidated proposal — supersedes the originals where they disagree. The first three remain as the pre-review argument and detail. |

## Reading order

1. **Synthesis first.** It's self-contained for the current proposal and captures the *post-review* state. Most of the disagreement-worthy decisions are explicit there.
2. The three originals if you want the detailed argument for the parts that survived review.

## The headline change from the review pass

A four-agent review (engineering, workflow, story-craft skeptic, voice) converged hard on one structural critique: **the originals' "upward faithfulness" scores would pressure authors toward consensus prose.** The synthesis replaces those 0.0–1.0 numbers with a bidirectional diff + persistent author verdict (`correct=upstream | correct=downstream | both are right | needs work`). The LLM still does the semantic comparison; the system stops emitting a number that conflates *drift* (the lower level departed in error) with *discovery* (the lower level found something the upper level didn't know yet). Three new author affordances accompany it: a per-finding override file, a drafting-mode bypass, and per-axis acceptance thresholds.

## What survives review and shouldn't be relitigated

- 8 levels in 2 tiers
- Three motions (forward / upward / lateral)
- Detection-deterministic, resolution-creative
- Don't compose, be choosy
- Blast radius / cost visibility before any cascade fires
- Lateral re-propagation never silently overwrites author work

## What's deferred to v2+

- The full `storyforge cascade` command (ships as `score --drift` in v1)
- LLM-driven semantic boundary checks (designed but not run in v1)
- Bible-consistency pass (~$20-25/run with caching; the most expensive feature; designed but deferred)
- The `spine_event` column on `scene-intent.csv` (~400-600 LOC of migration; use LLM mapping in v1 instead)

## What ships in v1

~600 LOC of Python, ~2 weeks of focused work, no schema migration, no LLM cost story to explain. New `reference/story-summary.md` (with Logline, Synopsis, Act-shape, Theme sections), the override / drafting / threshold mechanisms, a `storyforge score --level N` extension generalizing existing `hone` + `structural` logic, and a read-only `score --drift` report.

## Test plan

No tests — this PR is design docs only. Implementation lands in follow-up PRs once the synthesis has author sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)