### PR TITLE
Model tiers via LATEST_MODELS + correct/guard pricing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "author": {
     "name": "Ben Norris"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.45.3",
+  "version": "1.45.4",
   "author": {
     "name": "Ben Norris"
   },

--- a/scripts/lib/python/storyforge/api.py
+++ b/scripts/lib/python/storyforge/api.py
@@ -12,6 +12,7 @@ import threading
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
 
+from storyforge.common import LATEST_MODELS
 from storyforge.costs import PRICING, calculate_cost, log_operation
 
 
@@ -24,10 +25,12 @@ API_RETRIES = 2  # retry transient failures (timeouts, 5xx)
 
 # Model output token limits — the API returns HTTP 400 if max_tokens exceeds these.
 # You only pay for tokens actually generated, so requesting the max is safe cost-wise.
+# Keyed off the tier map so a model bump in common.LATEST_MODELS flows through
+# here with no separate version string to update.
 MODEL_MAX_OUTPUT = {
-    'claude-opus-4-8': 128000,
-    'claude-sonnet-4-6': 64000,
-    'claude-haiku-4-5-20251001': 16384,
+    LATEST_MODELS['opus']:   128000,
+    LATEST_MODELS['sonnet']: 64000,
+    LATEST_MODELS['haiku']:  16384,
 }
 _DEFAULT_MAX_OUTPUT = 32768
 

--- a/scripts/lib/python/storyforge/cmd_score.py
+++ b/scripts/lib/python/storyforge/cmd_score.py
@@ -25,8 +25,8 @@ import time
 
 from storyforge.common import (
     detect_project_root, log, set_log_file, read_yaml_field, select_model,
-    get_coaching_level, get_current_cycle, install_signal_handlers,
-    get_plugin_dir, build_shared_context,
+    model_for_tier, get_coaching_level, get_current_cycle,
+    install_signal_handlers, get_plugin_dir, build_shared_context,
 )
 from storyforge.git import (
     create_branch, ensure_branch_pushed, create_draft_pr, commit_and_push,
@@ -505,7 +505,7 @@ def main(argv=None):
 
     # Model selection
     sonnet_model = select_model('evaluation')
-    opus_model = 'claude-opus-4-8'
+    opus_model = model_for_tier('opus')
 
     if score_mode == 'batch':
         eval_model = opus_model

--- a/scripts/lib/python/storyforge/common.py
+++ b/scripts/lib/python/storyforge/common.py
@@ -212,29 +212,47 @@ def check_file_exists(filepath: str, label: str | None = None,
 # Model selection
 # ============================================================================
 
-_MODEL_MAP = {
-    'drafting': 'claude-opus-4-8',
-    'revision': 'claude-opus-4-8',
-    'mechanical': 'claude-sonnet-4-6',
-    'evaluation': 'claude-sonnet-4-6',
-    'extraction': 'claude-haiku-4-5-20251001',
-    'synthesis': 'claude-opus-4-8',
-    'review': 'claude-sonnet-4-6',
+# Single source of truth: the concrete model ID currently used for each
+# capability tier. The Anthropic API requires an exact model ID (there is no
+# floating "latest"/"opus" alias — a bare tier name 404s), so when a newer
+# model ships, bump the ID here — in this one place — and every dispatch site
+# below follows, because they all refer to the tier, never a version string.
+LATEST_MODELS = {
+    'opus':   'claude-opus-4-8',
+    'sonnet': 'claude-sonnet-4-6',
+    'haiku':  'claude-haiku-4-5-20251001',
+}
+
+# Which capability tier each task type dispatches to.
+_TASK_TIER = {
+    'drafting': 'opus',
+    'revision': 'opus',
+    'mechanical': 'sonnet',
+    'evaluation': 'sonnet',
+    'extraction': 'haiku',
+    'synthesis': 'opus',
+    'review': 'sonnet',
     # creative: synthesis-style work that needs strong judgment but isn't
     # full-scene drafting (style guides, summary proposals, prose adaptation).
-    'creative': 'claude-opus-4-8',
+    'creative': 'opus',
 }
+
+
+def model_for_tier(tier: str) -> str:
+    """Return the current concrete model ID for a capability tier."""
+    return LATEST_MODELS[tier]
 
 
 def select_model(task_type: str) -> str:
     """Select the appropriate model for a task type.
 
-    STORYFORGE_MODEL env var overrides all.
+    Resolves the task's tier through LATEST_MODELS; unknown tasks default to
+    the opus tier. STORYFORGE_MODEL env var overrides all.
     """
     override = os.environ.get('STORYFORGE_MODEL')
     if override:
         return override
-    return _MODEL_MAP.get(task_type, 'claude-opus-4-8')
+    return LATEST_MODELS[_TASK_TIER.get(task_type, 'opus')]
 
 
 def select_revision_model(pass_name: str, purpose: str = '') -> str:
@@ -248,8 +266,8 @@ def select_revision_model(pass_name: str, purpose: str = '') -> str:
 
     key = f'{pass_name} {purpose}'.lower()
     if re.search(r'continuity|timeline|fact.check|thread.track', key):
-        return 'claude-sonnet-4-6'
-    return 'claude-opus-4-8'
+        return LATEST_MODELS['sonnet']
+    return LATEST_MODELS['opus']
 
 
 # ============================================================================

--- a/scripts/lib/python/storyforge/costs.py
+++ b/scripts/lib/python/storyforge/costs.py
@@ -17,9 +17,21 @@ from datetime import datetime
 # ============================================================================
 
 PRICING = {
-    'opus':   {'input': 15.00, 'output': 75.00, 'cache_read': 1.50, 'cache_create': 18.75},
+    'opus':   {'input': 5.00,  'output': 25.00, 'cache_read': 0.50, 'cache_create': 6.25},
     'sonnet': {'input': 3.00,  'output': 15.00, 'cache_read': 0.30, 'cache_create': 3.75},
-    'haiku':  {'input': 0.80,  'output': 4.00,  'cache_read': 0.08, 'cache_create': 1.00},
+    'haiku':  {'input': 1.00,  'output': 5.00,  'cache_read': 0.10, 'cache_create': 1.25},
+}
+
+# The exact model ID each tier's PRICING above was last verified against.
+# Pricing is tier-based, but a new model version can reprice — so whenever
+# common.LATEST_MODELS bumps a tier to a new model, re-check the rates at
+# platform.claude.com/pricing, update PRICING if they changed, then bump the
+# ID here. A test asserts this matches LATEST_MODELS, so a version change that
+# skips the pricing review fails CI (see tests/commands/test_costs.py).
+PRICING_VERIFIED_FOR = {
+    'opus':   'claude-opus-4-8',
+    'sonnet': 'claude-sonnet-4-6',
+    'haiku':  'claude-haiku-4-5-20251001',
 }
 
 LEDGER_HEADER = 'timestamp|operation|target|model|input_tokens|output_tokens|cache_read|cache_create|cost_usd|duration_s'

--- a/tests/commands/test_api.py
+++ b/tests/commands/test_api.py
@@ -156,7 +156,8 @@ class TestExtractUsage:
 class TestMaxOutputTokens:
     def test_known_model(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-opus-4-8') == 128000
+        from storyforge.common import LATEST_MODELS
+        assert max_output_tokens(LATEST_MODELS['opus']) == 128000
 
     def test_unknown_model_returns_default(self):
         from storyforge.api import max_output_tokens, _DEFAULT_MAX_OUTPUT

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -192,12 +192,18 @@ class TestSelectModel:
         result = select_model('unknown_task')
         assert 'opus' in result
 
-    def test_opus_tasks_use_latest_opus(self):
-        # Pin the exact latest Opus so dispatch can't silently drift back to an
-        # older Opus (regression for #270 — was claude-opus-4-6).
+    def test_opus_tasks_resolve_through_tier_map(self):
+        # Opus-tier tasks resolve to the current opus model via LATEST_MODELS,
+        # so a version bump there is the only change needed — no per-site IDs.
+        from storyforge.common import LATEST_MODELS
         for task in ('drafting', 'revision', 'synthesis', 'creative'):
-            assert select_model(task) == 'claude-opus-4-8'
-        assert select_model('unknown_task') == 'claude-opus-4-8'
+            assert select_model(task) == LATEST_MODELS['opus']
+        assert select_model('unknown_task') == LATEST_MODELS['opus']
+
+    def test_model_for_tier(self):
+        from storyforge.common import model_for_tier, LATEST_MODELS
+        for tier in ('opus', 'sonnet', 'haiku'):
+            assert model_for_tier(tier) == LATEST_MODELS[tier]
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv('STORYFORGE_MODEL', 'custom-model-123')

--- a/tests/commands/test_costs.py
+++ b/tests/commands/test_costs.py
@@ -391,3 +391,20 @@ class TestGetPrice:
         monkeypatch.delenv('PRICING_SONNET_INPUT', raising=False)
         price = _get_price('claude-sonnet-4-6', 'input')
         assert price == PRICING['sonnet']['input']
+
+
+class TestPricingVerifiedForCurrentModels:
+    """Guard: pricing must be re-verified whenever a model version changes."""
+
+    def test_pricing_verified_for_matches_latest_models(self):
+        from storyforge.common import LATEST_MODELS
+        from storyforge.costs import PRICING_VERIFIED_FOR
+        # If this fails after a LATEST_MODELS bump: re-check the rates at
+        # platform.claude.com/pricing, update PRICING if they changed, then
+        # bump PRICING_VERIFIED_FOR to the new model ID(s).
+        assert PRICING_VERIFIED_FOR == LATEST_MODELS
+
+    def test_every_tier_has_pricing(self):
+        from storyforge.common import LATEST_MODELS
+        for tier in LATEST_MODELS:
+            assert tier in PRICING

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -6,16 +6,16 @@ from storyforge.costs import calculate_cost, estimate_cost, format_duration, log
 
 class TestPricing:
     def test_opus_input(self):
-        assert PRICING['opus']['input'] == 15.00
+        assert PRICING['opus']['input'] == 5.00
 
     def test_opus_output(self):
-        assert PRICING['opus']['output'] == 75.00
+        assert PRICING['opus']['output'] == 25.00
 
     def test_opus_cache_read(self):
-        assert PRICING['opus']['cache_read'] == 1.50
+        assert PRICING['opus']['cache_read'] == 0.50
 
     def test_opus_cache_create(self):
-        assert PRICING['opus']['cache_create'] == 18.75
+        assert PRICING['opus']['cache_create'] == 6.25
 
     def test_sonnet_input(self):
         assert PRICING['sonnet']['input'] == 3.00
@@ -30,16 +30,16 @@ class TestPricing:
         assert PRICING['sonnet']['cache_create'] == 3.75
 
     def test_haiku_input(self):
-        assert PRICING['haiku']['input'] == 0.80
+        assert PRICING['haiku']['input'] == 1.00
 
     def test_haiku_output(self):
-        assert PRICING['haiku']['output'] == 4.00
+        assert PRICING['haiku']['output'] == 5.00
 
     def test_haiku_cache_read(self):
-        assert PRICING['haiku']['cache_read'] == 0.08
+        assert PRICING['haiku']['cache_read'] == 0.10
 
     def test_haiku_cache_create(self):
-        assert PRICING['haiku']['cache_create'] == 1.00
+        assert PRICING['haiku']['cache_create'] == 1.25
 
 
 class TestCalculateCost:

--- a/tests/test_revise_safety.py
+++ b/tests/test_revise_safety.py
@@ -16,15 +16,18 @@ import os
 class TestMaxOutputTokens:
     def test_opus_returns_128k(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-opus-4-8') == 128000
+        from storyforge.common import LATEST_MODELS
+        assert max_output_tokens(LATEST_MODELS['opus']) == 128000
 
     def test_sonnet_returns_64k(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-sonnet-4-6') == 64000
+        from storyforge.common import LATEST_MODELS
+        assert max_output_tokens(LATEST_MODELS['sonnet']) == 64000
 
     def test_haiku_returns_16k(self):
         from storyforge.api import max_output_tokens
-        assert max_output_tokens('claude-haiku-4-5-20251001') == 16384
+        from storyforge.common import LATEST_MODELS
+        assert max_output_tokens(LATEST_MODELS['haiku']) == 16384
 
     def test_unknown_model_returns_default(self):
         from storyforge.api import max_output_tokens


### PR DESCRIPTION
Follow-up to #270 / #271. Two linked changes: make model dispatch tier-based (no hardcoded versions), and fix + guard the pricing that rides on those tiers.

## 1. Reference tiers, not versions

`common.LATEST_MODELS` is now the single tier→concrete-ID map:

```python
LATEST_MODELS = {
    'opus':   'claude-opus-4-8',
    'sonnet': 'claude-sonnet-4-6',
    'haiku':  'claude-haiku-4-5-20251001',
}
```

`select_model` (task→tier→ID), `select_revision_model`, `cmd_score` (`model_for_tier('opus')`), and `api.MODEL_MAX_OUTPUT` all key off it. **Bumping to a newer model is a one-line change in one place.** The only version literals left in source are those three lines (confirmed via grep).

**API caveat:** the Anthropic API requires an exact model ID — no floating `latest`/bare-`opus` alias (it 404s) — so `LATEST_MODELS` holds concrete IDs; the tier ergonomics live in our code.

## 2. Correct stale pricing

`costs.PRICING` had Opus at the old **$15/$75** (Opus-3 era) and Haiku at **$0.80/$4** (Haiku-3.5 era) — Opus estimates ran ~3× high. Corrected to current rates:

| Tier | Was | Now |
|---|---|---|
| Opus 4.8 | $15 / $75 | **$5 / $25** (cache 0.50 / 6.25) |
| Haiku 4.5 | $0.80 / $4 | **$1 / $5** (cache 0.10 / 1.25) |
| Sonnet 4.6 | $3 / $15 | unchanged (already correct) |

## 3. Guard pricing against future model bumps

Per the request to re-check pricing whenever a version changes: `costs.PRICING_VERIFIED_FOR` records the exact model ID each tier's pricing was last verified against, and a test asserts it equals `LATEST_MODELS`. **Bump a model without re-checking pricing → the test fails**, forcing a pricing review before merge.

## Verification

- No import cycle (`common` is stdlib-only at module top).
- Tests reference `LATEST_MODELS`/`PRICING` rather than literal IDs where possible, so they stay green across future bumps; added `model_for_tier`, pricing-verified-guard, and updated pricing-snapshot tests.
- Full suite: **4644 passed, 10 skipped.**

Version → 1.45.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)