### PR TITLE
Dispatch to latest Opus (claude-opus-4-8) instead of Opus 4.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/api.py
+++ b/scripts/lib/python/storyforge/api.py
@@ -25,7 +25,7 @@ API_RETRIES = 2  # retry transient failures (timeouts, 5xx)
 # Model output token limits — the API returns HTTP 400 if max_tokens exceeds these.
 # You only pay for tokens actually generated, so requesting the max is safe cost-wise.
 MODEL_MAX_OUTPUT = {
-    'claude-opus-4-6': 128000,
+    'claude-opus-4-8': 128000,
     'claude-sonnet-4-6': 64000,
     'claude-haiku-4-5-20251001': 16384,
 }
@@ -114,7 +114,7 @@ def invoke(prompt: str, model: str, max_tokens: int = 4096, label: str = '',
 
     Args:
         prompt: The user message text.
-        model: Model ID (e.g., 'claude-opus-4-6').
+        model: Model ID (e.g., 'claude-opus-4-8').
         max_tokens: Maximum output tokens.
         label: Optional label for heartbeat messages (e.g., 'revision pass 3').
         timeout: Socket timeout in seconds (default API_TIMEOUT).

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -505,7 +505,7 @@ def main(argv=None):
 
     # Model selection
     sonnet_model = select_model('evaluation')
-    opus_model = 'claude-opus-4-6'
+    opus_model = 'claude-opus-4-8'
 
     if score_mode == 'batch':
         eval_model = opus_model

--- a/scripts/lib/python/storyforge/common.py
+++ b/scripts/lib/python/storyforge/common.py
@@ -213,16 +213,16 @@ def check_file_exists(filepath: str, label: str | None = None,
 # ============================================================================
 
 _MODEL_MAP = {
-    'drafting': 'claude-opus-4-6',
-    'revision': 'claude-opus-4-6',
+    'drafting': 'claude-opus-4-8',
+    'revision': 'claude-opus-4-8',
     'mechanical': 'claude-sonnet-4-6',
     'evaluation': 'claude-sonnet-4-6',
     'extraction': 'claude-haiku-4-5-20251001',
-    'synthesis': 'claude-opus-4-6',
+    'synthesis': 'claude-opus-4-8',
     'review': 'claude-sonnet-4-6',
     # creative: synthesis-style work that needs strong judgment but isn't
     # full-scene drafting (style guides, summary proposals, prose adaptation).
-    'creative': 'claude-opus-4-6',
+    'creative': 'claude-opus-4-8',
 }
 
 
@@ -234,7 +234,7 @@ def select_model(task_type: str) -> str:
     override = os.environ.get('STORYFORGE_MODEL')
     if override:
         return override
-    return _MODEL_MAP.get(task_type, 'claude-opus-4-6')
+    return _MODEL_MAP.get(task_type, 'claude-opus-4-8')
 
 
 def select_revision_model(pass_name: str, purpose: str = '') -> str:
@@ -249,7 +249,7 @@ def select_revision_model(pass_name: str, purpose: str = '') -> str:
     key = f'{pass_name} {purpose}'.lower()
     if re.search(r'continuity|timeline|fact.check|thread.track', key):
         return 'claude-sonnet-4-6'
-    return 'claude-opus-4-6'
+    return 'claude-opus-4-8'
 
 
 # ============================================================================

--- a/tests/commands/test_api.py
+++ b/tests/commands/test_api.py
@@ -156,7 +156,7 @@ class TestExtractUsage:
 class TestMaxOutputTokens:
     def test_known_model(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-opus-4-6') == 128000
+        assert max_output_tokens('claude-opus-4-8') == 128000
 
     def test_unknown_model_returns_default(self):
         from storyforge.api import max_output_tokens, _DEFAULT_MAX_OUTPUT

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -192,6 +192,13 @@ class TestSelectModel:
         result = select_model('unknown_task')
         assert 'opus' in result
 
+    def test_opus_tasks_use_latest_opus(self):
+        # Pin the exact latest Opus so dispatch can't silently drift back to an
+        # older Opus (regression for #270 — was claude-opus-4-6).
+        for task in ('drafting', 'revision', 'synthesis', 'creative'):
+            assert select_model(task) == 'claude-opus-4-8'
+        assert select_model('unknown_task') == 'claude-opus-4-8'
+
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv('STORYFORGE_MODEL', 'custom-model-123')
         result = select_model('drafting')

--- a/tests/test_revise_safety.py
+++ b/tests/test_revise_safety.py
@@ -16,7 +16,7 @@ import os
 class TestMaxOutputTokens:
     def test_opus_returns_128k(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-opus-4-6') == 128000
+        assert max_output_tokens('claude-opus-4-8') == 128000
 
     def test_sonnet_returns_64k(self):
         from storyforge.api import max_output_tokens


### PR DESCRIPTION
Closes #270.

## Summary

Autonomous scripts were dispatching creative/drafting/synthesis work to `claude-opus-4-6`. This swaps all 9 Opus dispatch/reference sites to **`claude-opus-4-8`** — the latest, most-capable Opus, with a native 1M-token context window.

- `common.py` — `_MODEL_MAP` (drafting/revision/synthesis/creative), `select_model` default fallback, `select_revision_model`
- `cmd_score.py` — `opus_model`
- `api.py` — `MODEL_MAX_OUTPUT` key (value `128000` unchanged — 128K is Opus 4.8's max output) + docstring example

Sonnet 4.6 and Haiku 4.5 dispatch are unchanged (Opus-only, per the request).

## Why it's a clean swap (verified against the Anthropic migration guide)

4.6 → 4.8 would 400 if the code set `temperature`/`top_p`/`top_k`, `budget_tokens`/`thinking`, or used assistant prefills. It doesn't: `api.invoke()` sends only `model` / `max_tokens` / `messages` / `system`. Adaptive thinking is off-by-default on 4.8, matching current behavior. Pricing needs no change — `costs._detect_tier` is substring-based (`'opus' in model`), so `claude-opus-4-8` resolves to the opus tier automatically.

## Tests

- Updated the two `max_output_tokens` assertions that pinned `claude-opus-4-6`.
- Added `test_opus_tasks_use_latest_opus` pinning `select_model` to `claude-opus-4-8` so dispatch can't silently regress to an older Opus.
- Full suite: **4641 passed, 10 skipped.**

## Follow-up (out of scope, flagged in #270)

`costs.PRICING` opus tier is stale at **$15/$75 per MTok**; Opus 4.8 is **$5/$25**, so cost estimates/ledger run ~3× high. Left for a separate fix since it's independent of model dispatch.

Version → 1.45.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)