### PR TITLE
Persist AI cover prompt in all coaching modes (#274)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.45.4",
+  "version": "1.45.5",
   "author": {
     "name": "Ben Norris"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "storyforge",
   "description": "A novel-writing toolkit for Claude Code: interactive skills for creative development, autonomous scripts for execution, and deep craft knowledge throughout.",
-  "version": "1.45.5",
+  "version": "1.45.6",
   "author": {
     "name": "Ben Norris"
   },

--- a/skills/cover/SKILL.md
+++ b/skills/cover/SKILL.md
@@ -247,27 +247,59 @@ Present the full prompt to the author before spending API credits. This is their
 
 ### Step T2.3: Generate the Image
 
-Use the helper functions from the plugin's `scripts/lib/cover-api.sh`:
+The plugin does not ship an AI-generation helper — `storyforge cover` only produces typographic SVG covers. Call the image API directly with the Bash tool. `manuscript/assets/` must exist first (`mkdir -p manuscript/assets`).
 
-**For OpenAI:**
+**For OpenAI (`gpt-image-1`):**
 ```bash
-source "${PLUGIN_DIR}/scripts/lib/cover-api.sh"
-openai_generate_image "the full prompt" "manuscript/assets/cover-illustration.png" "1024x1536"
+curl -s https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(python3 -c 'import json,sys; print(json.dumps({"model":"gpt-image-1","prompt":sys.argv[1],"size":"1024x1536","quality":"high","n":1}))' "the full prompt text")" \
+  | python3 -c "import sys,json,base64; d=json.load(sys.stdin); print(d.get('error','')) or open('manuscript/assets/cover-illustration.png','wb').write(base64.b64decode(d['data'][0]['b64_json']))"
 ```
 
-**For Flux (BFL):**
+Building the JSON with `python3 -c` keeps the prompt's quotes and newlines from breaking the shell. Supported sizes: `1024x1024`, `1024x1536` (portrait, best for covers), `1536x1024`. Quality: `low` / `medium` / `high`.
+
+**For Flux (BFL):** the BFL API is submit-then-poll — POST the prompt to `https://api.bfl.ml/v1/flux-pro-1.1` with header `x-key: $BFL_API_KEY`, then GET the returned polling URL until `status` is `Ready` and download `result.sample`.
+
+**After generating, verify the file is a non-empty PNG before showing it to the author:**
 ```bash
-source "${PLUGIN_DIR}/scripts/lib/cover-api.sh"
-bfl_generate_image "the full prompt" "manuscript/assets/cover-illustration.png" "1024x1536"
+if [[ ! -s manuscript/assets/cover-illustration.png ]]; then
+    echo "ERROR: Image generation produced an empty or missing file. Check the API error above."
+    exit 1
+fi
 ```
 
 If the first result isn't right, offer to generate additional variations with adjusted prompts. Save as `cover-illustration-1.png`, `cover-illustration-2.png`, etc.
 
-### Step T2.4: Author Picks Favorite
+### Step T2.4: Record the Prompt (all coaching modes)
 
-Present the file paths. The author opens them to review and picks one.
+**Do this in every coaching mode, including `full`.** The generation prompt is the reproducible seed for the art — it must survive the session. After each image is generated, append an entry to `manuscript/assets/cover-prompt.md` (create it on the first generation) using the Write/Edit tool. Capture, per variation:
 
-### Step T2.5: Text Compositing Decision
+- the **full prompt text** (verbatim)
+- **model** (e.g. `gpt-image-1`), **size** (e.g. `1024x1536`), **quality**, and **n**
+- the **output file** it produced (e.g. `cover-illustration-2.png`)
+- **status** — `selected` or `superseded`, with a one-line reason (fill this in at Step T2.5 once the author chooses)
+
+Format:
+```markdown
+# Cover Prompt Log — {title}
+
+## Variation 2 — cover-illustration-2.png
+- **Status:** selected — author preferred the warmer palette
+- **Model:** gpt-image-1 · **Size:** 1024x1536 · **Quality:** high · **n:** 1
+
+> Full prompt text, verbatim, including the "no text, no letters, no words,
+> no typography" constraint.
+```
+
+This file is committed alongside the illustration at Step T2.6.
+
+### Step T2.5: Author Picks Favorite
+
+Present the file paths. The author opens them to review and picks one. Update `manuscript/assets/cover-prompt.md` — mark the chosen variation `selected` and the others `superseded`, each with a brief reason.
+
+### Step T2.6: Text Compositing Decision
 
 Ask: "Would you like me to add title and author text as a crisp overlay (recommended — AI text rendering is unreliable), or use this illustration as the complete cover?"
 
@@ -317,9 +349,9 @@ echo "Cover PNG verified: $(wc -c < manuscript/assets/cover.png) bytes"
 
 Copy the chosen illustration to `manuscript/assets/cover.png` and update configuration.
 
-### Step T2.6: Update Configuration and Commit
+### Step T2.7: Update Configuration and Commit
 
-Same as Tier 1 Step T1.6. Commit message: `"Cover: generate AI illustration for {title}"` or `"Cover: generate AI illustration with text compositing for {title}"`.
+Same as Tier 1 Step T1.6, plus **commit `manuscript/assets/cover-prompt.md` alongside the illustration** so the generation prompt is tracked. Commit message: `"Cover: generate AI illustration for {title}"` or `"Cover: generate AI illustration with text compositing for {title}"`.
 
 ## Coaching Level Behavior
 
@@ -368,7 +400,7 @@ git rev-parse --abbrev-ref HEAD
 
 Every artifact gets its own commit:
 - Saved the SVG cover? Commit and push.
-- Generated an AI illustration? Commit and push.
+- Generated an AI illustration? Commit and push — including `manuscript/assets/cover-prompt.md` (the prompt log, tracked in all coaching modes).
 - Completed text compositing? Commit and push.
 - Updated production configuration? Commit and push.
 

--- a/skills/cover/SKILL.md
+++ b/skills/cover/SKILL.md
@@ -251,14 +251,22 @@ The plugin does not ship an AI-generation helper — `storyforge cover` only pro
 
 **For OpenAI (`gpt-image-1`):**
 ```bash
-curl -s https://api.openai.com/v1/images/generations \
+curl -sS https://api.openai.com/v1/images/generations \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(python3 -c 'import json,sys; print(json.dumps({"model":"gpt-image-1","prompt":sys.argv[1],"size":"1024x1536","quality":"high","n":1}))' "the full prompt text")" \
-  | python3 -c "import sys,json,base64; d=json.load(sys.stdin); print(d.get('error','')) or open('manuscript/assets/cover-illustration.png','wb').write(base64.b64decode(d['data'][0]['b64_json']))"
+  | python3 -c '
+import sys, json, base64
+d = json.load(sys.stdin)
+if "error" in d or "data" not in d:
+    sys.stderr.write("OpenAI image API error: " + json.dumps(d.get("error", d)) + "\n")
+    sys.exit(1)
+with open("manuscript/assets/cover-illustration.png", "wb") as f:
+    f.write(base64.b64decode(d["data"][0]["b64_json"]))
+'
 ```
 
-Building the JSON with `python3 -c` keeps the prompt's quotes and newlines from breaking the shell. Supported sizes: `1024x1024`, `1024x1536` (portrait, best for covers), `1536x1024`. Quality: `low` / `medium` / `high`.
+The response handler checks for an API error **before** opening the output file, so a failed generation exits non-zero with a clean message and never truncates an existing illustration. `curl -sS` stays quiet on progress but still surfaces transport errors. Building the JSON with `python3 -c` keeps the prompt's quotes and newlines from breaking the shell. Supported sizes: `1024x1024`, `1024x1536` (portrait, best for covers), `1536x1024`. Quality: `low` / `medium` / `high`.
 
 **For Flux (BFL):** the BFL API is submit-then-poll — POST the prompt to `https://api.bfl.ml/v1/flux-pro-1.1` with header `x-key: $BFL_API_KEY`, then GET the returned polling URL until `status` is `Ready` and download `result.sample`.
 
@@ -351,7 +359,18 @@ Copy the chosen illustration to `manuscript/assets/cover.png` and update configu
 
 ### Step T2.7: Update Configuration and Commit
 
-Same as Tier 1 Step T1.6, plus **commit `manuscript/assets/cover-prompt.md` alongside the illustration** so the generation prompt is tracked. Commit message: `"Cover: generate AI illustration for {title}"` or `"Cover: generate AI illustration with text compositing for {title}"`.
+Same as Tier 1 Step T1.6, plus **commit `manuscript/assets/cover-prompt.md` alongside the illustration** so the generation prompt is tracked.
+
+Before committing, confirm the prompt log was actually written (Step T2.4) — this guard catches the exact regression this step exists to prevent:
+```bash
+if [[ ! -s manuscript/assets/cover-prompt.md ]]; then
+    echo "ERROR: cover-prompt.md is missing or empty — the generation prompt was not recorded (Step T2.4)."
+    echo "The prompt is the reproducible seed for the art. Write it before committing."
+    exit 1
+fi
+```
+
+Commit message: `"Cover: generate AI illustration for {title}"` or `"Cover: generate AI illustration with text compositing for {title}"`.
 
 ## Coaching Level Behavior
 

--- a/skills/cover/SKILL.md
+++ b/skills/cover/SKILL.md
@@ -285,9 +285,9 @@ If the first result isn't right, offer to generate additional variations with ad
 **Do this in every coaching mode, including `full`.** The generation prompt is the reproducible seed for the art — it must survive the session. After each image is generated, append an entry to `manuscript/assets/cover-prompt.md` (create it on the first generation) using the Write/Edit tool. Capture, per variation:
 
 - the **full prompt text** (verbatim)
-- **model** (e.g. `gpt-image-1`), **size** (e.g. `1024x1536`), **quality**, and **n**
+- **model** (e.g. `gpt-image-1`), **size** (one of `1024x1024` / `1024x1536` / `1536x1024`), **quality** (`low` / `medium` / `high`), and **n**
 - the **output file** it produced (e.g. `cover-illustration-2.png`)
-- **status** — `selected` or `superseded`, with a one-line reason (fill this in at Step T2.5 once the author chooses)
+- **status** — exactly `selected` or `superseded`, with a one-line reason (fill this in at Step T2.5 once the author chooses)
 
 Format:
 ```markdown

--- a/skills/cover/SKILL.md
+++ b/skills/cover/SKILL.md
@@ -268,7 +268,7 @@ with open("manuscript/assets/cover-illustration.png", "wb") as f:
 
 The response handler checks for an API error **before** opening the output file, so a failed generation exits non-zero with a clean message and never truncates an existing illustration. `curl -sS` stays quiet on progress but still surfaces transport errors. Building the JSON with `python3 -c` keeps the prompt's quotes and newlines from breaking the shell. Supported sizes: `1024x1024`, `1024x1536` (portrait, best for covers), `1536x1024`. Quality: `low` / `medium` / `high`.
 
-**For Flux (BFL):** the BFL API is submit-then-poll — POST the prompt to `https://api.bfl.ml/v1/flux-pro-1.1` with header `x-key: $BFL_API_KEY`, then GET the returned polling URL until `status` is `Ready` and download `result.sample`.
+**For Flux (BFL):** the BFL API is submit-then-poll — POST the prompt to `https://api.bfl.ai/v1/flux-pro-1.1` with header `x-key: $BFL_API_KEY`, then GET the returned polling URL. Poll while `status` is `Pending`; once `status` is `Ready`, download `result.sample`. Treat any other terminal status (`Error`, `Content Moderated`, `Request Moderated`, `Task not found`) as a failure — print the status and any message field and stop, rather than looping. Bound the poll loop (e.g. ~60 attempts) so a stuck request can't spin forever.
 
 **After generating, verify the file is a non-empty PNG before showing it to the author:**
 ```bash
@@ -301,7 +301,7 @@ Format:
 > no typography" constraint.
 ```
 
-This file is committed alongside the illustration at Step T2.6.
+This file is committed alongside the illustration at Step T2.7.
 
 ### Step T2.5: Author Picks Favorite
 

--- a/tests/test_cover_skill.py
+++ b/tests/test_cover_skill.py
@@ -49,3 +49,25 @@ def test_openai_handler_fails_safe_before_opening_file(cover_skill):
     (SF-1). Guard against the old fragile `print(...) or open(...)` one-liner."""
     assert "print(d.get('error','')) or open(" not in cover_skill
     assert '"data" not in d' in cover_skill
+
+
+def test_commit_cross_reference_points_to_the_commit_step(cover_skill):
+    """The 'committed ... at Step T2.N' reference must name the step whose
+    heading is 'Update Configuration and Commit' (CR-1/C-1 renumbering drift)."""
+    ref = re.search(r'committed alongside the illustration at Step (T2\.\d)', cover_skill)
+    assert ref, "missing 'committed ... at Step T2.N' cross-reference"
+    referenced_step = ref.group(1)
+    commit_heading = re.search(
+        r'### Step (T2\.\d): Update Configuration and Commit', cover_skill)
+    assert commit_heading, "missing 'Update Configuration and Commit' step heading"
+    assert referenced_step == commit_heading.group(1), (
+        f"cross-reference points to {referenced_step} but the commit step is "
+        f"{commit_heading.group(1)}")
+
+
+def test_bfl_uses_current_host_and_handles_failure(cover_skill):
+    """BFL host must be the current domain, and non-Ready terminal statuses
+    must be handled rather than polled forever (SF-2)."""
+    assert 'api.bfl.ai' in cover_skill
+    assert 'api.bfl.ml' not in cover_skill
+    assert 'Content Moderated' in cover_skill

--- a/tests/test_cover_skill.py
+++ b/tests/test_cover_skill.py
@@ -1,0 +1,51 @@
+"""Regression guards for the cover skill's documented Tier-2 contract.
+
+Skill markdown is interpreted by Claude at runtime, not executed, so these
+tests assert the documented invariants the PR #274 5-agent review surfaced:
+- no references to the non-shipped cover-api.sh helper (or its functions)
+- the AI generation prompt is persisted in all coaching modes, with a guard
+- the OpenAI response handler fails safe (no truncate-before-error)
+- step cross-references stay consistent under renumbering
+- the BFL host is the current domain, with terminal-failure handling
+"""
+import os
+import re
+
+import pytest
+
+
+@pytest.fixture
+def cover_skill(plugin_dir):
+    path = os.path.join(plugin_dir, 'skills', 'cover', 'SKILL.md')
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+def test_no_reference_to_unshipped_helper(cover_skill):
+    """The cover-api.sh helper does not ship — the skill must not tell the
+    author to source it or call its functions (issue #274 related observation)."""
+    for token in ('cover-api.sh', 'openai_generate_image', 'bfl_generate_image'):
+        assert token not in cover_skill, f"stale reference to non-shipped helper: {token}"
+
+
+def test_prompt_persistence_documented_in_all_modes(cover_skill):
+    """The prompt log must be recorded in every coaching mode, including full —
+    the core of issue #274."""
+    assert 'cover-prompt.md' in cover_skill
+    assert 'Record the Prompt' in cover_skill
+    # The instruction must explicitly cover full mode, not just coach/strict.
+    assert re.search(r'every coaching mode, including `full`', cover_skill)
+
+
+def test_prompt_persistence_has_mechanical_guard(cover_skill):
+    """Every other deliverable in the skill has a non-empty-file guard; the
+    prompt log must too, so the regression cannot silently recur (SF-3)."""
+    assert '[[ ! -s manuscript/assets/cover-prompt.md ]]' in cover_skill
+
+
+def test_openai_handler_fails_safe_before_opening_file(cover_skill):
+    """The OpenAI response handler must check for an API error before opening
+    the output file, so a failure never truncates an existing illustration
+    (SF-1). Guard against the old fragile `print(...) or open(...)` one-liner."""
+    assert "print(d.get('error','')) or open(" not in cover_skill
+    assert '"data" not in d' in cover_skill


### PR DESCRIPTION
## Summary

Closes #274.

The `cover` skill's Tier-2 (AI image generation) flow did not persist the generation **prompt** anywhere durable in **full** coaching mode — it lived only in the scratchpad and the conversation, so the reproducible seed for the cover art was lost after the session. `coach`/`strict` saved briefs/checklists; `full` (the default) saved nothing.

### What changed

- **New Step T2.4 — Record the Prompt (all coaching modes):** after each image is generated, the skill appends an entry to a tracked `manuscript/assets/cover-prompt.md`, capturing per variation:
  - the full prompt text (verbatim)
  - model / size / quality / n
  - the output file it produced
  - selected vs. superseded status (with reason), finalized when the author picks a favorite
- **Commit alongside the illustration** (Step T2.7 + the "Commit After Every Deliverable" list) so the prompt log is tracked in every mode, including `full`.
- **Fixed the Tier-2 generation instructions to match what ships** (the related observation in the issue): the referenced `scripts/lib/cover-api.sh` helper does not exist — `storyforge cover` only produces typographic SVG covers. Step T2.3 now calls the image API directly (curl to `gpt-image-1`, JSON built via `python3` to survive quoting, plus a poll-based note for BFL/Flux) and verifies the PNG is non-empty before showing it to the author.

Renumbered subsequent Tier-2 steps (T2.4→T2.7) accordingly. Version bumped to 1.45.5.

## Testing

Documentation-only change to `skills/cover/SKILL.md` (plus the version bump); no Python code or test surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)