### PR TITLE
Fix #245 — raise max_tokens for per-row-heavy tiers + truncation detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.35.2",
+  "version": "1.35.3",
   "author": {
     "name": "Ben Norris"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "author": {
     "name": "Ben Norris"
   },

--- a/references/story-power-rubric.md
+++ b/references/story-power-rubric.md
@@ -995,6 +995,31 @@ Four axes predict *lasting* more strongly than the others and get a
 
 Composite = `sum(score * weight) / sum(weights)`. Range stays 1-10.
 
+## Output token budget
+
+Per-tier `max_tokens` ceilings, codified in `scoring_story_power.py`:
+
+| Tier | Ceiling | Why |
+|---|---|---|
+| Pitch | 4,096 | 8 axes × bounded rationale |
+| Act-shape | 8,192 | 3 acts × 8 axes + 4 structural axes |
+| Spine | 8,192 | 5-10 events × 3 axes + 5 whole-spine |
+| Architecture | 32,768 | Per-scene axes scale with scene count |
+| Scene-map | 32,768 | Per-scene axes scale with scene count |
+| Briefs | 32,768 | Per-brief axes scale with brief count |
+
+The per-row-heavy tiers (architecture, scene-map, briefs) emit
+rationale that scales with project size. On real-sized manuscripts
+(25+ architecture scenes, 60+ scene-map rows, 30+ briefs), an 8K
+ceiling silently truncates the response mid-JSON; the parser then
+fails with a generic "unparseable" error. 32K leaves substantial
+headroom and is well under the 64K Claude Opus output cap.
+
+When the LLM truncates anyway (unusually large project, a future
+rubric that grew the prompt), the unparseable error message names
+truncation explicitly via `stop_reason=max_tokens` — so the cause is
+visible without grep-ing the raw log.
+
 ## Diagnostic output
 
 The scorecard ALSO produces a `diagnostic.md` that surfaces cross-axis

--- a/references/story-power-rubric.md
+++ b/references/story-power-rubric.md
@@ -1013,7 +1013,8 @@ rationale that scales with project size. On real-sized manuscripts
 (25+ architecture scenes, 60+ scene-map rows, 30+ briefs), an 8K
 ceiling silently truncates the response mid-JSON; the parser then
 fails with a generic "unparseable" error. 32K leaves substantial
-headroom and is well under the 64K Claude Opus output cap.
+headroom and is well under the per-model output cap (Opus 4.6: 128K,
+Sonnet 4.6: 64K — see `api.MODEL_MAX_OUTPUT` for the source of truth).
 
 When the LLM truncates anyway (unusually large project, a future
 rubric that grew the prompt), the unparseable error message names

--- a/scripts/lib/python/storyforge/scoring_story_power.py
+++ b/scripts/lib/python/storyforge/scoring_story_power.py
@@ -1469,7 +1469,8 @@ def _invoke_and_parse(project_dir: str, output_dir: str, log_file: str,
     model = select_model('creative')
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=4096)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_PITCH_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: story-power LLM call failed: {e}')
         return None, 'llm_error'
@@ -1477,7 +1478,8 @@ def _invoke_and_parse(project_dir: str, output_dir: str, log_file: str,
     parsed = _parse_response(text)
     if not parsed:
         _record_cost(project_dir, log_file, model, target='story-power:unparseable')
-        log(f'ERROR: story-power LLM response unparseable; raw at {log_file}')
+        log(f'ERROR: story-power LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _PITCH_MAX_TOKENS)}')
         return None, 'unparseable'
     _record_cost(project_dir, log_file, model)
     return parsed, 'ok'
@@ -1494,6 +1496,55 @@ def _read_response_text(log_file: str) -> str:
         if block.get('type') == 'text':
             return block.get('text', '')
     return ''
+
+
+def _read_stop_reason(log_file: str) -> str:
+    """Read the LLM's `stop_reason` from the raw log file. Returns an
+    empty string when the file is missing / unreadable / lacks the
+    field. Used to distinguish truncation (`max_tokens`) from other
+    unparseable-response causes so the error message names the
+    actual cause rather than just 'parse failed'."""
+    try:
+        with open(log_file, encoding='utf-8') as f:
+            resp = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return ''
+    return resp.get('stop_reason', '') or ''
+
+
+# Output-token ceilings per tier. The pitch + act-shape + spine tiers
+# return bounded payloads (8 axes × ≤3 acts; 5-10 events × 3 axes); 4K
+# and 8K respectively are sufficient. The per-row-heavy tiers
+# (architecture, scene-map, briefs) emit per-scene / per-brief
+# rationales that scale with project size — on a 25-scene
+# architecture or 60-scene scene map the 8K ceiling truncates the
+# response mid-JSON, producing parse failures (issue #245). 32K
+# leaves 4× headroom over the observed wall and is well below the
+# 64K Claude Opus output cap.
+_PITCH_MAX_TOKENS = 4096
+_BOUNDED_TIER_MAX_TOKENS = 8192
+_PER_ROW_TIER_MAX_TOKENS = 32768
+
+
+def _truncation_hint(log_file: str, max_tokens: int) -> str:
+    """Return a descriptive suffix when the LLM hit `max_tokens` and
+    the response is therefore truncated mid-JSON. Returns '' when
+    stop_reason is anything else (genuine parse error, not
+    truncation). The caller appends this to the unparseable ERROR so
+    the user sees the actual cause without having to grep the raw log.
+
+    Pinned by issue #245: a 25-scene architecture or 60-scene scene
+    map can hit the 8K ceiling silently; the previous error message
+    said only 'unparseable' without distinguishing truncation from
+    other parse failures."""
+    if _read_stop_reason(log_file) != 'max_tokens':
+        return ''
+    return (
+        f' (LLM hit max_tokens={max_tokens} and the response was '
+        'truncated mid-JSON — not a genuine parse failure. The tier '
+        'output scales with project size; consider reducing scope '
+        'with --scope or raising the per-tier ceiling.)'
+    )
 
 
 def _extract_scores(parsed: dict) -> dict[str, int]:
@@ -1853,7 +1904,8 @@ def _run_act_shape_extension(project_dir: str, output_dir: str,
                             os.path.basename(output_dir) + '-act-shape.json')
     os.makedirs(log_dir, exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_BOUNDED_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: act-shape LLM call failed: {e}. Pitch-mode scorecard '
             'still stands.')
@@ -1863,7 +1915,8 @@ def _run_act_shape_extension(project_dir: str, output_dir: str,
     if not parsed:
         _record_cost(project_dir, log_file, model,
                      target='story-power:act-shape:unparseable')
-        log(f'ERROR: act-shape LLM response unparseable; raw at {log_file}. '
+        log(f'ERROR: act-shape LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _BOUNDED_TIER_MAX_TOKENS)}. '
             'Pitch-mode scorecard still stands.')
         return _empty_extension('unparseable')
     _record_cost(project_dir, log_file, model, target='story-power:act-shape')
@@ -2909,7 +2962,8 @@ def _run_spine_extension(project_dir: str, output_dir: str, log_dir: str,
                             os.path.basename(output_dir) + '-spine.json')
     os.makedirs(log_dir, exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_BOUNDED_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: spine LLM call failed: {e}. Pitch result still stands.')
         return _empty_spine_extension('llm_error')
@@ -2918,7 +2972,8 @@ def _run_spine_extension(project_dir: str, output_dir: str, log_dir: str,
     if not parsed:
         _record_cost(project_dir, log_file, model,
                      target='story-power:spine:unparseable')
-        log(f'ERROR: spine LLM response unparseable; raw at {log_file}.')
+        log(f'ERROR: spine LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _BOUNDED_TIER_MAX_TOKENS)}.')
         return _empty_spine_extension('unparseable')
     _record_cost(project_dir, log_file, model, target='story-power:spine')
 
@@ -3675,7 +3730,8 @@ def _run_architecture_extension(project_dir: str, output_dir: str,
                             os.path.basename(output_dir) + '-architecture.json')
     os.makedirs(log_dir, exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_PER_ROW_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: architecture LLM call failed: {e}. Pitch result still stands.')
         ext = _empty_architecture_extension('llm_error')
@@ -3686,7 +3742,8 @@ def _run_architecture_extension(project_dir: str, output_dir: str,
     if not parsed:
         _record_cost(project_dir, log_file, model,
                      target='story-power:architecture:unparseable')
-        log(f'ERROR: architecture LLM response unparseable; raw at {log_file}.')
+        log(f'ERROR: architecture LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _PER_ROW_TIER_MAX_TOKENS)}.')
         ext = _empty_architecture_extension('unparseable')
         ext['field_findings'] = det_findings
         return ext
@@ -4568,7 +4625,8 @@ def _run_scene_map_extension(project_dir: str, output_dir: str,
                             os.path.basename(output_dir) + '-scene-map.json')
     os.makedirs(log_dir, exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_PER_ROW_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: scene-map LLM call failed: {e}. Pitch result still stands.')
         ext = _empty_scene_map_extension('llm_error')
@@ -4579,7 +4637,8 @@ def _run_scene_map_extension(project_dir: str, output_dir: str,
     if not parsed:
         _record_cost(project_dir, log_file, model,
                      target='story-power:scene-map:unparseable')
-        log(f'ERROR: scene-map LLM response unparseable; raw at {log_file}.')
+        log(f'ERROR: scene-map LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _PER_ROW_TIER_MAX_TOKENS)}.')
         ext = _empty_scene_map_extension('unparseable')
         ext['continuity_findings'] = det_findings
         return ext
@@ -5445,7 +5504,8 @@ def _run_briefs_extension(project_dir: str, output_dir: str,
                             os.path.basename(output_dir) + '-briefs.json')
     os.makedirs(log_dir, exist_ok=True)
     try:
-        invoke_to_file(prompt, model, log_file, max_tokens=8192)
+        invoke_to_file(prompt, model, log_file,
+                       max_tokens=_PER_ROW_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: briefs LLM call failed: {e}. Pitch result still stands.')
         ext = _empty_briefs_extension('llm_error')
@@ -5456,7 +5516,8 @@ def _run_briefs_extension(project_dir: str, output_dir: str,
     if not parsed:
         _record_cost(project_dir, log_file, model,
                      target='story-power:briefs:unparseable')
-        log(f'ERROR: briefs LLM response unparseable; raw at {log_file}.')
+        log(f'ERROR: briefs LLM response unparseable; raw at '
+            f'{log_file}{_truncation_hint(log_file, _PER_ROW_TIER_MAX_TOKENS)}.')
         ext = _empty_briefs_extension('unparseable')
         ext['brief_findings'] = det_findings
         return ext

--- a/scripts/lib/python/storyforge/scoring_story_power.py
+++ b/scripts/lib/python/storyforge/scoring_story_power.py
@@ -1498,20 +1498,6 @@ def _read_response_text(log_file: str) -> str:
     return ''
 
 
-def _read_stop_reason(log_file: str) -> str:
-    """Read the LLM's `stop_reason` from the raw log file. Returns an
-    empty string when the file is missing / unreadable / lacks the
-    field. Used to distinguish truncation (`max_tokens`) from other
-    unparseable-response causes so the error message names the
-    actual cause rather than just 'parse failed'."""
-    try:
-        with open(log_file, encoding='utf-8') as f:
-            resp = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return ''
-    return resp.get('stop_reason', '') or ''
-
-
 # Output-token ceilings per tier. The pitch + act-shape + spine tiers
 # return bounded payloads (8 axes × ≤3 acts; 5-10 events × 3 axes); 4K
 # and 8K respectively are sufficient. The per-row-heavy tiers
@@ -1523,28 +1509,119 @@ def _read_stop_reason(log_file: str) -> str:
 # (see api.MODEL_MAX_OUTPUT for the source of truth — Opus 4.6 caps
 # at 128K, Sonnet at 64K).
 _PITCH_MAX_TOKENS = 4096
-_BOUNDED_TIER_MAX_TOKENS = 8192
+_FIXED_PAYLOAD_TIER_MAX_TOKENS = 8192
 _PER_ROW_TIER_MAX_TOKENS = 32768
+
+# Monotonic ordering is an implicit design invariant: smaller payload
+# ⇒ smaller budget. A typo-class swap (e.g. setting pitch to 40960
+# and per-row to 4096) would currently only surface at LLM-truncation
+# time on the per-row tiers; this assert catches it at import.
+assert (_PITCH_MAX_TOKENS
+        <= _FIXED_PAYLOAD_TIER_MAX_TOKENS
+        <= _PER_ROW_TIER_MAX_TOKENS), (
+    f'story-power tier ceilings must be monotone non-decreasing '
+    f'(pitch={_PITCH_MAX_TOKENS}, fixed-payload={_FIXED_PAYLOAD_TIER_MAX_TOKENS}, '
+    f'per-row={_PER_ROW_TIER_MAX_TOKENS})'
+)
+
+
+# Anthropic stop_reason values per
+# https://docs.anthropic.com/en/api/messages — a closed set. The
+# Literal narrows downstream comparisons statically; the companion
+# frozenset gives runtime membership for schema-drift detection
+# (mirrors the BriefOutcome / VALID_BRIEF_OUTCOMES pattern). The
+# empty-string sentinel covers missing-from-response / unreadable
+# log file (see _read_stop_reason).
+StopReason = Literal[
+    'end_turn',
+    'max_tokens',
+    'stop_sequence',
+    'tool_use',
+    'pause_turn',
+    'refusal',
+    '',
+]
+KNOWN_STOP_REASONS: frozenset[StopReason] = frozenset({
+    'end_turn', 'max_tokens', 'stop_sequence',
+    'tool_use', 'pause_turn', 'refusal', '',
+})
+# Module-load contract: the only stop_reason the truncation hint cares
+# about must be a recognized value, otherwise the helper silently
+# disables itself.
+assert 'max_tokens' in KNOWN_STOP_REASONS, (
+    '_truncation_hint compares against literal "max_tokens"; if that '
+    'value drops out of KNOWN_STOP_REASONS, truncation detection is '
+    'silently disabled'
+)
+
+
+def _read_stop_reason(log_file: str) -> str:
+    """Read the LLM's `stop_reason` from the raw log file. Returns an
+    empty string when the file is missing / unreadable / lacks the
+    field / has a non-dict top-level (e.g., partial write produced a
+    JSON list).
+
+    Used to distinguish truncation (`max_tokens`) from other
+    unparseable-response causes so the error message names the
+    actual cause rather than just 'parse failed'.
+
+    Logs an INFO with the unrecognized value when stop_reason is
+    present but not in KNOWN_STOP_REASONS — this surfaces Anthropic
+    API schema drift (a new value appearing) so the codebase doesn't
+    silently lose truncation detection on a future change.
+
+    Logs a WARNING on OSError (file should exist but couldn't be
+    read) so the diagnostic itself doesn't fail silently — mirrors
+    _read_response_text's behavior. A JSONDecodeError is *expected*
+    on partial writes (the file exists, content is partial) and
+    stays quiet.
+    """
+    try:
+        with open(log_file, encoding='utf-8') as f:
+            resp = json.load(f)
+    except OSError as e:
+        log(f'WARNING: could not read story-power log to extract '
+            f'stop_reason: {e}')
+        return ''
+    except json.JSONDecodeError:
+        return ''
+    if not isinstance(resp, dict):
+        # A non-dict top level (list / string / number) is malformed
+        # for an Anthropic response shape; .get would crash and
+        # propagate AttributeError through the f-string in the
+        # caller, suppressing the original unparseable-error message.
+        return ''
+    raw = resp.get('stop_reason', '')
+    if not isinstance(raw, str):
+        return ''
+    if raw and raw not in KNOWN_STOP_REASONS:
+        log(f'INFO: story-power LLM returned unrecognized '
+            f'stop_reason={raw!r}; truncation detection will not '
+            'fire on this value. If Anthropic added a new stop_reason '
+            'token, extend KNOWN_STOP_REASONS to match.')
+    return raw
 
 
 def _truncation_hint(log_file: str, max_tokens: int) -> str:
-    """Return a descriptive suffix when the LLM hit `max_tokens` and
-    the response is therefore truncated mid-JSON. Returns '' when
-    stop_reason is anything else (genuine parse error, not
-    truncation). The caller appends this to the unparseable ERROR so
-    the user sees the actual cause without having to grep the raw log.
+    """Return a descriptive suffix when the LLM hit `max_tokens`.
 
-    Pinned by issue #245: a 25-scene architecture or 60-scene scene
-    map can hit the 8K ceiling silently; the previous error message
-    said only 'unparseable' without distinguishing truncation from
-    other parse failures."""
+    Returns '' when stop_reason is anything else. The caller appends
+    this to the unparseable ERROR so the user sees the actual cause
+    without grepping the raw log.
+
+    The wording is hedged ("likely truncated") rather than asserting
+    truncation outright: stop_reason='max_tokens' guarantees the LLM
+    stopped at the budget, but the response could in principle land
+    on valid-but-incomplete JSON whose parse failure has a different
+    proximate cause. Truncation is overwhelmingly the most likely
+    explanation when both signals fire together."""
     if _read_stop_reason(log_file) != 'max_tokens':
         return ''
     return (
-        f' (LLM hit max_tokens={max_tokens} and the response was '
-        'truncated mid-JSON — not a genuine parse failure. The tier '
-        'output scales with project size; consider reducing scope '
-        'with --scope or raising the per-tier ceiling.)'
+        f' (LLM hit max_tokens={max_tokens}; the response was likely '
+        'truncated mid-JSON. The tier output scales with project '
+        'size — consider reducing scope or raising the per-tier '
+        'ceiling.)'
     )
 
 
@@ -1906,7 +1983,7 @@ def _run_act_shape_extension(project_dir: str, output_dir: str,
     os.makedirs(log_dir, exist_ok=True)
     try:
         invoke_to_file(prompt, model, log_file,
-                       max_tokens=_BOUNDED_TIER_MAX_TOKENS)
+                       max_tokens=_FIXED_PAYLOAD_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: act-shape LLM call failed: {e}. Pitch-mode scorecard '
             'still stands.')
@@ -1917,7 +1994,7 @@ def _run_act_shape_extension(project_dir: str, output_dir: str,
         _record_cost(project_dir, log_file, model,
                      target='story-power:act-shape:unparseable')
         log(f'ERROR: act-shape LLM response unparseable; raw at '
-            f'{log_file}{_truncation_hint(log_file, _BOUNDED_TIER_MAX_TOKENS)}. '
+            f'{log_file}{_truncation_hint(log_file, _FIXED_PAYLOAD_TIER_MAX_TOKENS)}. '
             'Pitch-mode scorecard still stands.')
         return _empty_extension('unparseable')
     _record_cost(project_dir, log_file, model, target='story-power:act-shape')
@@ -2964,7 +3041,7 @@ def _run_spine_extension(project_dir: str, output_dir: str, log_dir: str,
     os.makedirs(log_dir, exist_ok=True)
     try:
         invoke_to_file(prompt, model, log_file,
-                       max_tokens=_BOUNDED_TIER_MAX_TOKENS)
+                       max_tokens=_FIXED_PAYLOAD_TIER_MAX_TOKENS)
     except Exception as e:
         log(f'ERROR: spine LLM call failed: {e}. Pitch result still stands.')
         return _empty_spine_extension('llm_error')
@@ -2974,7 +3051,7 @@ def _run_spine_extension(project_dir: str, output_dir: str, log_dir: str,
         _record_cost(project_dir, log_file, model,
                      target='story-power:spine:unparseable')
         log(f'ERROR: spine LLM response unparseable; raw at '
-            f'{log_file}{_truncation_hint(log_file, _BOUNDED_TIER_MAX_TOKENS)}.')
+            f'{log_file}{_truncation_hint(log_file, _FIXED_PAYLOAD_TIER_MAX_TOKENS)}.')
         return _empty_spine_extension('unparseable')
     _record_cost(project_dir, log_file, model, target='story-power:spine')
 

--- a/scripts/lib/python/storyforge/scoring_story_power.py
+++ b/scripts/lib/python/storyforge/scoring_story_power.py
@@ -1516,11 +1516,12 @@ def _read_stop_reason(log_file: str) -> str:
 # return bounded payloads (8 axes × ≤3 acts; 5-10 events × 3 axes); 4K
 # and 8K respectively are sufficient. The per-row-heavy tiers
 # (architecture, scene-map, briefs) emit per-scene / per-brief
-# rationales that scale with project size — on a 25-scene
-# architecture or 60-scene scene map the 8K ceiling truncates the
-# response mid-JSON, producing parse failures (issue #245). 32K
-# leaves 4× headroom over the observed wall and is well below the
-# 64K Claude Opus output cap.
+# rationales that scale with project size — at real-sized project
+# counts the 8K ceiling truncates the response mid-JSON, producing
+# parse failures (issue #245). 32K leaves substantial headroom over
+# the observed wall and remains well under the per-model output cap
+# (see api.MODEL_MAX_OUTPUT for the source of truth — Opus 4.6 caps
+# at 128K, Sonnet at 64K).
 _PITCH_MAX_TOKENS = 4096
 _BOUNDED_TIER_MAX_TOKENS = 8192
 _PER_ROW_TIER_MAX_TOKENS = 32768

--- a/tests/test_scoring_story_power.py
+++ b/tests/test_scoring_story_power.py
@@ -5901,3 +5901,286 @@ def test_briefs_skipped_when_csv_contains_only_scaffold_rows(tmp_path,
     assert result['briefs'] is None
 
 
+# ---------------------------------------------------------------------------
+# Issue #245 — max_tokens raised + truncation detection
+# ---------------------------------------------------------------------------
+
+def test_per_row_tier_max_tokens_constant_above_8k():
+    """The per-row-heavy tiers (architecture, scene-map, briefs) ship
+    with a max_tokens ceiling well above the 8K wall observed in
+    issue #245 (15-scene architecture + 43-scene scene-map both
+    truncated mid-JSON at 8192 output tokens)."""
+    from storyforge.scoring_story_power import (
+        _PER_ROW_TIER_MAX_TOKENS, _BOUNDED_TIER_MAX_TOKENS,
+        _PITCH_MAX_TOKENS,
+    )
+    assert _PER_ROW_TIER_MAX_TOKENS >= 16384, (
+        f'per-row tier ceiling must be at least 2× the observed 8K '
+        f'wall; got {_PER_ROW_TIER_MAX_TOKENS}'
+    )
+    # Bounded tiers (act-shape, spine) and pitch retain their lower
+    # ceilings — their payloads don't scale with project size.
+    assert _BOUNDED_TIER_MAX_TOKENS == 8192
+    assert _PITCH_MAX_TOKENS == 4096
+
+
+def test_architecture_passes_per_row_max_tokens(tmp_path, monkeypatch):
+    """Architecture mode calls invoke_to_file with the per-row tier
+    ceiling, not the old 8K wall."""
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    seen_max_tokens: dict[str, int] = {}
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-architecture' in log_file:
+            seen_max_tokens['architecture'] = kwargs.get('max_tokens', -1)
+            payload = _architecture_payload()
+        elif '-spine' in log_file:
+            payload = _spine_payload()
+        elif '-act-shape' in log_file:
+            payload = _act_shape_payload()
+        else:
+            payload = _full_payload()
+        response = {
+            'content': [{'type': 'text', 'text': json.dumps(payload)}],
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert seen_max_tokens['architecture'] == (
+        scoring_story_power._PER_ROW_TIER_MAX_TOKENS
+    ), seen_max_tokens
+
+
+def test_scene_map_passes_per_row_max_tokens(tmp_path, monkeypatch):
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    _seed_scene_map(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    seen: dict[str, int] = {}
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-scene-map' in log_file:
+            seen['scene-map'] = kwargs.get('max_tokens', -1)
+            payload = _scene_map_payload()
+        elif '-architecture' in log_file:
+            payload = _architecture_payload()
+        elif '-spine' in log_file:
+            payload = _spine_payload()
+        elif '-act-shape' in log_file:
+            payload = _act_shape_payload()
+        else:
+            payload = _full_payload()
+        response = {
+            'content': [{'type': 'text', 'text': json.dumps(payload)}],
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert seen['scene-map'] == scoring_story_power._PER_ROW_TIER_MAX_TOKENS
+
+
+def test_briefs_passes_per_row_max_tokens(tmp_path, monkeypatch):
+    _seed_summary(str(tmp_path))
+    _seed_briefs(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    seen: dict[str, int] = {}
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-briefs' in log_file:
+            seen['briefs'] = kwargs.get('max_tokens', -1)
+            payload = _briefs_payload()
+        elif '-act-shape' in log_file:
+            payload = _act_shape_payload()
+        else:
+            payload = _full_payload()
+        response = {
+            'content': [{'type': 'text', 'text': json.dumps(payload)}],
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert seen['briefs'] == scoring_story_power._PER_ROW_TIER_MAX_TOKENS
+
+
+def test_read_stop_reason_returns_field_when_present(tmp_path):
+    """Reads the LLM's stop_reason from the raw response log."""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({
+            'content': [{'type': 'text', 'text': 'partial'}],
+            'stop_reason': 'max_tokens',
+            'usage': {'input_tokens': 500, 'output_tokens': 8192},
+        }, f)
+    assert _read_stop_reason(log_file) == 'max_tokens'
+
+
+def test_read_stop_reason_handles_missing_field(tmp_path):
+    """A response without stop_reason (common in mocks) yields ''."""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({'content': [{'type': 'text', 'text': 'x'}]}, f)
+    assert _read_stop_reason(log_file) == ''
+
+
+def test_read_stop_reason_handles_missing_file():
+    from storyforge.scoring_story_power import _read_stop_reason
+    assert _read_stop_reason('/nonexistent/path.json') == ''
+
+
+def test_truncation_hint_returns_descriptive_text_on_max_tokens(tmp_path):
+    """When stop_reason is max_tokens, the hint names the cause + the
+    ceiling so the user knows which knob to turn."""
+    from storyforge.scoring_story_power import _truncation_hint
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({
+            'content': [{'type': 'text', 'text': 'partial'}],
+            'stop_reason': 'max_tokens',
+        }, f)
+    hint = _truncation_hint(log_file, 32768)
+    assert hint != ''
+    assert 'max_tokens=32768' in hint
+    assert 'truncated' in hint
+
+
+def test_truncation_hint_returns_empty_for_genuine_parse_failure(tmp_path):
+    """When stop_reason is end_turn (or absent), the hint is empty —
+    the parse failure is genuine, not truncation, and the original
+    'unparseable' message stands alone."""
+    from storyforge.scoring_story_power import _truncation_hint
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({
+            'content': [{'type': 'text', 'text': 'not json'}],
+            'stop_reason': 'end_turn',
+        }, f)
+    assert _truncation_hint(log_file, 32768) == ''
+
+
+def test_architecture_unparseable_with_max_tokens_logs_truncation_hint(
+        tmp_path, monkeypatch, capsys):
+    """End-to-end: when architecture LLM truncates at max_tokens and
+    the response is therefore unparseable, the ERROR message names
+    truncation as the cause — not 'parse failed' alone. (Issue #245
+    acceptance criterion 4.)"""
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-architecture' in log_file:
+            # Truncated JSON + stop_reason=max_tokens — the real-world
+            # signature from the issue logs.
+            text = '{"per_scene": [{"scene_id": "a01", "scores":'
+            stop = 'max_tokens'
+        elif '-spine' in log_file:
+            text = json.dumps(_spine_payload())
+            stop = 'end_turn'
+        elif '-act-shape' in log_file:
+            text = json.dumps(_act_shape_payload())
+            stop = 'end_turn'
+        else:
+            text = json.dumps(_full_payload())
+            stop = 'end_turn'
+        response = {
+            'content': [{'type': 'text', 'text': text}],
+            'stop_reason': stop,
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    result = scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert result['architecture']['status'] == 'unparseable'
+    out = capsys.readouterr().out
+    assert 'architecture LLM response unparseable' in out
+    assert 'truncated mid-JSON' in out
+    # The ceiling is named so the user knows the budget that hit the
+    # wall.
+    assert 'max_tokens=32768' in out
+
+
+def test_unparseable_without_truncation_omits_hint(tmp_path, monkeypatch,
+                                                      capsys):
+    """When the LLM returns malformed JSON but did NOT hit
+    max_tokens, the error message stays clean — no spurious
+    'truncated' suffix on what is actually a genuine parse failure."""
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-architecture' in log_file:
+            text = 'this is not json'
+            stop = 'end_turn'
+        elif '-spine' in log_file:
+            text = json.dumps(_spine_payload())
+            stop = 'end_turn'
+        elif '-act-shape' in log_file:
+            text = json.dumps(_act_shape_payload())
+            stop = 'end_turn'
+        else:
+            text = json.dumps(_full_payload())
+            stop = 'end_turn'
+        response = {
+            'content': [{'type': 'text', 'text': text}],
+            'stop_reason': stop,
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    out = capsys.readouterr().out
+    assert 'architecture LLM response unparseable' in out
+    assert 'truncated mid-JSON' not in out
+
+

--- a/tests/test_scoring_story_power.py
+++ b/tests/test_scoring_story_power.py
@@ -5911,7 +5911,7 @@ def test_per_row_tier_max_tokens_constant_above_8k():
     issue #245 (15-scene architecture + 43-scene scene-map both
     truncated mid-JSON at 8192 output tokens)."""
     from storyforge.scoring_story_power import (
-        _PER_ROW_TIER_MAX_TOKENS, _BOUNDED_TIER_MAX_TOKENS,
+        _PER_ROW_TIER_MAX_TOKENS, _FIXED_PAYLOAD_TIER_MAX_TOKENS,
         _PITCH_MAX_TOKENS,
     )
     assert _PER_ROW_TIER_MAX_TOKENS >= 16384, (
@@ -5920,7 +5920,7 @@ def test_per_row_tier_max_tokens_constant_above_8k():
     )
     # Bounded tiers (act-shape, spine) and pitch retain their lower
     # ceilings — their payloads don't scale with project size.
-    assert _BOUNDED_TIER_MAX_TOKENS == 8192
+    assert _FIXED_PAYLOAD_TIER_MAX_TOKENS == 8192
     assert _PITCH_MAX_TOKENS == 4096
 
 
@@ -6207,5 +6207,133 @@ def test_unparseable_without_truncation_omits_hint(tmp_path, monkeypatch,
     out = capsys.readouterr().out
     assert 'architecture LLM response unparseable' in out
     assert 'truncated mid-JSON' not in out
+
+
+def test_read_stop_reason_handles_non_dict_top_level(tmp_path):
+    """A JSON log whose top level is a list / string / number must not
+    crash _read_stop_reason — the .get call on a non-dict would
+    propagate AttributeError out of the diagnostic helper and
+    suppress the original unparseable-error message. (PR #247 review
+    SF-HIGH-1.)"""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'resp.json')
+    # Top-level list — has happened on partial writes where only the
+    # `content` array was flushed.
+    with open(log_file, 'w') as f:
+        json.dump(['partial', 'list'], f)
+    assert _read_stop_reason(log_file) == ''
+
+
+def test_read_stop_reason_handles_non_string_stop_reason(tmp_path):
+    """A response with a non-string stop_reason value (would not match
+    the API contract, but defensive against schema drift) returns ''
+    rather than crashing the comparison downstream."""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({'stop_reason': {'unexpected': 'shape'}}, f)
+    assert _read_stop_reason(log_file) == ''
+
+
+def test_read_stop_reason_logs_warning_on_oserror(tmp_path, capsys):
+    """OSError (file should exist but unreadable, or a missing
+    directory leading to FileNotFoundError) logs a WARNING so the
+    diagnostic itself doesn't fail silently. Mirrors
+    _read_response_text's behavior. (PR #247 review SF-MED-2.)"""
+    from storyforge.scoring_story_power import _read_stop_reason
+    # Nested non-existent directory raises FileNotFoundError, an
+    # OSError subclass.
+    _read_stop_reason(str(tmp_path / 'sub' / 'missing.json'))
+    out = capsys.readouterr().out
+    assert 'could not read story-power log' in out
+
+
+def test_read_stop_reason_decode_error_stays_quiet(tmp_path, capsys):
+    """A JSONDecodeError is expected on partial writes (file exists,
+    content incomplete) and stays quiet — that's the normal case
+    for a truncated invoke_to_file, not a diagnostic failure."""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'partial.json')
+    with open(log_file, 'w') as f:
+        f.write('{"partial":')  # incomplete
+    assert _read_stop_reason(log_file) == ''
+    out = capsys.readouterr().out
+    # The OSError WARNING must NOT fire on a parse failure.
+    assert 'could not read story-power log' not in out
+
+
+def test_read_stop_reason_logs_info_on_unrecognized_value(tmp_path, capsys):
+    """An unrecognized stop_reason value (Anthropic API schema drift)
+    logs an INFO so the codebase doesn't silently lose truncation
+    detection on a future API change. (PR #247 review SF-HIGH-2.)"""
+    from storyforge.scoring_story_power import _read_stop_reason
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({'stop_reason': 'budget_exhausted'}, f)
+    result = _read_stop_reason(log_file)
+    # The helper still returns the raw value so a downstream consumer
+    # can decide what to do; the INFO is a breadcrumb, not a block.
+    assert result == 'budget_exhausted'
+    out = capsys.readouterr().out
+    assert 'unrecognized stop_reason' in out
+    assert 'budget_exhausted' in out
+    assert 'KNOWN_STOP_REASONS' in out
+
+
+def test_read_stop_reason_known_values_stay_quiet(tmp_path, capsys):
+    """The documented stop_reason values do NOT log INFO — the
+    drift-detection breadcrumb should fire only on schema surprise."""
+    from storyforge.scoring_story_power import (
+        _read_stop_reason, KNOWN_STOP_REASONS,
+    )
+    log_file = str(tmp_path / 'resp.json')
+    for known in KNOWN_STOP_REASONS:
+        if not known:
+            continue  # '' sentinel covered by missing-field test
+        with open(log_file, 'w') as f:
+            json.dump({'stop_reason': known}, f)
+        _read_stop_reason(log_file)
+    out = capsys.readouterr().out
+    assert 'unrecognized stop_reason' not in out
+
+
+def test_max_tokens_constants_are_monotone():
+    """The module-load assert pins _PITCH <= _FIXED_PAYLOAD <=
+    _PER_ROW. This regression test exercises the actual values so a
+    future edit can't accidentally invert the ordering and rely on
+    the import-time assert never running. (PR #247 review TD-HIGH-1.)"""
+    from storyforge.scoring_story_power import (
+        _PITCH_MAX_TOKENS, _FIXED_PAYLOAD_TIER_MAX_TOKENS,
+        _PER_ROW_TIER_MAX_TOKENS,
+    )
+    assert _PITCH_MAX_TOKENS <= _FIXED_PAYLOAD_TIER_MAX_TOKENS
+    assert _FIXED_PAYLOAD_TIER_MAX_TOKENS <= _PER_ROW_TIER_MAX_TOKENS
+
+
+def test_known_stop_reasons_includes_max_tokens():
+    """KNOWN_STOP_REASONS must include 'max_tokens', otherwise the
+    drift-detection INFO would fire on every truncation and the
+    truncation hint would silently disable itself."""
+    from storyforge.scoring_story_power import KNOWN_STOP_REASONS
+    assert 'max_tokens' in KNOWN_STOP_REASONS
+    # The other documented values per Anthropic API docs.
+    assert 'end_turn' in KNOWN_STOP_REASONS
+    assert 'stop_sequence' in KNOWN_STOP_REASONS
+    assert 'tool_use' in KNOWN_STOP_REASONS
+
+
+def test_truncation_hint_uses_hedged_wording(tmp_path):
+    """The hint says 'likely truncated', not 'was truncated' —
+    stop_reason=max_tokens guarantees the LLM stopped at the budget
+    but doesn't *prove* the JSON was truncated mid-token. The hedge
+    prevents a future 'you said truncated but the JSON was complete'
+    confusion. (PR #247 review SF-MED-1.)"""
+    from storyforge.scoring_story_power import _truncation_hint
+    log_file = str(tmp_path / 'resp.json')
+    with open(log_file, 'w') as f:
+        json.dump({'stop_reason': 'max_tokens'}, f)
+    hint = _truncation_hint(log_file, 32768)
+    assert 'likely truncated' in hint
+    assert 'was truncated' not in hint
 
 

--- a/tests/test_scoring_story_power.py
+++ b/tests/test_scoring_story_power.py
@@ -5902,7 +5902,7 @@ def test_briefs_skipped_when_csv_contains_only_scaffold_rows(tmp_path,
 
 
 # ---------------------------------------------------------------------------
-# Issue #245 — max_tokens raised + truncation detection
+# max_tokens ceilings + truncation detection
 # ---------------------------------------------------------------------------
 
 def test_per_row_tier_max_tokens_constant_above_8k():
@@ -6120,8 +6120,7 @@ def test_architecture_unparseable_with_max_tokens_logs_truncation_hint(
         tmp_path, monkeypatch, capsys):
     """End-to-end: when architecture LLM truncates at max_tokens and
     the response is therefore unparseable, the ERROR message names
-    truncation as the cause — not 'parse failed' alone. (Issue #245
-    acceptance criterion 4.)"""
+    truncation as the cause — not 'parse failed' alone."""
     _seed_summary(str(tmp_path))
     _seed_architecture(str(tmp_path))
     monkeypatch.chdir(str(tmp_path))

--- a/tests/test_scoring_story_power.py
+++ b/tests/test_scoring_story_power.py
@@ -5924,6 +5924,31 @@ def test_per_row_tier_max_tokens_constant_above_8k():
     assert _PITCH_MAX_TOKENS == 4096
 
 
+def test_per_row_tier_max_tokens_under_creative_model_cap():
+    """The per-row ceiling must fit under the creative model's output
+    cap (api.MODEL_MAX_OUTPUT is the source of truth). PR #247 review
+    caught a factual claim of '64K Opus output cap' — Opus 4.6
+    actually caps at 128K, but the lesson is that constants drift
+    from documentation. This test grounds the claim in the API
+    config so a future model change can't silently break it."""
+    from storyforge.scoring_story_power import (
+        _PER_ROW_TIER_MAX_TOKENS,
+    )
+    from storyforge.api import MODEL_MAX_OUTPUT
+    from storyforge.common import select_model
+    creative_model = select_model('creative')
+    model_cap = MODEL_MAX_OUTPUT.get(creative_model)
+    assert model_cap is not None, (
+        f'creative model {creative_model!r} is not in MODEL_MAX_OUTPUT; '
+        'add an entry or update select_model'
+    )
+    assert _PER_ROW_TIER_MAX_TOKENS <= model_cap, (
+        f'_PER_ROW_TIER_MAX_TOKENS={_PER_ROW_TIER_MAX_TOKENS} exceeds '
+        f'the creative model {creative_model!r} cap of {model_cap}; '
+        'the API would reject the request with HTTP 400'
+    )
+
+
 def test_architecture_passes_per_row_max_tokens(tmp_path, monkeypatch):
     """Architecture mode calls invoke_to_file with the per-row tier
     ceiling, not the old 8K wall."""

--- a/tests/test_scoring_story_power.py
+++ b/tests/test_scoring_story_power.py
@@ -6059,6 +6059,72 @@ def test_briefs_passes_per_row_max_tokens(tmp_path, monkeypatch):
     assert seen['briefs'] == scoring_story_power._PER_ROW_TIER_MAX_TOKENS
 
 
+def test_all_tiers_pass_correct_max_tokens_constant(tmp_path, monkeypatch):
+    """Every tier (pitch, act-shape, spine, architecture, scene-map,
+    briefs) passes the *expected* per-tier ceiling to invoke_to_file.
+    Without this, a refactor that promotes spine to _PER_ROW (4×
+    cost regression) or demotes architecture to _FIXED_PAYLOAD
+    (reintroducing #245) would pass the existing per-tier tests
+    that only assert the value matches the expected constant for
+    that tier individually. This single test enforces the full
+    matrix in one place. (PR #247 review T-1.)"""
+    _seed_summary(str(tmp_path))
+    _seed_spine(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    _seed_scene_map(str(tmp_path))
+    _seed_briefs(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    seen: dict[str, int] = {}
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-briefs' in log_file:
+            seen['briefs'] = kwargs.get('max_tokens', -1)
+            payload = _briefs_payload()
+        elif '-scene-map' in log_file:
+            seen['scene-map'] = kwargs.get('max_tokens', -1)
+            payload = _scene_map_payload()
+        elif '-architecture' in log_file:
+            seen['architecture'] = kwargs.get('max_tokens', -1)
+            payload = _architecture_payload()
+        elif '-spine' in log_file:
+            seen['spine'] = kwargs.get('max_tokens', -1)
+            payload = _spine_payload()
+        elif '-act-shape' in log_file:
+            seen['act-shape'] = kwargs.get('max_tokens', -1)
+            payload = _act_shape_payload()
+        else:
+            seen['pitch'] = kwargs.get('max_tokens', -1)
+            payload = _full_payload()
+        response = {
+            'content': [{'type': 'text', 'text': json.dumps(payload)}],
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    expected = {
+        'pitch': scoring_story_power._PITCH_MAX_TOKENS,
+        'act-shape': scoring_story_power._FIXED_PAYLOAD_TIER_MAX_TOKENS,
+        'spine': scoring_story_power._FIXED_PAYLOAD_TIER_MAX_TOKENS,
+        'architecture': scoring_story_power._PER_ROW_TIER_MAX_TOKENS,
+        'scene-map': scoring_story_power._PER_ROW_TIER_MAX_TOKENS,
+        'briefs': scoring_story_power._PER_ROW_TIER_MAX_TOKENS,
+    }
+    assert seen == expected, (
+        f'tier → max_tokens mismatch.\nexpected: {expected}\n'
+        f'actual:   {seen}'
+    )
+
+
 def test_read_stop_reason_returns_field_when_present(tmp_path):
     """Reads the LLM's stop_reason from the raw response log."""
     from storyforge.scoring_story_power import _read_stop_reason
@@ -6334,5 +6400,150 @@ def test_truncation_hint_uses_hedged_wording(tmp_path):
     hint = _truncation_hint(log_file, 32768)
     assert 'likely truncated' in hint
     assert 'was truncated' not in hint
+
+
+def test_scene_map_unparseable_with_max_tokens_logs_truncation_hint(
+        tmp_path, monkeypatch, capsys):
+    """Scene-map mode mirrors the architecture truncation contract.
+    Without this test, a copy-paste regression that drops the
+    _truncation_hint call from scene-map's unparseable log site
+    would slip past architecture's coverage. (PR #247 review T-2.)"""
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    _seed_scene_map(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-scene-map' in log_file:
+            text = '{"per_scene": [{"scene_id": "s1", "scores":'
+            stop = 'max_tokens'
+        elif '-architecture' in log_file:
+            text = json.dumps(_architecture_payload())
+            stop = 'end_turn'
+        elif '-spine' in log_file:
+            text = json.dumps(_spine_payload())
+            stop = 'end_turn'
+        elif '-act-shape' in log_file:
+            text = json.dumps(_act_shape_payload())
+            stop = 'end_turn'
+        else:
+            text = json.dumps(_full_payload())
+            stop = 'end_turn'
+        response = {
+            'content': [{'type': 'text', 'text': text}],
+            'stop_reason': stop,
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    result = scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert result['scene_map']['status'] == 'unparseable'
+    out = capsys.readouterr().out
+    assert 'scene-map LLM response unparseable' in out
+    assert 'truncated mid-JSON' in out
+    assert 'max_tokens=32768' in out
+
+
+def test_briefs_unparseable_with_max_tokens_logs_truncation_hint(
+        tmp_path, monkeypatch, capsys):
+    """Briefs mode mirrors the architecture truncation contract.
+    (PR #247 review T-2.)"""
+    _seed_summary(str(tmp_path))
+    _seed_briefs(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-briefs' in log_file:
+            text = '{"per_brief": [{"scene_id": "s1", "scores":'
+            stop = 'max_tokens'
+        elif '-act-shape' in log_file:
+            text = json.dumps(_act_shape_payload())
+            stop = 'end_turn'
+        else:
+            text = json.dumps(_full_payload())
+            stop = 'end_turn'
+        response = {
+            'content': [{'type': 'text', 'text': text}],
+            'stop_reason': stop,
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    result = scoring_story_power.score_story_power(str(tmp_path), 'full')
+    assert result['briefs']['status'] == 'unparseable'
+    out = capsys.readouterr().out
+    assert 'briefs LLM response unparseable' in out
+    assert 'truncated mid-JSON' in out
+    assert 'max_tokens=32768' in out
+
+
+def test_truncation_path_records_unparseable_target_in_ledger(
+        tmp_path, monkeypatch):
+    """When architecture truncates and the parse fails, the cost
+    ledger MUST record the unparseable target (not the success
+    target). A regression that swapped the targets on the
+    truncation path would silently mis-bill — costs that look like
+    successful runs but actually delivered no diagnostic.
+    (PR #247 review T-3.)"""
+    _seed_summary(str(tmp_path))
+    _seed_architecture(str(tmp_path))
+    monkeypatch.chdir(str(tmp_path))
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+
+    def fake(prompt, model, log_file, **kwargs):
+        os.makedirs(os.path.dirname(log_file) or '.', exist_ok=True)
+        if '-architecture' in log_file:
+            text = '{"per_scene":'
+            stop = 'max_tokens'
+        elif '-spine' in log_file:
+            text = json.dumps(_spine_payload())
+            stop = 'end_turn'
+        elif '-act-shape' in log_file:
+            text = json.dumps(_act_shape_payload())
+            stop = 'end_turn'
+        else:
+            text = json.dumps(_full_payload())
+            stop = 'end_turn'
+        response = {
+            'content': [{'type': 'text', 'text': text}],
+            'stop_reason': stop,
+            'usage': {'input_tokens': 500, 'output_tokens': 400,
+                      'cache_read_input_tokens': 0,
+                      'cache_creation_input_tokens': 0},
+        }
+        with open(log_file, 'w') as f:
+            json.dump(response, f)
+        return response
+    from storyforge import api, scoring_story_power
+    monkeypatch.setattr(api, 'invoke_to_file', fake)
+    monkeypatch.setattr(scoring_story_power, 'invoke_to_file', fake)
+    scoring_story_power.score_story_power(str(tmp_path), 'full')
+    ledger_path = os.path.join(str(tmp_path), 'working', 'costs',
+                                  'ledger.csv')
+    assert os.path.isfile(ledger_path)
+    ledger = open(ledger_path).read()
+    # The architecture truncation path must record the unparseable
+    # target — not the success target.
+    assert 'story-power:architecture:unparseable' in ledger
+    # And it must NOT record the success target for the architecture
+    # call (separate from the success targets the other tiers
+    # legitimately produced).
+    assert 'story-power:architecture,' not in ledger
 
 


### PR DESCRIPTION
## Summary

Closes #245. The architecture, scene-map, and briefs modes were silently truncating mid-JSON on real-sized projects because the per-extension `max_tokens=8192` ceiling was below the response budget needed for per-row rationale at typical project scales (15+ architecture scenes, 43+ scene-map rows, 30+ briefs).

## Changes

- **Centralize per-tier ceilings** as module-level constants in `scoring_story_power.py`:
  - `_PITCH_MAX_TOKENS = 4096`
  - `_BOUNDED_TIER_MAX_TOKENS = 8192` (act-shape, spine — payloads bounded by tier structure)
  - `_PER_ROW_TIER_MAX_TOKENS = 32768` (architecture, scene-map, briefs — payloads scale with project size)
- **All six tier call sites** now reference the constants instead of literal integers; future tiers inherit the pattern.
- **Truncation detection** via new `_read_stop_reason()` + `_truncation_hint()` helpers. When a tier's parse fails AND the underlying response had `stop_reason='max_tokens'`, the unparseable ERROR appends `(LLM hit max_tokens=N and the response was truncated mid-JSON — not a genuine parse failure...)`. Per acceptance criterion 4.
- **Documentation**: `references/story-power-rubric.md` gains a "Output token budget" section with the per-tier table.

## Files

- `scripts/lib/python/storyforge/scoring_story_power.py` — constants, helpers, 6 call-site updates
- `tests/test_scoring_story_power.py` — 11 new tests
- `references/story-power-rubric.md` — new "Output token budget" section
- `.claude-plugin/plugin.json` — 1.35.1 → 1.35.2

## Test plan

- [x] All 265 tests pass (254 prior + 11 new)
- [x] `_PER_ROW_TIER_MAX_TOKENS ≥ 16384` regression guard
- [x] Architecture / scene-map / briefs pass the per-row ceiling to `invoke_to_file` (one hit-counter test each)
- [x] `_read_stop_reason` handles present field, missing field, missing file
- [x] `_truncation_hint` returns descriptive text on `max_tokens`, empty on `end_turn`
- [x] End-to-end: architecture unparseable with `stop_reason=max_tokens` surfaces both `truncated mid-JSON` and `max_tokens=32768` in the log
- [x] End-to-end: genuine parse failure (`stop_reason=end_turn`) omits the truncation suffix — no spurious "truncated" on real parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)